### PR TITLE
Some fixes for Eclipse integration of Gradle

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile 'io.spray:spray-caching_2.11:1.3.3'
     compile 'io.spray:spray-json_2.11:1.3.2'
     compile 'io.spray:spray-can_2.11:1.3.3'
-    compile 'io.spray:spray-client:1.3.1'
+    compile 'io.spray:spray-client_2.11:1.3.1'
     compile 'io.spray:spray-httpx_2.11:1.3.3'
     compile 'io.spray:spray-io_2.11:1.3.3'
     compile 'io.spray:spray-routing_2.11:1.3.3'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'scala'
 apply plugin: 'eclipse'
-compileJava.options.encoding = 'UTF-8'
+compileTestScala.options.encoding = 'UTF-8'
 
 repositories {
     mavenCentral()
@@ -18,7 +18,7 @@ sourceSets {
 }
 
 test {
-    jvmArgs = [ "-Dtestthreads=1" ]
+    systemProperty 'testthreads', System.getProperty('testthreads', '1')
     testLogging {
         events "passed", "skipped", "failed"
     }


### PR DESCRIPTION
Solving cross-compiled dependency problem, compiling tests in UTF-8, passing testthreads to tests