### PR TITLE
add new property whisk.version.tag with image tag and expose on /api/…

### DIFF
--- a/common/scala/src/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/whisk/core/WhiskConfig.scala
@@ -1,4 +1,5 @@
 /*
+
  * Copyright 2015-2016 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,8 +132,9 @@ object WhiskConfig {
     val edgeHostName = "edge.host"
     val whiskVersionName = "whisk.version.name"
     val whiskVersionDate = "whisk.version.date"
-
-    val whiskVersion = Map(whiskVersionName -> null, whiskVersionDate -> null)
+    val whiskVersionBuildno = "whisk.version.buildno"
+    
+    val whiskVersion = Map(whiskVersionName -> null, whiskVersionDate -> null, whiskVersionBuildno -> null)
 
     val dockerImageTag = "docker.image.tag"
 

--- a/config/writePropertyFile.sh
+++ b/config/writePropertyFile.sh
@@ -35,6 +35,7 @@ echo "nginx.conf.dir="$NGINX_CONF_DIR >> "$WHISK_HOME/whisk.properties"
 # Write configuration information to whisk.properties
 echo "whisk.version.name" = $WHISK_CONFIG_NAME >> "$WHISK_HOME/whisk.properties"
 echo "whisk.version.date" = `date '+%Y-%m-%dT%H:%M:%S%:z' ` >> "$WHISK_HOME/whisk.properties"
+echo "whisk.version.buildno" = "$DOCKER_IMAGE_TAG" >> "$WHISK_HOME/whisk.properties"
 
 # Authorization to use for unit tests
 echo "testing.auth=$WHISK_TEST_AUTH" >> "$WHISK_HOME/whisk.properties"

--- a/core/controller/build.xml
+++ b/core/controller/build.xml
@@ -23,6 +23,7 @@
             <arg line="-e &quot;COMPONENT_NAME=controller&quot;" />
             <arg line="-e &quot;WHISK_VERSION_NAME=${whisk.version.name}&quot;" />
             <arg line="-e &quot;WHISK_VERSION_DATE=${whisk.version.date}&quot;" />
+            <arg line="-e &quot;WHISK_VERSION_BUILDNO=${whisk.version.buildno}&quot;" />
             <arg line="-v ${whisk.logs.dir}/controller:/logs" />
             <arg line="-h controller_${edge.docker.endpoint}" />
             <arg line="${consul.service.check}" />

--- a/core/controller/src/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/whisk/core/controller/RestAPIs.scala
@@ -39,6 +39,7 @@ import whisk.common.Verbosity
 import whisk.common.Verbosity.Level
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.whiskVersionDate
+import whisk.core.WhiskConfig.whiskVersionBuildno
 import whisk.core.connector.LoadBalancerResponse
 import whisk.core.entitlement.Collection
 import whisk.core.entitlement.EntitlementService
@@ -54,7 +55,8 @@ import whisk.core.entity.types.EntityStore
 
 abstract protected[controller] class RestAPIVersion(
     protected val apiversion: String,
-    protected val build: String)
+    protected val build: String,
+    protected val buildno: String)
     extends Directives {
 
     /** Base API prefix. */
@@ -70,7 +72,8 @@ abstract protected[controller] class RestAPIVersion(
         JsObject(
             "openwhisk" -> "hello".toJson,
             "version" -> apiversion.toJson,
-            "build" -> build.toJson)
+            "build" -> build.toJson,
+            "buildno" -> buildno.toJson)
     }
 }
 
@@ -92,7 +95,7 @@ protected[controller] class RestAPIVersion_v1(
     verbosity: Verbosity.Level,
     implicit val actorSystem: ActorSystem,
     implicit val executionContext: ExecutionContext)
-    extends RestAPIVersion("v1", config(whiskVersionDate))
+    extends RestAPIVersion("v1", config(whiskVersionDate), config(whiskVersionBuildno))
     with Authenticate
     with AuthenticatedRoute {
 

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -81,7 +81,12 @@ class WskBasicTests
         val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuild")).stdout
         stdout should include regex ("""whisk API build*.*201.*\n""")
     }
-
+    
+    it should "show api build number" in {
+        val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuildno")).stdout
+        stdout should include regex ("""whisk API build*.*.*\n""")
+    }
+    
     it should "set auth in property file" in {
         val wskprops = File.createTempFile("wskprops", ".tmp")
         val env = Map("WSK_CONFIG_FILE" -> wskprops.getAbsolutePath())

--- a/tools/cli/wsk
+++ b/tools/cli/wsk
@@ -131,6 +131,7 @@ def parseArgs(props):
     subcmd.add_argument('--namespace', help='namespace', action='store_true')
     subcmd.add_argument('--cliversion', help='whisk CLI version', action='store_true')
     subcmd.add_argument('--apibuild', help='whisk API build version', action='store_true')
+    subcmd.add_argument('--apibuildno', help='whisk API build number', action='store_true')
 
     listmenu = subparsers.add_parser('list', help='list all triggers, actions, and rules in the registry')
     listmenu.add_argument('name', nargs='?', help='the namespace to list')
@@ -203,7 +204,7 @@ def propCmd(args, props, userprops, propsLocation):
             print 'ok: whisk namespace unset'
         return 0
     elif args.subcmd == 'get':
-        args.all = args.auth == args.apihost == args.apiversion == args.namespace == args.cliversion == args.apibuild == False
+        args.all = args.auth == args.apihost == args.apiversion == args.namespace == args.cliversion == args.apibuild == args.apibuildno == False
         if args.all or args.auth:
             print 'whisk auth\t\t%s' % userprops.get('AUTH')
         if args.all or args.apihost:
@@ -226,6 +227,18 @@ def propCmd(args, props, userprops, propsLocation):
                     return responseError(res, prefix=None)
             else:
                 print 'whisk API build\t\tNone',
+        if args.all or args.apibuildno:
+            if props['apihost'] is not None:
+                url = 'https://%(apibase)s' % { 'apibase' : apiBase(props) }
+                res = request('GET', url, verbose=args.verbose)
+                if res.status == httplib.OK:
+                    result = json.loads(res.read())
+                    print 'whisk API buildno\t%s' % result['buildno']
+                else:
+                    print 'whisk API build\t\tCannot determine API buildno:',
+                    return responseError(res, prefix=None)
+            else:
+                print 'whisk API buildno\t\tNone',
         return 0
     return 2
 


### PR DESCRIPTION
…v1 endpoint in controller

I enhanced the `/api/v1` endpoint in the controller by a new attribute that contains the tag of the docker images.

```
curl -k https://192.168.99.100/api/v1 -H "Authorization: MjNiYzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOjEyM3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
{
  "openwhisk": "hello",
  "version": "v1",
  "build": "2016-03-16T18:16:50:z",
  "tag": "latest"
}
```