### PR TITLE
Fix link to alarm service example.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ To use this example, follow these steps:
     }
     ```
 
-You can also use the event-driven capabilities in OpenWhisk to invoke this action in response to events. Follow the [alarm service example](./catalog.md#using-the-alarm-package) to configure an event source to invoke the `hello` action every time a periodic event is generated.
+You can also use the event-driven capabilities in OpenWhisk to invoke this action in response to events. Follow the [alarm service example](./packages.md#creating-and-using-trigger-feeds) to configure an event source to invoke the `hello` action every time a periodic event is generated.
 
 
 ## System details


### PR DESCRIPTION
The previous link was going directly to the Alarm documentation in the catalog page. This one links to the alarm example that includes wiring the trigger to an action.