### PR TITLE
issue #100 provide initial playbook for loadbalancer. supports registry

### DIFF
--- a/core/loadBalancer/deploy.yml
+++ b/core/loadBalancer/deploy.yml
@@ -1,0 +1,22 @@
+- name: OpenWhisk LoadBalancer
+  hosts: main
+  tasks:
+  - name: Pull image
+    shell: "docker pull {{docker.registry}}whisk/loadbalancer:{{docker_image_tag}}"
+    when: docker.registry != ""
+  - name: (Re)start container
+    docker:
+      name: loadbalancer
+      image: "{{docker.registry}}whisk/loadbalancer:{{docker_image_tag}}"
+      state: reloaded
+      restart_policy: "{{docker.restart.policy}}"
+      env:
+        "COMPONENT_NAME": "loadbalancer"
+        "CONSULSERVER_HOST": "{{consul.host}}"
+        "CONSUL_HOST_PORT4": "{{consul.port4}}"
+        "PORT": 8080
+        "KAFKA_NUMPARTITIONS": 2
+      volumes:
+        - "{{whisk.logs.dir}}/loadbalancer:/logs"
+      ports:
+        - "{{loadbalancer.port}}:8080"

--- a/environments/local/group_vars/all
+++ b/environments/local/group_vars/all
@@ -10,12 +10,13 @@ whisk:
     key: config/keys/openwhisk-self-key.pem
   logs:
     dir: /tmp/wsklogs
+docker_image_tag: latest
 docker:
+  registry: ""
   restart:
     policy: always
 
 controller:
-  host: 172.17.0.1
   port: 10001
 
 consul:
@@ -24,21 +25,18 @@ consul:
   port5: 8600
 
 kafka:
-  host: 172.17.0.1
   port: 9092
   ras:
     port: 9093
 
 zookeeper:
-  host: 172.17.0.1
   port: 2181
 
 activator:
-  host: 172.17.0.1
   port: 12000
 
 invoker:
   port: 12001
 
-loadBalancer:
+loadbalancer:
   port: 10003


### PR DESCRIPTION
Signed-off-by: Hoang Anh Le <hoang@de.ibm.com>

initial support for deployment using docker registry. unfortunately the ansible docker module has bugs that prevent us from using the "pull" and "registry" settings (they are ignored) which forces us to write a shell task that does the pull. other components will be updated with registry support as well.