### PR TITLE
Extend sentinel processing to stderr

### DIFF
--- a/core/nodejsAction/src/service.js
+++ b/core/nodejsAction/src/service.js
@@ -144,6 +144,7 @@ function NodeActionService(config, rawLog, logger) {
             userScript.whisk.setAuthKey(authKey)
             userScript.run(args, function(response) {
                 rawLog.log('XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX')
+                rawLog.error('XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX')
                 logger.info('[doRun]', 'response is', response.result);
                 logger.info('[usage]', userScript.userScriptName,
                             ': activationId = ', (ids || {}).activationId,

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -36,8 +36,9 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
             "main" -> JsString("main")))
     def runPayload(args: JsValue) = JsObject("value" -> args)
 
-    // Filters out the weird markers inserted by the container (see relevant private code in Invoker.scala)
-    def filtered(str: String) = str.replaceAll("XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX", "")
+    // Filters out the sentinel markers inserted by the container (see relevant private code in Invoker.scala)
+    val sentinel = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+    def filtered(str: String) = str.replaceAll(sentinel, "")
 
     behavior of "whisk/nodejsaction"
 
@@ -65,7 +66,7 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 
     it should "fail to initialize with bad code" in {
@@ -160,7 +161,7 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 
     it should "not warn when returning whisk.done" in {
@@ -179,7 +180,7 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 
     it should "warn when using whisk.done twice" in {
@@ -236,7 +237,7 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 
     it should "support the documentation examples (2)" in {
@@ -258,7 +259,7 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 
     it should "support the documentation examples (3)" in {
@@ -289,6 +290,6 @@ class NodeJsActionContainerTests extends FlatSpec with Matchers {
         }
 
         filtered(out).trim shouldBe empty
-        err.trim shouldBe empty
+        filtered(err).trim shouldBe empty
     }
 }


### PR DESCRIPTION
The marker is generated on both streams and logs are re-read until the marker shows up on both streams.

PPG 404 passed except for 2 stray failures.  
Re-running with PPG 406 just in case - 1 other stray.