### PR TITLE
Support Promises/A+ in nodeJsActions

### DIFF
--- a/core/nodejsAction/package.json
+++ b/core/nodejsAction/package.json
@@ -2,6 +2,7 @@
   "name": "nodejsAction",
   "version": "0.0.1",
   "dependencies": {
+    "bluebird": "^3.3.4",
     "body-parser": "^1.11.0",
     "btoa": "^1.1.2",
     "express": "^4.11.2",

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -296,4 +296,50 @@ class NodeJsActionContainerTests extends FlatSpec
         filtered(out).trim shouldBe empty
         err.trim shouldBe empty
     }
+
+    it should "support resolved promises" in {
+      val (out, err) = withNodeJsContainer { c =>
+      val code = """
+      | function main(args) {
+        |     return new Promise(function(resolve, reject) {
+        |       setTimeout(function() {
+        |         resolve({ done: true });
+        |       }, 100);
+        |    })
+        | }
+        """.stripMargin
+
+        c.init(initPayload(code))._1 should be(200)
+
+        val (runCode, runRes) = c.run(runPayload(JsObject()))
+        runCode should be(200)
+        runRes should be(Some(JsObject("done" -> JsBoolean(true))))
+      }
+
+      filtered(out).trim shouldBe empty
+      err.trim shouldBe empty
+    }
+
+    it should "support rejected promises" in {
+      val (out, err) = withNodeJsContainer { c =>
+      val code = """
+      | function main(args) {
+        |     return new Promise(function(resolve, reject) {
+        |       setTimeout(function() {
+        |         reject({ done: true });
+        |       }, 100);
+        |    })
+        | }
+        """.stripMargin
+
+        c.init(initPayload(code))._1 should be(200)
+
+        val (runCode, runRes) = c.run(runPayload(JsObject()))
+
+        runCode should be(200)
+        runRes.get.fields.get("error") shouldBe defined
+      }
+      filtered(out).trim shouldBe empty
+      err.trim shouldBe empty
+    }
 }


### PR DESCRIPTION
This change adds support for returning promises to node.js actions.

It can be used like this.
```
function main() {
   return new Promise(function (resolve, reject) {
       setTimeout(function() {
           resolve({done: true});
       }, 100);
   })
}
```

You can also reject promises, causing them to be wrapped in an error.
```
function main() {
   return new Promise(function (resolve, reject) {
       setTimeout(function() {
           reject({msg: "oops"});
       }, 100);
   })
}
```
Returns this `{ error: { msg: "oops" } }`

This fix uses the Bluebird promise library for now until a newer node versions is implemented. At which point we can remove the dependency and use ES6 promises. They both have the same resolve api so this will be a server change only and transparent to any users.

Note this commit makes use of the fact that calling Promise.resolve on a non-promise type (value/undefined) returns that value.

(See spec)
http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects

This fix resolves #56 