### PR TITLE
Add test to confirm presence of code on failed API calls.

### DIFF
--- a/common/build.xml
+++ b/common/build.xml
@@ -13,12 +13,6 @@
         </parallel>
     </target>
 
-    <path id="libJars">
-        <fileset dir="${openwhisk.home}/common/libs">
-            <include name="**/*.jar" />
-        </fileset>
-    </path>
-
     <!-- build the docker base image with scala -->
     <target name="buildScalaBaseImage">
         <var file="whisk.properties" />
@@ -47,7 +41,6 @@
         <mkdir dir="${build.dir}/commonScala" />
         <scalac destdir="${build.dir}/commonScala" failonerror="true" scalacdebugging="true" fork="true">
             <src path="${openwhisk.home}/common/scala/src" />
-            <classpath refid="libJars" />
             <classpath path="${build.dir}/commonScala" />
             <classpath refid="scala.build.classpath" />
         </scalac>

--- a/common/scala/src/whisk/common/TransactionId.scala
+++ b/common/scala/src/whisk/common/TransactionId.scala
@@ -35,6 +35,7 @@ import spray.json.RootJsonFormat
  * indirectly in the referenced meta object.
  */
 case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
+    def apply() = meta.id
     override def toString = if (meta.id > 0) s"#tid_${meta.id}" else (if (meta.id < 0) s"#sid_${-meta.id}" else "??")
 
     /**

--- a/tests/src/system/basic/PackageTests.scala
+++ b/tests/src/system/basic/PackageTests.scala
@@ -18,6 +18,7 @@ package system.basic
 
 import java.io.File
 import java.util.Date
+import scala.language.postfixOps
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.HashMap
 import scala.concurrent.duration.Duration
@@ -50,8 +51,7 @@ import common.WskProps
 @RunWith(classOf[JUnitRunner])
 class PackageTests
     extends TestHelpers
-    with WskTestHelpers
-    with Matchers {
+    with WskTestHelpers {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk()
@@ -103,7 +103,6 @@ class PackageTests
             }
     }
 
-
     it should "perform package binds so parameters are inherited" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val packageName = "package1"
@@ -112,8 +111,8 @@ class PackageTests
             val packageActionName = packageName + "/" + actionName
             val bindActionName = bindName + "/" + actionName
             val packageParams = Map("key1a" -> "value1a".toJson, "key1b" -> "value1b".toJson)
-            val bindParams    = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
-            val actionParams  = Map("key0"  -> "value0".toJson)
+            val bindParams = Map("key2a" -> "value2a".toJson, "key1b" -> "value2b".toJson)
+            val actionParams = Map("key0" -> "value0".toJson)
             val file = TestUtils.getCatalogFilename("samples/printParams.js")
             assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
                 pkg.create(packageName, packageParams)
@@ -144,22 +143,20 @@ class PackageTests
             assert(found, s"Did not find '$expected' in activation($activationId) ${logs getOrElse "empty"}")
     }
 
-
     /**
      * Check that a description of an item includes the specified parameters.
      * Parameters keys in later parameter maps override earlier ones.
      */
     def checkForParameters(itemDescription: String, paramSets: Map[String, JsValue]*) {
         // Merge and the parameters handling overrides.
-        val merged = HashMap.empty[String,JsValue]
+        val merged = HashMap.empty[String, JsValue]
         paramSets.foreach { merged ++= _ }
         val flatDescription = itemDescription.replace("\n", "").replace("\r", "")
-        merged.foreach {case (key:String, value:JsValue) =>
-            val toFind = s""""key": "${key}",            "value": ${value.toString}"""
-            flatDescription should include regex toFind
+        merged.foreach {
+            case (key: String, value: JsValue) =>
+                val toFind = s""""key": "${key}",            "value": ${value.toString}"""
+                flatDescription should include regex toFind
         }
     }
-
-
 
 }

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -46,8 +46,7 @@ import common.WskProps
 @RunWith(classOf[JUnitRunner])
 class WskBasicTests
     extends TestHelpers
-    with WskTestHelpers
-    with Matchers {
+    with WskTestHelpers {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk()
@@ -241,7 +240,7 @@ class WskBasicTests
 
     it should "reject delete of action that does not exist" in {
         wsk.action.sanitize("deleteFantasy").
-            stdout should include("error: The requested resource does not exist.")
+            stdout should include regex ("""error: The requested resource does not exist. \(code \d+\)""")
     }
 
     it should "reject create with missing file" in {

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -499,6 +499,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
                 status should be(Conflict)
                 val response = responseAs[ErrorResponse]
                 response.error should include("Package not empty (contains 1 entity)")
+                response.code() should be >= 1L
             }
         }
     }

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -146,7 +146,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         put(entityStore, rule)
         Delete(s"$collectionPath/$name") ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
-            responseAs[ErrorResponse].error should be(s"rule status is '${Status.ACTIVE}', must be '${Status.INACTIVE}' to delete")
+            val response = responseAs[ErrorResponse]
+            response.error should be(s"rule status is '${Status.ACTIVE}', must be '${Status.INACTIVE}' to delete")
+            response.code() should be >= 1L
         }
     }
 


### PR DESCRIPTION
Add tests to verify a response code is present on failed API calls.
Remove invalid reference to libJars.
Add custom serializer to JSON to only serialize relevant parts of TransactionId.
Add convenience method to retrieve id from TransactionId metadata object.
Remove evidence ugliness in WhiskPackage.