### PR TITLE
Merge load balancer into controller

### DIFF
--- a/common/scala/src/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -58,7 +58,7 @@ class KafkaProducerConnector(
                 sentCounter.next()
                 promise.success(status)
             case Failure(t) =>
-                error(this, s"sending message failed: ${t.getMessage}")
+                error(this, s"sending message on topic '$topic' failed: ${t.getMessage}")
                 promise.failure(t)
         }
         promise.future

--- a/common/scala/src/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/whisk/core/WhiskConfig.scala
@@ -176,6 +176,7 @@ object WhiskConfig {
     val invokerHosts = Map(invokerHostsList -> null)
     val elkHost = Map(elkHostName -> null, elkHostPort -> null)
     val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
+    val controllerHost = Map(controllerHostName -> null, controllerHostPort -> null)
     val loadbalancerHost = Map(loadbalancerHostName -> null, loadbalancerHostPort -> null)
     val messagehubtriggerHost = Map(messagehubtriggerHostName -> null, messagehubtriggerHostPort -> null)
     val monitorHost = Map(monitorHostName -> null, monitorHostPort -> null)

--- a/core/build.xml
+++ b/core/build.xml
@@ -10,13 +10,13 @@
         <parallel threadCount="${deploythreads}" failonany="true">
             <ant antfile="${openwhisk.home}/core/controller/build.xml" target="startController" />
             <ant antfile="${openwhisk.home}/core/dispatcher/build.xml" target="startActivator" />
-            <ant antfile="${openwhisk.home}/core/loadBalancer/build.xml" target="startLoadBalancer" />
+            <!-- <ant antfile="${openwhisk.home}/core/loadBalancer/build.xml" target="startLoadBalancer" /> -->
             <antcall target="deploySlaves" />
         </parallel>
         <parallel threadCount="${deploythreads}" failonany="true">
             <ant antfile="${openwhisk.home}/core/controller/build.xml" target="waitController" />
             <ant antfile="${openwhisk.home}/core/dispatcher/build.xml" target="waitActivator" />
-            <ant antfile="${openwhisk.home}/core/loadBalancer/build.xml" target="waitLoadBalancer" />
+            <!-- <ant antfile="${openwhisk.home}/core/loadBalancer/build.xml" target="waitLoadBalancer" /> -->
         </parallel>
     </target>
 

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -13,7 +13,9 @@ repositories {
 sourceSets {
     main {
         scala {
-            srcDir 'src'
+            // This does not work because this project cannot use that project reference
+            // srcDirs = ['src/'].plus(project(':core:loadbalancer').sourceSets.main.scala.srcDirs)
+            srcDirs = ['src/'].plus('../loadBalancer/src/')
             exclude 'resources/**'
         }
         resources {

--- a/core/controller/build.xml
+++ b/core/controller/build.xml
@@ -21,6 +21,7 @@
             <arg line="-e &quot;CONSUL_HOST_PORT4=${consul.host.port4}&quot;" />
             <arg line="-e &quot;PORT=${controller.docker.port}&quot;" />
             <arg line="-e &quot;COMPONENT_NAME=controller&quot;" />
+            <arg line="-e &quot;KAFKA_NUMPARTITIONS=2&quot;" />
             <arg line="-e &quot;WHISK_VERSION_NAME=${whisk.version.name}&quot;" />
             <arg line="-e &quot;WHISK_VERSION_DATE=${whisk.version.date}&quot;" />
             <arg line="-e &quot;WHISK_VERSION_BUILDNO=${whisk.version.buildno}&quot;" />

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -388,7 +388,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         val args = { env map { _ ++ action.parameters } getOrElse action.parameters } merge payload
         val message = Message(transid, s"/actions/invoke/${action.namespace}/${action.name}/${action.rev}", user, ActivationId(), args)
         info(this, s"[POST] action activation id: ${message.activationId}")
-        performLoadBalancerRequest(publish(INVOKER), message) map {
+        performLoadBalancerRequest(publish(INVOKER), message, transid) map {
             (action.limits.timeout(), _)
         } flatMap {
             case (duration, response) =>

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -388,7 +388,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         val args = { env map { _ ++ action.parameters } getOrElse action.parameters } merge payload
         val message = Message(transid, s"/actions/invoke/${action.namespace}/${action.name}/${action.rev}", user, ActivationId(), args)
         info(this, s"[POST] action activation id: ${message.activationId}")
-        performLoadBalancerRequest(publish(INVOKER), message, transid) map {
+        performLoadBalancerRequest(INVOKER, message, transid) map {
             (action.limits.timeout(), _)
         } flatMap {
             case (duration, response) =>

--- a/core/controller/src/whisk/core/controller/Backend.scala
+++ b/core/controller/src/whisk/core/controller/Backend.scala
@@ -82,10 +82,10 @@ object WhiskServices extends LoadbalancerRequest {
      */
     def performLoadBalancerRequest(config: WhiskConfig, timeout: Timeout = 10 seconds)(
         implicit as: ActorSystem, ec: ExecutionContext): (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse] = {
-        if (true) {
+        if (false) {
             // This connects to a separate LoadBalancer micro-service.
             val requester = request(config.loadbalancerHost, timeout)
-            (component: String, message : ActivationMessage, tran : TransactionId) => { requester(Post(component, message.toJson.asJsObject)) }
+            (component: String, message : ActivationMessage, tran : TransactionId) => { requester(Post(publish(component), message.toJson.asJsObject)) }
         } else {
             // This version runs a local LoadBalanceService
             val loadBalancer = new LoadBalancerService(config, Verbosity.Loud)

--- a/core/controller/src/whisk/core/controller/Controller.scala
+++ b/core/controller/src/whisk/core/controller/Controller.scala
@@ -23,8 +23,9 @@ import akka.japi.Creator
 import spray.routing.Directive.pimpApply
 import whisk.common.TransactionId
 import whisk.common.Verbosity
+import whisk.core.loadBalancer.InvokerHealth
 import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.consulServer
+import whisk.core.WhiskConfig.{consulServer, kafkaHost, kafkaPartitions}
 import whisk.http.BasicHttpService
 import whisk.http.BasicRasService
 import whisk.utils.ExecutionContextFactory
@@ -53,9 +54,13 @@ class Controller(
 }
 
 object Controller {
-    def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
+    def requiredProperties = 
+        Map(WhiskConfig.servicePort -> 8080.toString) ++
         RestAPIVersion_v1.requiredProperties ++
-        consulServer
+        consulServer ++
+        kafkaHost ++
+        Map(kafkaPartitions -> null) ++
+        InvokerHealth.requiredProperties
 
     private class ServiceBuilder(config: WhiskConfig, instance: Int) extends Creator[Controller] {
         implicit val executionContext = ExecutionContextFactory.makeExecutionContext()

--- a/core/controller/src/whisk/core/controller/Controller.scala
+++ b/core/controller/src/whisk/core/controller/Controller.scala
@@ -51,10 +51,11 @@ class Controller(
 
     /** The REST APIs. */
     private val apiv1 = new RestAPIVersion_v1(config, verbosity, context.system, executionContext)
+
 }
 
 object Controller {
-    def requiredProperties = 
+    def requiredProperties =
         Map(WhiskConfig.servicePort -> 8080.toString) ++
         RestAPIVersion_v1.requiredProperties ++
         consulServer ++

--- a/core/controller/src/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/whisk/core/controller/RestAPIs.scala
@@ -34,8 +34,7 @@ import spray.routing.Directive.pimpApply
 import spray.routing.Directives
 import spray.routing.Route
 
-import whisk.common.TransactionId
-import whisk.common.Verbosity
+import whisk.common.{TransactionId, Verbosity}
 import whisk.common.Verbosity.Level
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.whiskVersionDate
@@ -43,17 +42,9 @@ import whisk.core.WhiskConfig.whiskVersionBuildno
 import whisk.core.connector.LoadBalancerResponse
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.Message
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.EntitlementService
-import whisk.core.entitlement.Privilege
-import whisk.core.entitlement.Resource
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskActivationStore
-import whisk.core.entity.WhiskAuthStore
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.types.ActivationStore
-import whisk.core.entity.types.AuthStore
-import whisk.core.entity.types.EntityStore
+import whisk.core.entitlement.{Collection, EntitlementService, Privilege, Resource}
+import whisk.core.entity.{Subject, WhiskActivationStore, WhiskAuthStore, WhiskEntityStore}
+import whisk.core.entity.types.{ActivationStore, AuthStore, EntityStore}
 
 abstract protected[controller] class RestAPIVersion(
     protected val apiversion: String,
@@ -134,7 +125,7 @@ protected[controller] class RestAPIVersion_v1(
     // initialize backend services
     protected implicit val consulServer = WhiskServices.consulServer(config)
     protected implicit val entitlementService = WhiskServices.entitlementService(config)
-    protected implicit val performLoadBalancerRequest: (String, ActivationMessage) => Future[LoadBalancerResponse] = WhiskServices.performLoadBalancerRequest(config)
+    protected implicit val performLoadBalancerRequest = WhiskServices.performLoadBalancerRequest(config)
 
     // register collections and set verbosities on datastores and backend services
     Collection.initialize(entityStore, verbosity)
@@ -169,7 +160,7 @@ protected[controller] class RestAPIVersion_v1(
             override val entityStore: EntityStore,
             override val activationStore: ActivationStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskActionsApi with WhiskServices {
@@ -183,7 +174,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
             override val activationStore: ActivationStore,
-            override val performLoadBalancerRequest: (String, ActivationMessage) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskTriggersApi with WhiskServices {
@@ -197,7 +188,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskRulesApi with WhiskServices {
@@ -221,7 +212,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: Level)(
             implicit override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskPackagesApi with WhiskServices {

--- a/core/controller/src/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/whisk/core/controller/RestAPIs.scala
@@ -45,6 +45,7 @@ import whisk.core.connector.Message
 import whisk.core.entitlement.{Collection, EntitlementService, Privilege, Resource}
 import whisk.core.entity.{Subject, WhiskActivationStore, WhiskAuthStore, WhiskEntityStore}
 import whisk.core.entity.types.{ActivationStore, AuthStore, EntityStore}
+import whisk.core.controller.WhiskServices.LoadBalancerReq
 
 abstract protected[controller] class RestAPIVersion(
     protected val apiversion: String,
@@ -125,7 +126,7 @@ protected[controller] class RestAPIVersion_v1(
     // initialize backend services
     protected implicit val consulServer = WhiskServices.consulServer(config)
     protected implicit val entitlementService = WhiskServices.entitlementService(config)
-    protected implicit val performLoadBalancerRequest = WhiskServices.performLoadBalancerRequest(config)
+    protected implicit val performLoadBalancerRequest = WhiskServices.makeLoadBalancer(config)
 
     // register collections and set verbosities on datastores and backend services
     Collection.initialize(entityStore, verbosity)
@@ -160,7 +161,7 @@ protected[controller] class RestAPIVersion_v1(
             override val entityStore: EntityStore,
             override val activationStore: ActivationStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: LoadBalancerReq => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskActionsApi with WhiskServices {
@@ -174,7 +175,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
             override val activationStore: ActivationStore,
-            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: LoadBalancerReq => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskTriggersApi with WhiskServices {
@@ -188,7 +189,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: LoadBalancerReq => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskRulesApi with WhiskServices {
@@ -212,7 +213,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: Level)(
             implicit override val entityStore: EntityStore,
             override val entitlementService: EntitlementService,
-            override val performLoadBalancerRequest: (String, ActivationMessage, TransactionId) => Future[LoadBalancerResponse],
+            override val performLoadBalancerRequest: LoadBalancerReq => Future[LoadBalancerResponse],
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskPackagesApi with WhiskServices {

--- a/core/controller/src/whisk/core/controller/Rules.scala
+++ b/core/controller/src/whisk/core/controller/Rules.scala
@@ -302,7 +302,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      */
     private def postToActivator(user: Subject, namespace: Namespace, name: EntityName, prevState: Status, newRule: WhiskRule, docid: DocInfo)(implicit transid: TransactionId) = {
         val message = Message(transid, s"/rules/${newRule.status}/${newRule.docid}", user, ActivationId(), None)
-        val post = performLoadBalancerRequest(publish(ACTIVATOR), message) flatMap { response =>
+        val post = performLoadBalancerRequest(publish(ACTIVATOR), message, transid) flatMap { response =>
             response.id match {
                 case Some(_) =>
                     info(this, s"[POST] rule status change to ${newRule.status} activated")

--- a/core/controller/src/whisk/core/controller/Rules.scala
+++ b/core/controller/src/whisk/core/controller/Rules.scala
@@ -302,7 +302,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      */
     private def postToActivator(user: Subject, namespace: Namespace, name: EntityName, prevState: Status, newRule: WhiskRule, docid: DocInfo)(implicit transid: TransactionId) = {
         val message = Message(transid, s"/rules/${newRule.status}/${newRule.docid}", user, ActivationId(), None)
-        val post = performLoadBalancerRequest(publish(ACTIVATOR), message, transid) flatMap { response =>
+        val post = performLoadBalancerRequest(ACTIVATOR, message, transid) flatMap { response =>
             response.id match {
                 case Some(_) =>
                     info(this, s"[POST] rule status change to ${newRule.status} activated")

--- a/core/controller/src/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/whisk/core/controller/Triggers.scala
@@ -123,7 +123,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                         val message = Message(transid, s"/triggers/fire/${trigger.docid}", user, ActivationId(), args)
                         info(this, s"[POST] trigger activation id: ${message.activationId}")
                         val start = Instant.now(Clock.systemUTC())
-                        val postToLoadbalancer = performLoadBalancerRequest(publish(ACTIVATOR), message) flatMap {
+                        val postToLoadbalancer = performLoadBalancerRequest(publish(ACTIVATOR), message, transid) flatMap {
                             response =>
                                 response.id match {
                                     case Some(activationId) =>

--- a/core/controller/src/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/whisk/core/controller/Triggers.scala
@@ -123,7 +123,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                         val message = Message(transid, s"/triggers/fire/${trigger.docid}", user, ActivationId(), args)
                         info(this, s"[POST] trigger activation id: ${message.activationId}")
                         val start = Instant.now(Clock.systemUTC())
-                        val postToLoadbalancer = performLoadBalancerRequest(publish(ACTIVATOR), message, transid) flatMap {
+                        val postToLoadbalancer = performLoadBalancerRequest(ACTIVATOR, message, transid) flatMap {
                             response =>
                                 response.id match {
                                     case Some(activationId) =>

--- a/core/dispatcher/src/whisk/core/activator/Activator.scala
+++ b/core/dispatcher/src/whisk/core/activator/Activator.scala
@@ -195,7 +195,7 @@ class Activator(
     }
 
     private def getUniqueName(name: String, subject: Subject): String = s"$subject.$name"
-    private val postLoadBalancerRequest = request(config.loadbalancerHost)
+    private val postLoadBalancerRequest = request(config.controllerHost)
     private val datastore = WhiskEntityStore.datastore(config)
     datastore.setVerbosity(Verbosity.Loud)
 }

--- a/core/dispatcher/src/whisk/core/activator/PostInvoke.scala
+++ b/core/dispatcher/src/whisk/core/activator/PostInvoke.scala
@@ -38,7 +38,7 @@ import spray.json.pimpAny
 import whisk.common.HttpUtils
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.loadbalancerHost
+import whisk.core.WhiskConfig.{controllerHost, loadbalancerHost}
 import whisk.core.dispatcher.DispatchRule
 import whisk.core.dispatcher.Dispatcher
 import whisk.core.entity.ActivationId
@@ -110,5 +110,5 @@ class PostInvoke(
 }
 
 object PostInvoke {
-    def requiredProperties = loadbalancerHost
+    def requiredProperties = loadbalancerHost ++ controllerHost
 }

--- a/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -62,6 +62,9 @@ class LoadBalancerService(config: WhiskConfig, verbosity: Verbosity.Level)
     private val invokerHealth = new InvokerHealth(config, { () => producer.sentCount() })
     private val _activationThrottle = new ActivationThrottle(LoadBalancer.config.consulServer, invokerHealth)
 
+    // This must happen after the overrides
+    setVerbosity(verbosity)
+
     // --- WIP -----
     private var count = 0
     private val overloadThreshold = 5000 // this is the total across all invokers.  Disable by setting to -1.

--- a/tests/src/common/WhiskProperties.java
+++ b/tests/src/common/WhiskProperties.java
@@ -173,6 +173,14 @@ public class WhiskProperties {
         return Integer.parseInt(whiskProperties.getProperty("loadbalancer.host.port"));
     }
 
+    public static String getControllerHost() {
+        return whiskProperties.getProperty("controller.host");
+    }
+
+    public static int getControllerPort() {
+        return Integer.parseInt(whiskProperties.getProperty("controller.host.port"));
+    }
+
     /**
      * are we running on Mac OS X?
      */

--- a/tests/src/services/PingTests.scala
+++ b/tests/src/services/PingTests.scala
@@ -113,14 +113,6 @@ class PingTests {
     }
 
     /**
-     * Check that the loadbalancer endpoint is up and running
-     */
-    @Test
-    def pingLoadBalancer(): Unit = {
-        PingTests.isAlive("loadbalancer", WhiskProperties.getFileRelativeToWhiskHome(".").getAbsolutePath())
-    }
-
-    /**
      * Check that the controller endpoint is up and running
      */
     @Test

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -80,7 +80,7 @@ protected trait ControllerTestCommon
     val entitlementService: EntitlementService = new LocalEntitlementService(config)(executionContext)
     val actorSystem = ActorSystem("controllertests")
     val activationId = ActivationId() // need a static activation id to test activations api
-    val performLoadBalancerRequest = (comp: String, msg: ActivationMessage, transid: TransactionId) => Future {
+    val performLoadBalancerRequest = (lbr : WhiskServices.LoadBalancerReq) => Future {
         LoadBalancerResponse.id(activationId)
     }
     val consulServer = "???"

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -80,7 +80,7 @@ protected trait ControllerTestCommon
     val entitlementService: EntitlementService = new LocalEntitlementService(config)(executionContext)
     val actorSystem = ActorSystem("controllertests")
     val activationId = ActivationId() // need a static activation id to test activations api
-    val performLoadBalancerRequest = (comp: String, msg: ActivationMessage) => Future {
+    val performLoadBalancerRequest = (comp: String, msg: ActivationMessage, transid: TransactionId) => Future {
         LoadBalancerResponse.id(activationId)
     }
     val consulServer = "???"


### PR DESCRIPTION
This is the final piece that merges load controller into the controller.

1. Don't deploy loadbalancer and move the kafka partition parameter over to controller when deploying the latter.  
2. Include the source of the load balancer when compiling the controller.
3. Fix an earlier incomplete refactoring when publish(...) was not moved.
4. Add a switch to performLoadBalancer (in case we need to go back) and flip it to use internal load balancer.  Add missing transaction id parameter explicitly (easier because of how Backend and *API interact).