### PR TITLE
Add kafka path

### DIFF
--- a/common/scala/src/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -61,7 +61,7 @@ class KafkaConsumerConnector(
      */
     def commit() = consumer.commitSync()
 
-    override def onMessage(process: Array[Byte] => Boolean) = {
+    override def onMessage(process: (String, Array[Byte]) => Boolean) = {
         val self = this
         val thread = new Thread() {
             override def run() = {
@@ -75,7 +75,7 @@ class KafkaConsumerConnector(
                                 val offset = r.offset
                                 val msg = r.value
                                 info(self, s"processing $topic[$partition][$offset ($count)]")
-                                val consumed = process(msg)
+                                val consumed = process(topic, msg)
                             }
                             commit()
                     } match {

--- a/common/scala/src/whisk/core/connector/Message.scala
+++ b/common/scala/src/whisk/core/connector/Message.scala
@@ -85,3 +85,28 @@ object ActivationMessage extends DefaultJsonProtocol {
 
     implicit val serdes = jsonFormat6(ActivationMessage.apply)
 }
+
+
+/**
+  * When adding fields, the serdes of the companion object must be updated also.
+  */
+case class CompletionMessage(
+    override val transid: TransactionId,
+    activationId: ActivationId)
+    extends Message {
+
+    override def serialize = CompletionMessage.serdes.write(this).compactPrint
+
+    override def toString = {
+        s"$activationId"
+    }
+}
+
+object CompletionMessage extends DefaultJsonProtocol {
+
+    def apply(msg: String): Try[CompletionMessage] = Try {
+        serdes.read(msg.parseJson)
+    }
+
+    implicit val serdes = jsonFormat2(CompletionMessage.apply)
+}

--- a/common/scala/src/whisk/core/connector/MessageConsumer.scala
+++ b/common/scala/src/whisk/core/connector/MessageConsumer.scala
@@ -18,7 +18,7 @@ package whisk.core.connector
 
 trait MessageConsumer {
     /** Calls process for every message received. */
-    def onMessage(process: (Array[Byte]) => Boolean): Unit
+    def onMessage(process: (String, Array[Byte]) => Boolean): Unit
 
     /** Closes consumer. */
     def close(): Unit

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
         scala {
             // This does not work because this project cannot use that project reference
             // srcDirs = ['src/'].plus(project(':core:loadbalancer').sourceSets.main.scala.srcDirs)
-            srcDirs = ['src/'].plus('../loadBalancer/src/')
+            srcDirs = ['src/'].plus('../loadBalancer/src/').plus('../dispatcher/src/')
             exclude 'resources/**'
         }
         resources {

--- a/core/dispatcher/src/whisk/core/activator/Activator.scala
+++ b/core/dispatcher/src/whisk/core/activator/Activator.scala
@@ -78,7 +78,7 @@ class Activator(
      * @param matches dictates if request is to enable or disable a rule and the rule id
      * @return Future[DocInfo] with document id and revision if the status change was successful
      */
-    override def doit(msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
+    override def doit(topic: String, msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
         Future {
             // conformance checks can terminate the future if a variance is detected
             require(matches != null && matches.size == 1, "matches undefined")

--- a/core/dispatcher/src/whisk/core/activator/PostInvoke.scala
+++ b/core/dispatcher/src/whisk/core/activator/PostInvoke.scala
@@ -69,7 +69,7 @@ class PostInvoke(
     /**
      * Posts invoke request as a kafka message.
      */
-    override def doit(msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
+    override def doit(topic: String, msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
         val ruleActivationId = ActivationId()
         val message = Message(transid, s"/actions/invoke/$actionId", subject, ActivationId(), msg.content, Some(ruleActivationId))
         info("PostInvoke", s"[POST] rule activation id: $ruleActivationId")

--- a/core/dispatcher/src/whisk/core/dispatcher/DispatchRule.scala
+++ b/core/dispatcher/src/whisk/core/dispatcher/DispatchRule.scala
@@ -42,10 +42,11 @@ abstract class DispatchRule(
      * The method is run inside a future. If the method fails with an exception, the exception completes
      * the wrapping future within which the method is run.
      *
+     * @param topic the topic the message came in on
      * @param msg the Message object to process
      * @param matches a sequences of pattern matches that triggered this action
      * @param transid the transaction id for the kafka message
      * @return Future that execute the handler
      */
-    def doit(msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[Any]
+    def doit(topic: String, msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[Any]
 }

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -127,7 +127,7 @@ class Invoker(
      * @param msg is the kafka message payload as Json
      * @param matches contains the regex matches
      */
-    override def doit(msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
+    override def doit(topic: String, msg: Message, matches: Seq[Match])(implicit transid: TransactionId): Future[DocInfo] = {
         Future {
             // conformance checks can terminate the future if a variance is detected
             require(matches != null && matches.size >= 1, "matches undefined")

--- a/tests/src/whisk/core/activator/test/ActivatorTests.scala
+++ b/tests/src/whisk/core/activator/test/ActivatorTests.scala
@@ -98,7 +98,7 @@ class ActivatorTests extends FlatSpec
         put(datastore, rule)
 
         // send activator message to activate
-        val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+        val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
         future onFailure { case t => println(t) }
         val result = Await.result(future, timeout)
 
@@ -116,7 +116,7 @@ class ActivatorTests extends FlatSpec
         put(datastore, rule)
 
         // send activator message to activate
-        val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+        val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
         future onFailure { case t => println(t) }
         val result = Await.result(future, timeout)
 
@@ -130,7 +130,7 @@ class ActivatorTests extends FlatSpec
         put(datastore, newRule)
 
         intercept[IllegalStateException] {
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -144,7 +144,7 @@ class ActivatorTests extends FlatSpec
         put(datastore, rule)
 
         // send activator message to activate
-        val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+        val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
         future onFailure { case t => println(t) }
         val result = Await.result(future, timeout)
 
@@ -156,7 +156,7 @@ class ActivatorTests extends FlatSpec
         // set state to deactivating in datastore
         val newRule = updatedRule.toggle(Status.DEACTIVATING)
         put(datastore, newRule); {
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
 
@@ -172,7 +172,7 @@ class ActivatorTests extends FlatSpec
             val rule = WhiskRule(namespace, EntityName("fail when enabling already enabled rule"), Status.ACTIVE, EntityName("a trigger"), EntityName("an action"))
             val message = Message(tid, "", Subject(), ActivationId(), None, None)
             put(datastore, rule)
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -185,7 +185,7 @@ class ActivatorTests extends FlatSpec
             val message = Message(tid, "", Subject(), ActivationId(), None, None)
             put(datastore, rule)
             val msg = JsObject("subject" -> "some test subject".toJson)
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.ACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -198,7 +198,7 @@ class ActivatorTests extends FlatSpec
             val message = Message(tid, "", Subject(), ActivationId(), None, None)
             put(datastore, rule)
             val msg = JsObject("subject" -> "some test subject".toJson)
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -211,7 +211,7 @@ class ActivatorTests extends FlatSpec
             val message = Message(tid, "", Subject(), ActivationId(), None, None)
             put(datastore, rule)
             val msg = JsObject("subject" -> "some test subject".toJson)
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -224,7 +224,7 @@ class ActivatorTests extends FlatSpec
             val message = Message(tid, "", Subject(), ActivationId(), None, None)
             put(datastore, rule)
             val msg = JsObject("subject" -> "some test subject".toJson)
-            val future = activator.doit(message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
+            val future = activator.doit("someTopic", message, activator.matches(s"/rules/${Status.DEACTIVATING}/${rule.docid}"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
@@ -233,13 +233,13 @@ class ActivatorTests extends FlatSpec
     it should "fail when arguments do not conform" in {
         implicit val tid = transid()
         intercept[IllegalArgumentException] {
-            val future = activator.doit(null, activator.matches(s"/rules/${Status.ACTIVATING}/"))
+            val future = activator.doit("someTopic", null, activator.matches(s"/rules/${Status.ACTIVATING}/"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }
 
         intercept[IllegalArgumentException] {
-            val future = activator.doit(null, activator.matches(s"/rules/${Status.ACTIVATING}/xyz"))
+            val future = activator.doit("someTopic", null, activator.matches(s"/rules/${Status.ACTIVATING}/xyz"))
             future onFailure { case t => println(t) }
             val result = Await.result(future, timeout)
         }

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -116,7 +116,7 @@ class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with Be
             }
             dispatcher.addHandler(post, replace = false)
             dispatcher.start()
-            post.doit(msg, Seq()) onFailure { case t => t.printStackTrace() }
+            post.doit("someTopic", msg, Seq()) onFailure { case t => t.printStackTrace() }
             logContains("received")
         }
         dispatcher.stop()

--- a/tests/src/whisk/core/dispatcher/test/TestConnector.scala
+++ b/tests/src/whisk/core/dispatcher/test/TestConnector.scala
@@ -37,12 +37,12 @@ class TestDispatcher(topic: String)
         producer.send(topic, msg)
     }
 
-    def onMessage(process: Array[Byte] => Boolean): Unit = {
+    def onMessage(process: (String, Array[Byte]) => Boolean): Unit = {
         new Thread {
             override def run() = while (!closed) {
                 val msg = queue.take()
                 println(s"received message for '$topic' ${new String(msg, "utf-8")}")
-                process(msg)
+                process(topic, msg)
             }
         }.start
     }

--- a/tests/src/whisk/core/invoker/test/InvokerTests.scala
+++ b/tests/src/whisk/core/invoker/test/InvokerTests.scala
@@ -95,7 +95,7 @@ class InvokerTests extends FlatSpec
         val activationDoc = Console.withOut(stream) {
             val rule = new Invoker(config, 1, false)
             rule.setVerbosity(Verbosity.Loud)
-            val future = rule.doit(message, rule.matches(s"/actions/invoke/${wsk.docid}"))
+            val future = rule.doit("someTopic", message, rule.matches(s"/actions/invoke/${wsk.docid}"))
             val docinfo = Await.result(future, 10 seconds)
             val activationResult = Await.result(WhiskActivation.get(activationstore, docinfo), dbOpTimeout)
             Await.result(WhiskActivation.del(activationstore, docinfo), dbOpTimeout)


### PR DESCRIPTION
Add a kafka path from the invoker back to the loadbalancer component of the controller.

On each activation completion the invoker sends a CompletionMessage back.  For now, this contains just the activation id.  The loadbalancer, on receipt, simply prints this in the log for now.  No other action is taken for this PR.  Also extend signature to include topic that is being handled for when multiple topics are handled by the same handler.

Related to Issue #142. PPG 382 passed.