### PR TITLE
Remove global RestAssured config uses.

### DIFF
--- a/common/scala/src/whisk/core/connector/Message.scala
+++ b/common/scala/src/whisk/core/connector/Message.scala
@@ -83,7 +83,7 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
-    private implicit object TransidJsonForat extends RootJsonFormat[TransactionId] {
+    private implicit object TransidJsonFormat extends RootJsonFormat[TransactionId] {
         def write(tid: TransactionId) = tid.id.toJson
 
         def read(value: JsValue) = Try {

--- a/tests/src/services/PingTests.java
+++ b/tests/src/services/PingTests.java
@@ -16,9 +16,6 @@
 
 package services;
 
-import static com.jayway.restassured.RestAssured.baseURI;
-import static com.jayway.restassured.RestAssured.get;
-import static com.jayway.restassured.RestAssured.port;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -27,6 +24,8 @@ import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+
+import com.jayway.restassured.RestAssured;
 
 import common.Pair;
 import common.TestUtils;
@@ -49,10 +48,8 @@ public class PingTests {
     public void pingDocker(String var, String endpoint) {
         assertTrue(var + " not set", endpoint != null);
         assertTrue(var + " not set", endpoint.length() > 0);
-        baseURI = "http://" + endpoint;
-        port = 4243;
 
-        String response = get("/info").body().asString();
+        String response = RestAssured.given().port(4243).baseUri("http://" + endpoint).get("/info").body().asString();
         System.out.println("GET /info");
         System.out.println(response);
         assertTrue(response.contains("Containers"));
@@ -65,7 +62,6 @@ public class PingTests {
     public void pingMainDocker() {
         pingDocker("main.docker.endpoint", WhiskProperties.getMainDockerEndpoint());
     }
-
 
     /**
      * Check the kafka docker endpoint is functioning.
@@ -101,7 +97,6 @@ public class PingTests {
 
     /**
      * Check that the invoker endpoints are up and running
-     * TODO: the # of invokers should not be hardcoded
      */
     @Test
     public void pingInvoker() throws IOException {
@@ -117,6 +112,7 @@ public class PingTests {
     public void pingLoadBalancer() throws IOException {
         PingTests.isAlive("loadbalancer", WhiskProperties.getFileRelativeToWhiskHome(".").getAbsolutePath());
     }
+
     /**
      * Check that the controller endpoint is up and running
      */
@@ -125,8 +121,7 @@ public class PingTests {
         PingTests.isAlive("controller", WhiskProperties.getFileRelativeToWhiskHome(".").getAbsolutePath());
     }
 
-  
     public static Pair<String, String> isAlive(String name, String whiskPropertyFile) throws IOException {
-        return TestUtils.runCmd(TestUtils.SUCCESS_EXIT,  bin, WhiskProperties.python, "isAlive", "-d", whiskPropertyFile ,name);
+        return TestUtils.runCmd(TestUtils.SUCCESS_EXIT, bin, WhiskProperties.python, "isAlive", "-d", whiskPropertyFile, name);
     }
 }

--- a/tests/src/system/rest/ActionSchemaTests.scala
+++ b/tests/src/system/rest/ActionSchemaTests.scala
@@ -16,21 +16,20 @@
 
 package system.rest
 
+import scala.util.Success
+import scala.util.Try
+
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+
 import com.jayway.restassured.RestAssured
-import com.jayway.restassured.config.RestAssuredConfig
-import com.jayway.restassured.config.SSLConfig
+
 import common.WhiskProperties
-import spray.json.pimpAny
-import spray.json.pimpString
-import spray.json.DefaultJsonProtocol._
-import spray.json.JsNull
-import scala.util.{ Try, Success, Failure }
 import spray.json.JsArray
 import spray.json.JsObject
+import spray.json.pimpString
 
 /**
  * Basic tests of API calls for actions
@@ -43,6 +42,7 @@ class ActionSchemaTests extends FlatSpec with Matchers with RestUtil with JsonSc
         val auth = WhiskProperties.getBasicAuth;
         val response = RestAssured.
             given().
+            config(sslconfig).
             auth().basic(auth.fst, auth.snd).
             get(getBaseURL() + "/namespaces/whisk.system/actions/samples/");
         assert(response.statusCode() == 200);
@@ -71,6 +71,7 @@ class ActionSchemaTests extends FlatSpec with Matchers with RestUtil with JsonSc
         val auth = WhiskProperties.getBasicAuth;
         val response = RestAssured.
             given().
+            config(sslconfig).
             auth().basic(auth.fst, auth.snd).
             get(getBaseURL() + "/namespaces/whisk.system/actions/samples/wordCount");
         assert(response.statusCode() == 200);

--- a/tests/src/system/rest/JsonSchema.scala
+++ b/tests/src/system/rest/JsonSchema.scala
@@ -16,9 +16,8 @@
 
 package system.rest;
 
-import com.jayway.restassured.RestAssured
-import common.WhiskProperties
 import common.TestUtils
+import common.WhiskProperties
 
 /**
  * Utilities for dealing with JSON schema

--- a/tests/src/system/rest/RestUtil.scala
+++ b/tests/src/system/rest/RestUtil.scala
@@ -16,15 +16,16 @@
 
 package system.rest
 
+import scala.util.Try
+
 import com.jayway.restassured.RestAssured
 import com.jayway.restassured.config.RestAssuredConfig
 import com.jayway.restassured.config.SSLConfig
+
 import common.WhiskProperties
-import spray.json.JsValue
 import spray.json.JsObject
+import spray.json.JsValue
 import spray.json.pimpString
-import scala.util.Try
-import spray.json.JsNull
 
 /**
  * Utilities for REST tests
@@ -33,9 +34,8 @@ protected[rest] trait RestUtil {
 
     private val trustStorePassword = WhiskProperties.getSslCertificateChallenge
 
-    // must force RestAssured to allow all hosts in SSL certificates ...
-    RestAssured.config = new RestAssuredConfig()
-        .sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames());
+    // force RestAssured to allow all hosts in SSL certificates
+    protected val sslconfig = new RestAssuredConfig().sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames());
 
     /**
      * @return the URL and port for the whisk service
@@ -58,8 +58,7 @@ protected[rest] trait RestUtil {
      * and return it as a string.
      */
     def getJsonSchema(model: String): JsValue = {
-
-        val response = RestAssured.get(getServiceURL() + "/api/v1/api-docs")
+        val response = RestAssured.given().config(sslconfig).get(getServiceURL() + "/api/v1/api-docs")
 
         assert(response.statusCode() == 200)
 

--- a/tests/src/system/rest/SwaggerTests.scala
+++ b/tests/src/system/rest/SwaggerTests.scala
@@ -20,11 +20,10 @@ import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+
 import com.jayway.restassured.RestAssured
-import com.jayway.restassured.config.RestAssuredConfig
-import com.jayway.restassured.config.SSLConfig
+
 import common.WhiskProperties
-import org.junit.Ignore
 
 /**
  * Basic tests of Swagger support
@@ -33,7 +32,7 @@ import org.junit.Ignore
 class SwaggerTests extends FlatSpec with Matchers with RestUtil {
 
     "Whisk API service" should "respond to /docs with Swagger UI" in {
-        val response = RestAssured.
+        val response = RestAssured.given().config(sslconfig).
             get(getServiceURL() + "/api/v1/docs/index.html")
 
         response.statusCode() should be(200)
@@ -41,7 +40,7 @@ class SwaggerTests extends FlatSpec with Matchers with RestUtil {
     }
 
     it should "respond to /api-docs with Swagger XML" in {
-        val response = RestAssured.
+        val response = RestAssured.given().config(sslconfig).
             get(getServiceURL() + "/api/v1/api-docs")
 
         response.statusCode() should be(200)
@@ -50,8 +49,7 @@ class SwaggerTests extends FlatSpec with Matchers with RestUtil {
 
     it should "respond to invalid URI with status code 404" in {
         val auth = WhiskProperties.getBasicAuth
-        val response = RestAssured.
-            given().
+        val response = RestAssured.given().config(sslconfig).
             auth().basic(auth.fst, auth.snd).
             get(getServiceURL() + "/api/v1/docs/dummy")
         response.statusCode() should be(404)


### PR DESCRIPTION
Remove global uses of RestAssured configuration which may bleed across tests.