### PR TITLE
fix KeyValue.value in swagger definition, fixes #262

### DIFF
--- a/core/controller/src/resources/whiskswagger.json
+++ b/core/controller/src/resources/whiskswagger.json
@@ -1377,6 +1377,7 @@
                     "type": "string"
                 },
                 "value": {
+                    "type": "object",
                     "description": "Any JSON value"
                 }
             }


### PR DESCRIPTION
I have setup the env to run the tests this time, but a lot are failing (but that even before my change, so I suspect this is not related).