### PR TITLE
Add template-couchdb-local.env

### DIFF
--- a/template-couchdb-local.env
+++ b/template-couchdb-local.env
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Set the Cloudant account username and password for Whisk to use.
+#
+
+OPEN_WHISK_DB_HOST=
+OPEN_WHISK_DB_PORT=
+OPEN_WHISK_DB_USERNAME=
+OPEN_WHISK_DB_PASSWORD=
+


### PR DESCRIPTION
Fix issue #151

template-couchdb-local.env should be added to openwhisk in order to support users of couchdb.