### PR TITLE
Pull request #55 and CouchDB documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following are verified to work on Ubuntu 14.04.3 LTS. You may need `sudo` or
   echo "OPEN_WHISK_DB_PASSWORD=<cloudant password>" >> cloudant-local.env
 
   # initialize datastore (confirm by responding DROPIT when prompted)
-  tools/cloudant/createImmortalDBs.sh <cloudant username> <cloudant password>
+  tools/db/createImmortalDBs.sh <cloudant username> <cloudant password>
 
   # install all required software
   (cd tools/ubuntu-setup && source all.sh)


### PR DESCRIPTION
Includes the documentation fix in #55 as well as new documentation on the use of CouchDB as an alternative to Cloudant.