### PR TITLE
Fix transaction id to be explicit and mutable within Container

### DIFF
--- a/common/scala/src/whisk/common/ConsulKVReporter.scala
+++ b/common/scala/src/whisk/common/ConsulKVReporter.scala
@@ -36,7 +36,7 @@ class ConsulKVReporter(
     private val t = new Thread() {
         override def run() = {
             Thread.sleep(initialDelayMilli)
-            val (selfHostname, stderr, exitCode) = SimpleExec.syncRunCmd(Array("hostname", "-f"))
+            val (selfHostname, stderr, exitCode) = SimpleExec.syncRunCmd(Array("hostname", "-f"))(TransactionId.dontcare)
             kvStore.put(hostKey, JsString(selfHostname))
             kvStore.put(startKey, JsString(s"${DateUtil.getTimeString}"))
             while (true) {

--- a/common/scala/src/whisk/common/Curl.scala
+++ b/common/scala/src/whisk/common/Curl.scala
@@ -24,9 +24,9 @@ object Curl extends Logging {
   private val curl = "/usr/bin/curl"
 
   def put(url : String, body : String) =
-    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XPUT", url,  "-d", body))
+    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XPUT", url,  "-d", body))(TransactionId.dontcare)
 
   def get(url : String) =
-    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XGET", url))
+    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XGET", url))(TransactionId.dontcare)
 
 }

--- a/common/scala/src/whisk/common/SimpleExec.scala
+++ b/common/scala/src/whisk/common/SimpleExec.scala
@@ -23,7 +23,7 @@ import scala.sys.process.stringSeqToProcess
  * Utility methods for running commands.
  */
 object SimpleExec extends Logging {
-    def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId = TransactionId.dontcare): (String, String, Int) = {
+    def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId): (String, String, Int) = {
         info(this, s"Running command: ${cmd.mkString(" ")}")
         val pb = stringSeqToProcess(cmd)
         var outs = List[String]()

--- a/core/dispatcher/src/whisk/core/container/Container.scala
+++ b/core/dispatcher/src/whisk/core/container/Container.scala
@@ -27,6 +27,7 @@ import whisk.common.Counter
  * Reifies a docker container.
  */
 class Container(
+    originalId: TransactionId,
     pool: ContainerPool,
     val key: String,
     containerName: Option[String],
@@ -35,10 +36,12 @@ class Container(
     pull: Boolean = false,
     val limits: ActionLimits = ActionLimits(),
     env: Map[String, String] = Map(),
-    args: Array[String] = Array())(implicit transid: TransactionId)
+    args: Array[String] = Array())
     extends ContainerUtils {
 
     setVerbosity(pool.getVerbosity())
+
+    implicit var transid = originalId
 
     val id = Container.idCounter.next()
     val name = containerName.getOrElse("anon")

--- a/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
@@ -169,7 +169,7 @@ trait ContainerUtils extends Logging {
      * Synchronously runs the given docker command returning stdout if successful.
      */
     def runDockerCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): DockerOutput = {
-        getDockerCmd(dockerhost) map { _ ++ args } map { SimpleExec.syncRunCmd(_) } match {
+        getDockerCmd(dockerhost) map { _ ++ args } map { info(this, s"runDockerCmd: transid = $transid"); SimpleExec.syncRunCmd(_)(transid) } match {
             case Some((stdout, stderr, exitCode)) =>
                 if (exitCode == 0) {
                     Some(stdout.trim)

--- a/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
@@ -30,6 +30,7 @@ import whisk.core.entity.ActionLimits
  * Reifies a whisk container - one that respects the whisk container API.
  */
 class WhiskContainer(
+    originalId: TransactionId,
     pool: ContainerPool,
     key: String,
     containerName: String,
@@ -38,8 +39,8 @@ class WhiskContainer(
     pull: Boolean,
     env: Map[String, String],
     limits: ActionLimits,
-    args: Array[String] = Array())(implicit transid: TransactionId)
-    extends Container(pool, key, Some(containerName), image, network, pull, limits, env, args) {
+    args: Array[String] = Array())
+    extends Container(originalId, pool, key, Some(containerName), image, network, pull, limits, env, args) {
 
     var boundParams = JsObject()  // Mutable to support pre-alloc containers
     var lastLogSize = 0L


### PR DESCRIPTION
Transaction id was neither propagated nor maintained correctly.  Making the field explicit and mutable (as container warmed up by the system can be used by a different transaction) fixes the missing ???.  

Moreover, even before the recent warmup work, containers were being reused and the lack of updating the implicit transaction id parameter led to associated docker operations being mis-attributed.

Remove the default dont_care parameter for SimpleExec so that caller must supply one.