### PR TITLE
update swagger to specify TriggerLimits is of type object. fixes #241.

### DIFF
--- a/core/controller/src/resources/whiskswagger.json
+++ b/core/controller/src/resources/whiskswagger.json
@@ -1738,7 +1738,8 @@
             }
         },
         "TriggerLimits": {
-            "description": "Limits on a specific trigger"
+            "description": "Limits on a specific trigger",
+            "type": "object"
         },
         "Package": {
             "required": [


### PR DESCRIPTION
I wanted to run the tests after the change, but when I'm trying to run gradle test I get the following 

```
* Where:
Build file '/Users/cjolif/Dev/hub/openwhisk/tests/build.gradle' line: 59

* What went wrong:
A problem occurred evaluating project ':tests'.
> /Users/cjolif/Dev/hub/openwhisk/whisk.properties (No such file or directory)
```