### PR TITLE
WIP: Lost activation count

### DIFF
--- a/tests/src/common/WskCli.java
+++ b/tests/src/common/WskCli.java
@@ -39,6 +39,7 @@ public class WskCli {
 
     private static final File cliDir = WhiskProperties.getFileRelativeToWhiskHome("bin");
 
+    private static final String adminBinaryName = "wskadmin";
     private final String binaryName;
     private final File binaryPath;
     public String subject;
@@ -994,4 +995,24 @@ public class WskCli {
     public void setEnv(Map<String, String> env) {
         this.env = env;
     }
+
+    /*
+     * Since there are many unit tests in Java and some of them need access to WskAdmin,
+     * we lightly reflect the admin methods here.
+     */
+    public static RunResult admin(String... params)
+            throws IllegalArgumentException, IOException {
+        File workingDir = new File(".");
+        String[] cmd = new String[] { WhiskProperties.python, new File(cliDir, adminBinaryName).toString() };
+        return TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, null, Util.concat(cmd, params));
+    }
+
+    /*
+     * Create a user.  The caller is responsible for checking success upon which stdout contains the authKey.
+     */
+    public static RunResult createUser(String subject) throws Exception {
+        return admin("user", "create", subject);
+    }
+
+
 }

--- a/tests/src/system/basic/CLIRuleTests.java
+++ b/tests/src/system/basic/CLIRuleTests.java
@@ -462,7 +462,7 @@ public class CLIRuleTests {
                                 System.out.println("Running part 1 at " + System.currentTimeMillis());
                                 for (int j=0; j<1+ITERATIONS/2; j++) 
                                     wsk.triggerNoCheck("T_del", "deletePayload_"+j);
-                                Thread.sleep(20 * 1000);
+                                Thread.sleep(30 * 1000);
                                 System.out.println("Running part 2 at " + System.currentTimeMillis());
                                 for (int j=0; j<1+ITERATIONS/2; j++) 
                                     wsk.triggerNoCheck("T_del", "deletePayload_"+j);

--- a/tests/src/system/basic/CLIRuleTests.java
+++ b/tests/src/system/basic/CLIRuleTests.java
@@ -446,7 +446,6 @@ public class CLIRuleTests {
             wsk.createAction("A_del", TestUtils.getCatalogFilename("samples/wc.js"));
             wsk.createTrigger("T_del");
             wsk.createRule("R_del", "T_del", "A_del");
-            Thread.sleep(5000);
             wsk.delete(Action, "A_del");
 
             // Try to trip inconsistency in concurrent activation count of a broken trigger but not rate throttler
@@ -463,11 +462,11 @@ public class CLIRuleTests {
                                 int ITERATIONS = 1 + (LIMIT / THREADS);
                                 System.out.println("Thread " + index + ". Running part 1 at " + System.currentTimeMillis());
                                 for (int j=0; j<1+ITERATIONS/2; j++) 
-                                    wsk.triggerNoCheck("T_del", "deletePayload_"+j);
+                                    wsk.triggerNoCheck("T_del", "deletePayload_1_"+j);
                                 Thread.sleep(30 * 1000);  // so as to not trigger per-minute throttle
                                 System.out.println("Thread " + index + ". Running part 2 at " + System.currentTimeMillis());
                                 for (int j=0; j<1+ITERATIONS/2; j++) 
-                                    wsk.triggerNoCheck("T_del", "deletePayload_"+j);
+                                    wsk.triggerNoCheck("T_del", "deletePayload_2_"+j);
                                 System.out.println("Thread " + index + ". Done at " + System.currentTimeMillis());
                             } catch (Exception e) {
                                 System.out.println("Exception: " + e);
@@ -479,7 +478,7 @@ public class CLIRuleTests {
             for (int i=0; i<threads.length; i++) {
                 threads[i].join();
             }
-            Thread.sleep(3 * 1000);
+            Thread.sleep(5 * 1000); // allow triggers and counts to propagate so we can test throttle
 
             // Check that it's working normally
             String expected = "A_normal_payload";


### PR DESCRIPTION
Add test that detects lost activation counts leading to inappropriate throttling by creating a dangling rule.  Fix the invoker so that activations have their counts and records generated even if unsuccessful.