### PR TITLE
Change build steps to be sequential by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ notifications:
   email: false
 
 before_install:
-  - ./tools/build/scanCode.sh
   - ./tools/travis/setup.sh
 
 script:

--- a/README.md
+++ b/README.md
@@ -197,6 +197,19 @@ The following commands are relative to the OpenWhisk directory. If necessary, ch
 
 **Tip:** Since the first build takes some time, it is not uncommon for some step to fail if there's a network hiccup or other interruption of some kind. If this happens you may see a `Build FAILED` message that suggests a Docker operation timed out. You can simply try `ant build` again and it will mostly pick up where it left off. This should only be an issue the very first time you build whisk -- subsequent builds do far less network activity thanks to Docker caching.
 
+To teardown OpenWhisk and remove all Docker containers, run `ant teardown`. You can then redeploy the system with `ant deploy`. To do both at once, use `ant redeploy`.
+
+A typical build (excluding the very first build) should last 2-3 minutes. You can accelerate this if you have a host machine with more than 8GB RAM with a parallel build. You can do this two ways.
+
+1. Override the `buildthreads` parameter on the command line, as in `ant clean build deploy -Dbuildthreads=4`. This command runs up to 4 build steps in parallel.
+2. Save your custom overrides to `openwhisk/config/custom-config.xml`. See `openwhisk/config/config.xml` for options that you may override. An example custom configuration to run up to 4 build steps in parallel follows.
+
+  ```
+  <project>
+      <property name="buildthreads" value="4" />
+  </project>
+  ```
+
 ### Add OpenWhisk command line tools to your path
 
 The OpenWhisk command line tools are located in the `openwhisk/bin` folder. The instructions that follow assume `/your/path/to/openwhisk/bin` is in your system `PATH`. If you are using a Vagrant machine in a shared configuration (Mac users), the OpenWhisk command line tools are already in your path inside the virtual machine.

--- a/build.xml
+++ b/build.xml
@@ -27,13 +27,23 @@
         <delete dir="common/scala/bin" />
     </target>
 
+    <!-- scan the code base, checking some conventions that are enforced -->
+    <target name="scanCode">
+        <exec executable="/bin/bash" failonerror="true">
+            <arg value="tools/build/scanCode.sh" />
+        </exec>
+    </target>
+
     <!-- kill all containers, garbage collect docker images, and delete scratch directories -->
     <target name="clean" depends="dust,teardown">
     </target>
 
     <!-- compile and build images and tests -->
     <target name="build" depends="writePropertyFile">
-        <ant antfile="common/build.xml" target="build" />
+        <parallel threadCount="${buildthreads}" failonany="true">
+            <ant target="scanCode" />
+            <ant antfile="common/build.xml" target="build" />
+        </parallel>
         <parallel threadCount="${buildthreads}" failonany="true">
             <ant antfile="services/build.xml" target="build" />
             <ant antfile="core/build.xml" target="build" />

--- a/config/config.xml
+++ b/config/config.xml
@@ -19,8 +19,18 @@
     <!-- derived properties -->
     <property name="docker.scratch" value="${build.dir}/docker-scratch" />
 
+    <!-- import optional config for any properties which -->
+    <!-- can be override by custom settings; a sample    -->
+    <!-- custom-config.xml would look like this:         -->
+    <!-- <project>
+            <property name="buildthreads" value="4" />
+            <property name="testthreads" value="3" />
+         </project>
+    -->
+    <import file="custom-config.xml" optional="true" />
+
     <!-- parallel test threads for running junit: optional. -->
-    <condition property="testthreads" value="3">
+    <condition property="testthreads" value="1">
         <not>
             <isset property="testthreads" />
         </not>
@@ -28,14 +38,14 @@
 
 
     <!-- parallel build threads. -->
-    <condition property="buildthreads" value="8">
+    <condition property="buildthreads" value="1">
         <not>
             <isset property="buildthreads" />
         </not>
     </condition>
 
     <!-- parallel docker push threads. -->
-    <condition property="pushthreads" value="2">
+    <condition property="pushthreads" value="1">
         <not>
             <isset property="pushthreads" />
         </not>
@@ -80,7 +90,7 @@
     <property name="consul.service.check" value="-e SERVICE_CHECK_HTTP=/ping -e SERVICE_CHECK_TIMEOUT=2s -e SERVICE_CHECK_INTERVAL=15s" />
 
     <!-- gather values for environment variables and store them in a properties file -->
-    <target name="writePropertyFile" depends="setDeployTarget" unless="property.file.written" >
+    <target name="writePropertyFile" depends="setDeployTarget" unless="property.file.written">
         <exec dir="config" failonerror="true" executable="/bin/bash">
             <arg value="setupProps.sh" />
             <arg value="${deploy.target}Env.sh" />

--- a/tools/build/scanCode.sh
+++ b/tools/build/scanCode.sh
@@ -5,7 +5,7 @@
 
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-ROOT="$DIR/../.."
+ROOT=$DIR/../..
 
 #
 # Scan a file for tabs.  Fail if any tab is found.
@@ -29,9 +29,7 @@ function checkForTabs {
     #root directory to scan
     root=$1
 
-    for f in $(find "$root" -name "*.js" -o -name "*.java" -o -name "*.scala" -o -name "build.xml" -o -name "deploy.xml" -o -name "*.md" \
-               | grep -Fv resources/swagger-ui \
-               | grep -Fv consul/ui/static \
+    for f in $(find -L "$root" -type f -name "*.js" -o -name "*.java" -o -name "*.scala" -o -name "build.xml" -o -name "deploy.xml" -o -name "*.md" \
                | grep -Fv node_modules \
                | grep -Fv site-packages)
     do
@@ -43,7 +41,7 @@ function checkForTabs {
 # Fail if there are any symlinks found with the exception of wsk and wskadmin
 #
 function checkForLinks {
-   #root directory to scan
+    #root directory to scan
     root=$1
 
     for f in $(find "$root" -type l | grep -v node_modules | grep -v bin/wsk)
@@ -54,7 +52,8 @@ function checkForLinks {
     done
 }
 
+# These checks follow links with -L.
 checkForTabs "$ROOT"
+
+# checkForLinks is tricky because use of -L (needed to use open) will defeat "-type l"
 checkForLinks "$ROOT"
-
-


### PR DESCRIPTION
Changed build threads (and other settings) to be sequential to avoid repeats of problems reported in issue #35 and #31. Provide instructions in README on how to override for parallel build instead.

Also, added scan code to build and removed from travis config.