### PR TITLE
Maintain preallocated nodejs container

### DIFF
--- a/core/dispatcher/src/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerPool.scala
@@ -162,10 +162,7 @@ class ContainerPool(
 
     def getNumberOfIdleContainers(key: String)(implicit transid: TransactionId): Int = {
         this.synchronized {
-            keyMap.get(key) match {
-                case None => 0
-                case Some(bucket) => bucket.count { _.isIdle() }
-            }
+            keyMap.get(key) map { bucket => bucket.count { _.isIdle() } } getOrElse 0
         }
     }
 
@@ -313,7 +310,7 @@ class ContainerPool(
     private val warmupThread = new Thread {
         override def run {
             while (true) {
-                val tid = TransactionId(0)
+                val tid = TransactionId.dontcare
                 if (getNumberOfIdleContainers(warmNodejsKey)(tid) < WARM_NODEJS_CONTAINERS) {
                     makeWarmNodejsContainer()(tid)
                 }

--- a/core/dispatcher/src/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerPool.scala
@@ -327,6 +327,10 @@ class ContainerPool(
         val limits = ActionLimits()
         val warmContainerName = "someWarmContainer"
         val con = new WhiskContainer(this, warmNodejsKey, warmContainerName, imageName, network, false, env, limits)
+        con.pause()
+        this.synchronized {
+            introduceContainer(warmNodejsKey, con)
+        }
         info(this, s"ContainerPool: started warm nodejs container")
         con
     }

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -67,7 +67,7 @@ class ContainerPoolTests extends FlatSpec
             ++ WhiskAuthStore.requiredProperties)
     assert(config.isValid)
 
-    val pool = new ContainerPool(config)
+    val pool = new ContainerPool(config, 0, false)
     pool.setVerbosity(Verbosity.Loud)
     pool.logDir = "/tmp"
 


### PR DESCRIPTION
PG 174 passed.

This commit is the 2nd phase of having pre-warmed nodejs containers and consists of having a thread that continually maintains N unspecialized containers that are part of the container pool data structure.  These containers are not yet used.  This incremental commit is intended to ensure that maintaining these containers is not harmful (before the final stage where we promote them for use).
