### PR TITLE
Write openwhisk.home to property file. 

### DIFF
--- a/config/localEnv.sh
+++ b/config/localEnv.sh
@@ -35,13 +35,13 @@ USE_DOCKER_REGISTRY=false # skip push/pull locally
 USE_CLI_DOWNLOAD=false # do not download CLI
 DOCKER_REGISTRY=
 
-WHISK_TEST_AUTH=guest
+WHISK_TEST_AUTH=$DIR/keys/auth.guest
 
 #
 # SSL certificate used by router
 #
-WHISK_SSL_CERTIFICATE=config/keys/openwhisk-self-cert.pem
-WHISK_SSL_KEY=config/keys/openwhisk-self-key.pem
+WHISK_SSL_CERTIFICATE=$DIR/keys/openwhisk-self-cert.pem
+WHISK_SSL_KEY=$DIR/keys/openwhisk-self-key.pem
 WHISK_SSL_CHALLENGE=openwhisk
 
 #

--- a/config/writePropertyFile.sh
+++ b/config/writePropertyFile.sh
@@ -11,6 +11,7 @@ WHISK_CONFIG_NAME=`echo $WHISK_CONFIG_NAME | sed -e 's/Env.sh//'`
 # Where am I? Get config.
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+OPENWHISK_HOME="$(dirname $DIR)"
 
 # Get root project directory
 WHISK_HOME="$(dirname "$DIR")"
@@ -18,6 +19,7 @@ rm -f "$WHISK_HOME/whisk.properties"
 
 touch "$WHISK_HOME/whisk.properties"
 
+echo "openwhisk.home="$OPENWHISK_HOME >> "$WHISK_HOME/whisk.properties"
 echo "whisk.logs.dir="$WHISK_LOGS_DIR >> "$WHISK_HOME/whisk.properties"
 
 echo "docker.port="$DOCKER_PORT >> "$WHISK_HOME/whisk.properties"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -58,7 +58,7 @@ task deleteKeystore(type: Delete) {
 task createKeystore(dependsOn: deleteKeystore, type:Exec) {
     Properties props = new Properties()
     props.load(new FileInputStream(file('../whisk.properties')))
-    def whiskCert = file('../' + props['whisk.ssl.cert'])
+    def whiskCert = file(props['whisk.ssl.cert'])
     commandLine 'keytool', '-import', '-alias', 'Whisk', '-noprompt', '-trustcacerts', '-file', whiskCert.getAbsolutePath(), '-keystore', keystorePath, '-storepass', 'openwhisk'
 }
 compileTestScala.finalizedBy createKeystore


### PR DESCRIPTION
This avoid having to disambiguate its location in the presence of multiple whisk.properties files in the directory tree.