### PR TITLE
Improve 2 tests

### DIFF
--- a/tests/src/system/basic/CLIJavaTests.java
+++ b/tests/src/system/basic/CLIJavaTests.java
@@ -43,8 +43,6 @@ public class CLIJavaTests {
     public void helloWorldJava() throws Exception {
         final String actionName = "helloJava";
 
-        long start = System.currentTimeMillis();
-
         try {
             wsk.sanitize(Action, actionName);
             wsk.createAction(actionName, TestUtils.getCatalogFilename("samples/helloJava/build/libs/helloJava.jar"));
@@ -60,8 +58,6 @@ public class CLIJavaTests {
                 assertTrue("Did not find " + expected[i] + " in activation " + activationIds[i], pass);
             }
 
-            long duration = System.currentTimeMillis() - start;
-            assertTrue("Test took " + duration + "ms -- this is too slow.", duration < DEFAULT_WAIT * 1000);
         } finally {
             wsk.delete(Action, actionName);
         }

--- a/tests/src/system/basic/CLIPackageTests.java
+++ b/tests/src/system/basic/CLIPackageTests.java
@@ -162,7 +162,10 @@ public class CLIPackageTests {
             String now = new Date().toString();
             String activationId = wsk.invoke(bindActionName, TestUtils.makeParameter("payload", now));
             String expected = String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now);
-            assertTrue("Expected message not found: " + expected + " in activation " + activationId, wsk.logsForActivationContain(activationId, expected, DELAY));
+            if (!wsk.logsForActivationContain(activationId, expected, DELAY)) {
+                String result = wsk.getResult(activationId).stdout.trim();
+                assertTrue("Expected message not found: " + expected + " in activation " + activationId + "\n" + result, false);
+            }
         } finally {
             wsk.sanitize(Package, bindName);
             wsk.sanitize(Action, packageActionName);


### PR DESCRIPTION
1. Print out activation record in case of failure to help debug intermittent failure.
2. Remove an extra check that is measuring time that is already measured (activation) and is too strict because it gives no allowance for sanitize/create.  Moreover, redundant with junit-level timeout.