### PR TITLE
Record init duration in transaction object

### DIFF
--- a/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
@@ -87,9 +87,12 @@ class WhiskContainer(
      * @param state the value of the status to compare the actual state against
      * @return triple of start time, end time, response for user action.
      */
-    def run(args: JsObject, meta: JsObject, authKey : String, timeout: Int)(implicit transid: TransactionId): RunResult = {
+    def run(args: JsObject, meta: JsObject, authKey : String, timeout: Int, actionName: String, activationId: String)
+           (implicit transid: TransactionId): RunResult = {
         val start = ContainerCounter.now()
+        info("Invoker", s"sending arguments to $actionName $details")
         val response = sendPayload("/run", JsObject(meta.fields + ("value" -> args) + ("authKey" -> JsString(authKey))), timeout)
+        info("Invoker", s"finished running activation id: $activationId")
         (start, ContainerCounter.now(), response)
     }
 
@@ -99,7 +102,7 @@ class WhiskContainer(
     def run(payload: String, activationId: String): RunResult = {
         val params = JsObject("payload" -> JsString(payload))
         val meta = JsObject("activationId" -> JsString(activationId))
-        run(params, meta, "no_auth_key", 30000)(TransactionId.dontcare)
+        run(params, meta, "no_auth_key", 30000, "no_action", "no_activation_id")(TransactionId.dontcare)
     }
 
     /**

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -405,10 +405,12 @@ class Invoker(
                                     actionVersion: SemVer, payload: JsObject, response: Option[(Int, String)], log: JsArray)(
                                         implicit transid: TransactionId): WhiskActivation = {
         val interval = (transaction.initInterval, transaction.runInterval) match {
-            case (None, Some(interval)) => interval
-            case (Some(interval), None) => interval
+            case (None, Some(run)) => run
+            case (Some(init), None) => init
             case (None, None) => (Instant.now(Clock.systemUTC()), Instant.now(Clock.systemUTC()))
-            case (Some(interval1), Some(interval2)) => (interval1._1, interval2._2)
+            case (Some(init), Some(run)) => 
+                val durMilli = init._2.toEpochMilli() - init._1.toEpochMilli()
+                (run._1.minusMillis(durMilli), run._2)
         }
         WhiskActivation(
             namespace = msg.subject.namespace,


### PR DESCRIPTION
Record both run and init duration into the transaction object and unify them during makeWhiskActivation.

PPG 244