### PR TITLE
Fix warnings in eclipse

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -21,7 +21,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.scala-lang:scala-library:2.11.1'
+    compile 'org.scala-lang:scala-library:2.11.7'
 
     compile 'io.spray:spray-caching_2.11:1.3.3'
     compile 'io.spray:spray-json_2.11:1.3.2'

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -23,6 +23,7 @@ sourceSets {
 }
 
 dependencies {
+    compile 'org.scala-lang:scala-library:2.11.7'
     compile project(':common:scala')
 }
 

--- a/core/dispatcher/build.gradle
+++ b/core/dispatcher/build.gradle
@@ -23,6 +23,7 @@ sourceSets {
 }
 
 dependencies {
+    compile 'org.scala-lang:scala-library:2.11.7'
     compile project(':common:scala')
 }
 

--- a/core/loadBalancer/build.gradle
+++ b/core/loadBalancer/build.gradle
@@ -23,6 +23,7 @@ sourceSets {
 }
 
 dependencies {
+    compile 'org.scala-lang:scala-library:2.11.7'
     compile project(':common:scala')
 }
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -28,6 +28,7 @@ test {
 }
 
 dependencies {
+    testCompile 'org.scala-lang:scala-library:2.11.7'
     testCompile 'org.apache.commons:commons-exec:1.1'
     testCompile 'org.apache.commons:commons-lang3:3.3.2'
     testCompile 'commons-logging:commons-logging:1.1.3'

--- a/tests/src/system/basic/CLIActionTests.java
+++ b/tests/src/system/basic/CLIActionTests.java
@@ -39,7 +39,6 @@ import com.google.gson.JsonParser;
 import common.Pair;
 import common.TestUtils;
 import common.TestUtils.RunResult;
-import common.WhiskProperties;
 import common.WskCli;
 
 /**


### PR DESCRIPTION
* Updated `scala-library`
* Explicity reference used scala library per project (needed for eclipse to keep down the warnings)
* Removed unused import