### PR TITLE
Factor out HTTP client

### DIFF
--- a/common/scala/src/whisk/common/ConsulKV.scala
+++ b/common/scala/src/whisk/common/ConsulKV.scala
@@ -36,8 +36,14 @@ import scala.language.postfixOps
  */
 class ConsulKV(agent: String) {
 
-    private val consulAgent = new HttpUtils(agent)
+    private val consulClient = HttpUtils.makeHttpClient(30000, true)
+    private val consulAgent = new HttpUtils(consulClient, agent)
     private val kvEndpoint = "/v1/kv/"
+
+    override def finalize() = {
+        /** Closes HTTP connection to consul. */
+        consulClient.close()
+    }
 
     /**
      * Performs the given put, adding a new entry or over-writing an existing one.
@@ -122,8 +128,8 @@ object ConsulKV {
     object InvokerKeys {
         // All invoker written information written here.
         // Underneath this, each invoker has its own path.
-        val allInvokers = "invokers"               // we store a small amount of data here
-        val allInvokersData = "invokersData"       // we store large amounts of data here
+        val allInvokers = "invokers" // we store a small amount of data here
+        val allInvokersData = "invokersData" // we store large amounts of data here
         def instancePath(instance: Int) = s"${allInvokers}/invoker${instance}"
         def instanceDataPath(instance: Int) = s"${allInvokersData}/invoker${instance}"
 

--- a/common/scala/src/whisk/common/ConsulServiceHealth.scala
+++ b/common/scala/src/whisk/common/ConsulServiceHealth.scala
@@ -28,10 +28,9 @@ object ConsulServiceHealth extends App {
         val consul = new ConsulServiceCheck(consulServer)
 
         if (config.isValid) {
-            // retrieve set of services to check
-            var servicesToCheck = config.consulServices.split(",").toSet
-            // add invoker0 to the list
-            servicesToCheck = servicesToCheck + ("invoker0")
+            // retrieve set of services to check and invoker0 to the list which exists in all deployments
+            // TODO: add invokers specific to a deployment
+            val servicesToCheck = config.consulServices.split(",").toSet + "invoker0"
             val passing = consul.getAllPassing()
             val critical = consul.getAllCritical()
             val warning = consul.getAllWarning()

--- a/tests/src/actionContainers/ActionContainer.scala
+++ b/tests/src/actionContainers/ActionContainer.scala
@@ -117,9 +117,11 @@ object ActionContainer {
 
     private def syncPost(host: String, endPoint: String, content: JsValue): (Int, Option[JsObject]) = {
         import whisk.common.HttpUtils
-        val (code, bytes) = new HttpUtils(host).dopost(endPoint, content, Map.empty)
+        val connection = HttpUtils.makeHttpClient(30000, true)
+        val (code, bytes) = new HttpUtils(connection, host).dopost(endPoint, content, Map.empty)
         val str = new java.lang.String(bytes)
         val json = Try(str.parseJson.asJsObject).toOption
+        Try { connection.close() }
         (code, json)
     }
 

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -41,12 +41,13 @@ public class TestUtils {
     public static final int SUCCESS_EXIT = 0;
     public static final int ERROR_EXIT = 1;
     public static final int MISUSE_EXIT = 2;
-    public static final int BAD_REQUEST = 144; // 400 overflows
-    public static final int UNAUTHORIZED = 145; // 401 overflows
-    public static final int FORBIDDEN = 147; // 403 overflows
-    public static final int NOT_FOUND = 148; // 404 overflows
-    public static final int NOTALLOWED = 149; // 405 overflows
-    public static final int CONFLICT = 153; // 409 overflows
+    public static final int BAD_REQUEST = 144; // 400
+    public static final int UNAUTHORIZED = 145; // 401
+    public static final int FORBIDDEN = 147; // 403
+    public static final int NOT_FOUND = 148; // 404
+    public static final int NOTALLOWED = 149; // 405
+    public static final int CONFLICT = 153; // 409
+    public static final int TIMEOUT = 246; // 502
     public static final int DONTCARE_EXIT = -1;   // any value is ok
     public static final int ANY_ERROR_EXIT = -2;  // any non-zero value is ok
 


### PR DESCRIPTION
Pull HTTP client out of the utility class so that multiple requests can reuse the same connection rather than generating and tearing down the connection repeatedly.

This is a transition step to moving to use spray-client instead. 