### PR TITLE
Change base url to use cloudant user.

### DIFF
--- a/tools/db/createImmortalDBs.sh
+++ b/tools/db/createImmortalDBs.sh
@@ -29,7 +29,7 @@ source "$SCRIPTDIR/../../config/dbSetup.sh"
 
 if [ "$OPEN_WHISK_DB_PROVIDER" == "Cloudant" ]; then
     CURL_ADMIN="curl -s --user $OPEN_WHISK_DB_USERNAME:$OPEN_WHISK_DB_PASSWORD"
-    URL_BASE="https://$USER.cloudant.com"
+    URL_BASE="https://$OPEN_WHISK_DB_USERNAME.cloudant.com"
 
     # First part of confirmation prompt.
     echo "About to drop and recreate database '$DB_IMMORTAL_DBS' in this Cloudant account:"


### PR DESCRIPTION
Currently script, tries to work with `URL_BASE="https://$USER.cloudant.com"` where `$USER` is the user of local machine (computer host), which doesn't necessary same as `OPEN_WHISK_DB_USERNAME` the actual cloudant account username. Changed script to work with `OPEN_WHISK_DB_USERNAME` instead of `$USER`.