### PR TITLE
Retry on package view in test

### DIFF
--- a/tests/src/whisk/consul/ConsulKVTests.scala
+++ b/tests/src/whisk/consul/ConsulKVTests.scala
@@ -28,8 +28,6 @@ import spray.json.JsNumber
 import spray.json.JsString
 import spray.json.JsNull
 import spray.json.JsValue
-import scala.concurrent.duration._
-import scala.language.reflectiveCalls
 import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
@@ -60,7 +58,7 @@ class ConsulKVTests extends FlatSpec with Matchers {
         val kvInner = List(("k1", JsNumber(55)), ("k2", JsString("dog")), ("k3/inner", JsString("monkey")))
         val kv = kvInner.map { case (k, v) => (s"$keyPrefix/$k", v) }
         kv foreach { case (k, v) => consul.put(k, v) }
-        retry ({
+        retry {
             val retrieved: Map[String, JsValue] = consul.getRecurse(keyPrefix)
             assert(retrieved.size == kv.size)
             kv.foreach {
@@ -68,7 +66,7 @@ class ConsulKVTests extends FlatSpec with Matchers {
                     println(s"$k -> $v")
                     assert(retrieved.get(k) == Some(v)) // not a KV operation - no inner retry
             }
-        }, 5, waitBeforeRetry = Some(5 second))
+        }
         kv.foreach({
             case (k, v) =>
                 consul.delete(k)
@@ -81,12 +79,10 @@ class ConsulKVTests extends FlatSpec with Matchers {
         val value = JsString("testValue")
 
         consul.put(key, value)
-        retry ({ assert(consul.get(key) == value) },
-               5, waitBeforeRetry = Some(5 second))
+        retry { assert(consul.get(key) == value) }
 
         consul.delete(key)
-        retry ({ assert(consul.get(key) == JsNull) },
-              5, waitBeforeRetry = Some(5 second))
+        retry { assert(consul.get(key) == JsNull) }
     }
 
 }

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -161,7 +161,6 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname, None)
         put(entityStore, provider)
-        // Not adding retry here as it's not a read operation
         Delete(s"$collectionPath/${provider.name}/") ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
         }


### PR DESCRIPTION
Fix retry on package test, so that retry is on the view, not on the delete which will succeed if the view is not up to date yet.

Remove generous retries added previously to consul tests which were not in fact needed.