### PR TITLE
Activate pre-warmed nodejs containers

### DIFF
--- a/common/scala/src/whisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/whisk/core/entity/MemoryLimit.scala
@@ -42,7 +42,7 @@ protected[entity] class MemoryLimit private (val megabytes: Int) extends AnyVal 
 protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
     protected[entity] val MIN_MEMORY = 128 // MB
     protected[entity] val MAX_MEMORY = 512 // MB
-    protected[entity] val STD_MEMORY = 256 // MB
+    protected[core] val STD_MEMORY = 256 // MB
 
     /** Gets TimeLimit with default duration */
     protected[core] def apply(): MemoryLimit = new MemoryLimit(STD_MEMORY)
@@ -55,7 +55,7 @@ protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
      * @throws IllegalArgumentException if limit does not conform to requirements
      */
     @throws[IllegalArgumentException]
-    protected[entity] def apply(megabytes: Int): MemoryLimit = {
+    protected[core] def apply(megabytes: Int): MemoryLimit = {
         require(megabytes >= MIN_MEMORY, s"memory $megabytes below allowed threshold")
         require(megabytes <= MAX_MEMORY, s"memory $megabytes exceeds allowed threshold")
         new MemoryLimit(megabytes);


### PR DESCRIPTION
Enable use of pre-warm nodejs containers by providing an alternative path for promoting a pre-warmed container to a matching action.  The action must match both language (nodejs) and the memory limits.  Currently, only nodejs and standard memory limits are pre-warmed.  Other cases to be handled later.

1. getOnce renamed to getOrMake with parts of it factored out to retrieve
2. changeKey is used to support the promotion apropos the data structure
3. makeWhiskContainer now bifurcates to makeGeneralContainer (spin a new one up) and getWarmNodejsContainer (try to get a pre-existing warm one)

PPG 219
