### PR TITLE
Correct script path to update folder structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following are verified to work on Ubuntu 14.04.3 LTS. You may need `sudo` or
   echo "OPEN_WHISK_DB_PASSWORD=<cloudant password>" >> cloudant-local.env
 
   # initialize datastore (confirm by responding DROPIT when prompted)
-  tools/cloudant/createImmortalDBs.sh <cloudant username> <cloudant password>
+  tools/db/createImmortalDBs.sh <cloudant username> <cloudant password>
 
   # install all required software
   (cd tools/ubuntu-setup && source all.sh)


### PR DESCRIPTION
In the current folder structure there is no folder `tools/cloudant`, therefore the initialization datastore step in the tutorial doesn't make a lot sense.
Changed it according to the available structure of the folders in the project.