### PR TITLE
Upgrading docker to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: true
 
 before_install:
   - sudo apt-get -y update -qq
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" --force-yes -y install docker-engine=1.10.3-0~trusty
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" --force-yes -y install docker-engine=1.11.0-0~trusty
   - docker --version
   - sudo apt-get -y install python-pip
   - pip install --user jsonschema

--- a/docker.gradle
+++ b/docker.gradle
@@ -33,7 +33,7 @@ task distDocker << {
     retry(cmd, dockerRetries, dockerTimeout)
 }
 task tagImage << {
-    def cmd = dockerBinary + ['tag', '-f', dockerImageName, dockerRegistry + dockerImageName + ':' + dockerImageTag]
+    def cmd = dockerBinary + ['tag', dockerImageName, dockerRegistry + dockerImageName + ':' + dockerImageTag]
     retry(cmd, dockerRetries, dockerTimeout)
 }
 task pushImage << {

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -14,7 +14,7 @@ sudo apt-cache policy docker-engine
 sudo apt-get -y install linux-image-extra-$(uname -r)
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.10.3-0~trusty
+sudo apt-get install -y --force-yes docker-engine=1.11.0-0~trusty
 
 # enable (security - use 127.0.0.1)
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' >> /etc/default/docker'


### PR DESCRIPTION
This PR contains:
- lift travis and ubuntu setup to docker 1.11
- remove deprecated `-f` in `docker tag`