### PR TITLE
Add notion of sid to extend tid

### DIFF
--- a/common/scala/src/whisk/common/ConsulKVReporter.scala
+++ b/common/scala/src/whisk/common/ConsulKVReporter.scala
@@ -36,7 +36,7 @@ class ConsulKVReporter(
     private val t = new Thread() {
         override def run() = {
             Thread.sleep(initialDelayMilli)
-            val (selfHostname, stderr, exitCode) = SimpleExec.syncRunCmd(Array("hostname", "-f"))(TransactionId.dontcare)
+            val (selfHostname, stderr, exitCode) = SimpleExec.syncRunCmd(Array("hostname", "-f"))(TransactionId.unknown)
             kvStore.put(hostKey, JsString(selfHostname))
             kvStore.put(startKey, JsString(s"${DateUtil.getTimeString}"))
             while (true) {

--- a/common/scala/src/whisk/common/Curl.scala
+++ b/common/scala/src/whisk/common/Curl.scala
@@ -24,9 +24,9 @@ object Curl extends Logging {
   private val curl = "/usr/bin/curl"
 
   def put(url : String, body : String) =
-    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XPUT", url,  "-d", body))(TransactionId.dontcare)
+    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XPUT", url,  "-d", body))(TransactionId.unknown)
 
   def get(url : String) =
-    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XGET", url))(TransactionId.dontcare)
+    SimpleExec.syncRunCmd(Array(curl, "-sS", "-XGET", url))(TransactionId.unknown)
 
 }

--- a/common/scala/src/whisk/core/connector/Message.scala
+++ b/common/scala/src/whisk/core/connector/Message.scala
@@ -35,7 +35,7 @@ trait Message {
     /**
      * A transaction id to attach to the message. If not defined, defaults to 'dontcare' value.
      */
-    val transid = TransactionId.dontcare
+    val transid = TransactionId.unknown
 
     /**
      * Serializes message to string. Must be idempotent.

--- a/core/dispatcher/src/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerPool.scala
@@ -346,7 +346,7 @@ class ContainerPool(
     // A background thread that re-populates the container pool with fresh (un-instantiated) nodejs containers.
     private val warmupThread = new Thread {
         override def run {
-            val tid = TransactionId.dontcare
+            val tid = TransactionId.invokerWarmup
             while (true) {
                 if (getNumberOfIdleContainers(warmNodejsKey)(tid) < WARM_NODEJS_CONTAINERS) {
                     makeWarmNodejsContainer()(tid)
@@ -469,7 +469,7 @@ class ContainerPool(
     private val timer = new Timer()
     private val gcTask = new TimerTask {
         def run() {
-            performGC()(TransactionId.dontcare)
+            performGC()(TransactionId.invoker)
         }
     }
     timer.scheduleAtFixedRate(gcTask, 0, gcFreqMilli)

--- a/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
@@ -103,7 +103,7 @@ class WhiskContainer(
     def run(payload: String, activationId: String): RunResult = {
         val params = JsObject("payload" -> JsString(payload))
         val meta = JsObject("activationId" -> JsString(activationId))
-        run(params, meta, "no_auth_key", 30000, "no_action", "no_activation_id")(TransactionId.dontcare)
+        run(params, meta, "no_auth_key", 30000, "no_action", "no_activation_id")(TransactionId.testing)
     }
 
     /**

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -454,7 +454,7 @@ class Invoker(
         })
 
     // This will remove leftover action containers
-    pool.killStragglers()(TransactionId.dontcare)
+    pool.killStragglers()(TransactionId.invoker)
 
     // This is used for the getContainer endpoint used in perfContainer testing it is not real state
     private val activationIdMap = new TrieMap[ActivationId, String]

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -38,7 +38,7 @@ import whisk.utils.ExecutionContextFactory
 
 @RunWith(classOf[JUnitRunner])
 class KafkaConnectorTests extends FlatSpec with Matchers with BeforeAndAfter {
-    implicit val transid = TransactionId.dontcare
+    implicit val transid = TransactionId.testing
     implicit val ec = ExecutionContextFactory.makeSingleThreadExecutionContext()
 
     behavior of "Kafka connector"

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -60,7 +60,7 @@ class ContainerPoolTests extends FlatSpec
 
     implicit val actorSystem = ActorSystem()
 
-    implicit val transid = TransactionId.dontcare
+    implicit val transid = TransactionId.testing
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
 
     val config = new WhiskConfig(

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -183,7 +183,7 @@ trait DbUtils extends TransactionCounter {
      * Deletes all documents added to gc queue.
      */
     def cleanup()(implicit timeout: Duration = 10 seconds) = {
-        docsToDelete.map { e => Try(Await.result(e._1.del(e._2)(TransactionId.dontcare), timeout)) }
+        docsToDelete.map { e => Try(Await.result(e._1.del(e._2)(TransactionId.testing), timeout)) }
         docsToDelete.clear()
     }
 }

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -51,7 +51,7 @@ import whisk.core.entity.WhiskTrigger
 
 @RunWith(classOf[JUnitRunner])
 class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
-    implicit val transid = TransactionId.dontcare
+    implicit val transid = TransactionId.testing
     implicit val ec = Dispatcher.executionContext
 
     val dispatcher = new TestDispatcher("whisk")
@@ -79,7 +79,7 @@ class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with Be
 
         val today = Calendar.getInstance().getTime().toString
         val content = JsObject("payload" -> JsString(today))
-        val msg = Message(TransactionId.dontcare, "", Subject(), ActivationId(), Some(content))
+        val msg = Message(TransactionId.testing, "", Subject(), ActivationId(), Some(content))
         implicit val stream = new java.io.ByteArrayOutputStream
         dispatcher.setVerbosity(Verbosity.Loud)
         Console.withOut(stream) {
@@ -99,7 +99,7 @@ class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with Be
         assert(config.isValid)
 
         val today = Calendar.getInstance.getTime.toString
-        val msg = Message(TransactionId.dontcare, "", Subject(), ActivationId(), Some(JsObject("payload" -> JsString(today))))
+        val msg = Message(TransactionId.testing, "", Subject(), ActivationId(), Some(JsObject("payload" -> JsString(today))))
         val namespace = Namespace("post test namespace")
         val dispatcher = new TestDispatcher("invoke0")
         implicit val stream = new java.io.ByteArrayOutputStream

--- a/tests/src/whisk/core/loadBalancer/LoadBalancerTests.scala
+++ b/tests/src/whisk/core/loadBalancer/LoadBalancerTests.scala
@@ -70,7 +70,7 @@ class LoadBalancerTests
 
     behavior of "LoadBalancer API"
 
-    implicit val trid = TransactionId.dontcare
+    implicit val trid = TransactionId.testing
     implicit val routeTestTimeout = RouteTestTimeout(Duration(90, SECONDS))
     implicit val executionContext = new ExecutionContext {
         def execute(runnable: Runnable) {
@@ -139,7 +139,7 @@ class LoadBalancerTests
     }
 
     it should "post" in {
-        val msg = Message(TransactionId.dontcare, "", Subject(), ActivationId(), None)
+        val msg = Message(TransactionId.testing, "", Subject(), ActivationId(), None)
         Post("/publish/whisk", msg) ~> routes ~> check {
             status === OK
             val response = responseAs[LoadBalancerResponse]


### PR DESCRIPTION
Activity occurs in the invoker (probably others) not necessarily as a result of a transaction.

Background activity can be logged using an `sid_NNN` in the log messages to give greater
information.  Most `dontcare` have been replaced by more meaningful values with the few remaining
cases named to `unknown`.

PPG 350 - passed.