### PR TITLE
issue #291 allow api host to be set if nothing else was set yet.

### DIFF
--- a/tools/cli/wsk
+++ b/tools/cli/wsk
@@ -66,7 +66,7 @@ def main():
 
         if (args.verbose):
             print props
-        if apihost is None and (args.cmd != 'property' or args.cmd == 'property' and args.subcmd != 'get'):
+        if apihost is None and (args.cmd != 'property' or args.cmd == 'property' and args.subcmd != 'set'):
             print 'error: API host is not set. Set it with "wsk property set --apihost <host>".'
             return 2
 


### PR DESCRIPTION
this should apply the correct logic. you can run into this when no ~/.wskprops and no default.props exist.