### PR TITLE
Show stack trace on one line

### DIFF
--- a/catalog/samples/wcbin.js
+++ b/catalog/samples/wcbin.js
@@ -12,15 +12,17 @@ function main(params) {
         },
         blocking : true,
         next : function(error, activation) {
-            console.log('error:', error, 'activation:', activation);
+            console.log('activation:', activation);
             if (!error) {
                 var wordsInDecimal = activation.result.count;
                 var wordsInBinary = wordsInDecimal.toString(2) + ' (base 2)';
                 whisk.done({
                     binaryCount : wordsInBinary
                 });
-            } else
+            } else {
+                console.log('error:', error);
                 whisk.error(error);
+            }
         }
     });
     return whisk.async();

--- a/common/scala/src/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/whisk/core/database/CouchDbRestClient.scala
@@ -16,30 +16,36 @@
 
 package whisk.core.database
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+import scala.Left
+import scala.Right
 import scala.concurrent.Future
-import scala.concurrent.duration._
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 
 import akka.actor.ActorSystem
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-
+import spray.can.Http
 import spray.can.Http
 import spray.client.pipelining._
 import spray.io.ClientSSLEngineProvider
-import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.http._
 import spray.httpx.RequestBuilding.addCredentials
 import spray.httpx.UnsuccessfulResponseException
 import spray.httpx.SprayJsonSupport
 import spray.util._
-
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-
+import spray.json.JsArray
+import spray.json.JsBoolean
+import spray.json.JsNumber
+import spray.json.JsObject
+import spray.json.JsString
+import spray.json.JsValue
 import whisk.common.Logging
-import whisk.core.entity.DocInfo
 
 /** This class only handles the basic communication to the proper endpoints
  *  ("JSON in, JSON out"). It is up to its clients to interpret the results.
@@ -151,7 +157,7 @@ class CouchDbRestClient protected(system: ActorSystem, urlBase: String, username
 
     def shutdown() : Future[Unit] = {
         implicit val actorSystem = system
-        implicit val timeout = Timeout(45.seconds)
+        implicit val timeout = Timeout(45 seconds)
         IO(Http).ask(Http.CloseAll).map(_ => ())
     }
 }

--- a/common/scala/src/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/whisk/http/BasicHttpService.scala
@@ -17,6 +17,8 @@
 package whisk.http
 
 import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
 import akka.actor.Actor
 import akka.actor.ActorContext
 import akka.actor.ActorSystem
@@ -27,12 +29,13 @@ import akka.japi.Creator
 import akka.pattern.ask
 import akka.util.Timeout
 import spray.can.Http
+import spray.http.ContentType
+import spray.http.HttpEntity
 import spray.http.HttpRequest
+import spray.http.HttpResponse
 import spray.http.MediaTypes.`text/plain`
-import spray.httpx.marshalling
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.json.DefaultJsonProtocol.jsonFormat1
-import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.httpx.marshalling
 import spray.routing.Directive.pimpApply
 import spray.routing.HttpService
 import spray.routing.RejectionHandler
@@ -43,10 +46,6 @@ import spray.routing.directives.LoggingMagnet.forMessageFromFullShow
 import whisk.common.Logging
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
-import spray.http.HttpResponse
-import spray.http.HttpEntity
-import spray.http.ContentType
-import spray.routing.MalformedRequestContentRejection
 
 trait BasicHttpService extends HttpService with TransactionCounter with Logging {
 
@@ -116,7 +115,7 @@ object BasicHttpService {
         val system = ActorSystem(name)
         val actor = system.actorOf(Props.create(service), s"$name-service")
 
-        implicit val timeout = Timeout(5.seconds)
+        implicit val timeout = Timeout(5 seconds)
         IO(Http)(system) ? Http.Bind(actor, interface, port)
     }
 }

--- a/core/dispatcher/src/whisk/core/dispatcher/Dispatcher.scala
+++ b/core/dispatcher/src/whisk/core/dispatcher/Dispatcher.scala
@@ -159,10 +159,10 @@ trait MessageDispatcher extends Registrar with Logging {
     }
 
     private def errorMsg(handler: DispatchRule, e: Throwable): String =
-        s"failed applying handler: $handler\n" + errorMsg(e)
+        s"failed applying handler '${handler.name}': ${errorMsg(e)}"
 
     private def errorMsg(msg: String, e: Throwable) =
-        s"failed processing message: $msg\n$e${e.getStackTrace.mkString("", " ", "")}"
+        s"failed processing message: $msg $e${e.getStackTrace.mkString("", " ", "")}"
 
     private def errorMsg(e: Throwable): String = {
         if (e.isInstanceOf[java.util.concurrent.ExecutionException])

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -126,7 +126,7 @@ You can use the `changes` feed to configure a service to fire a trigger on every
 
 You can now create rules and associate them to actions to react to the document updates.
 
-The content of the generated events depends on the value of the value of the `includeDoc` parameter when creating the trigger. If set to true, each trigger event that is fired includes the modified Cloudant document. For example, consider the following modified document:
+The content of the generated events depends on the value of the `includeDoc` parameter when creating the trigger. If set to true, each trigger event that is fired includes the modified Cloudant document. For example, consider the following modified document:
 
   ```
   {

--- a/tests/.pydevproject
+++ b/tests/.pydevproject
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-</pydev_project>

--- a/tests/src/actionContainers/ActionContainer.scala
+++ b/tests/src/actionContainers/ActionContainer.scala
@@ -16,24 +16,27 @@
 
 package actionContainers
 
-import spray.json._
-import spray.json.DefaultJsonProtocol._
-import scala.util.Random
-
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.PrintWriter
 
-import common.WhiskProperties
-
-import scala.util.Try
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.blocking
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.sys.process._
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+import scala.sys.process.ProcessLogger
+import scala.sys.process.stringToProcess
+import scala.util.Random
+import scala.util.Try
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintWriter
+import common.WhiskProperties
+import spray.json.JsObject
+import spray.json.JsValue
+import spray.json.pimpString
+import whisk.common.HttpUtils
 
 /**
  * For testing convenience, this interface abstracts away the REST calls to a
@@ -88,11 +91,11 @@ object ActionContainer {
         val name = imageName.toLowerCase.replaceAll("""[^a-z]""", "") + rand
 
         // We create the container...
-        val runOut = awaitDocker(s"run --name $name -d $imageName", 10.seconds)
+        val runOut = awaitDocker(s"run --name $name -d $imageName", 10 seconds)
         assert(runOut._1 == 0, "'docker run' did not exit with 0: " + runOut)
 
         // ...find out its IP address...
-        val ipOut = awaitDocker(s"""inspect --format '{{.NetworkSettings.IPAddress}}' $name""", 10.seconds)
+        val ipOut = awaitDocker(s"""inspect --format '{{.NetworkSettings.IPAddress}}' $name""", 10 seconds)
         assert(ipOut._1 == 0, "'docker inspect did not exit with 0")
         val ip = ipOut._2.replaceAll("""[^0-9.]""", "")
 
@@ -107,11 +110,11 @@ object ActionContainer {
             code(mock)
             // I'm told this is good for the logs.
             Thread.sleep(100)
-            val (_, out, err) = awaitDocker(s"logs $name", 10.seconds)
+            val (_, out, err) = awaitDocker(s"logs $name", 10 seconds)
             (out, err)
         } finally {
-            awaitDocker(s"kill $name", 10.seconds)
-            awaitDocker(s"rm $name", 10.seconds)
+            awaitDocker(s"kill $name", 10 seconds)
+            awaitDocker(s"rm $name", 10 seconds)
         }
     }
 

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -48,7 +48,7 @@ public class TestUtils {
     public static final int NOTALLOWED = 149;    // 405 - 256 = 149
     public static final int CONFLICT = 153;      // 409 - 256 = 153
     public static final int THROTTLED = 173;     // 429 (TOO_MANY_REQUESTS) - 256 = 173
-    public static final int TIMEOUT = 246;       // 502 (GATEWAY_TIMEOUT)   - 256 = 173
+    public static final int TIMEOUT = 246;       // 502 (GATEWAY_TIMEOUT)   - 256 = 246
     public static final int DONTCARE_EXIT = -1;  // any value is ok
     public static final int ANY_ERROR_EXIT = -2; // any non-zero value is ok
 

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -540,8 +540,8 @@ class WskActivation()
         activationId: String,
         needle: String,
         project: String = "logs",
-        initialWait: Duration = 1 seconds,
-        pollPeriod: Duration = 1 seconds,
+        initialWait: Duration = 1 second,
+        pollPeriod: Duration = 1 second,
         totalWait: Duration = 30 seconds)(
             implicit wp: WskProps): (Boolean, Option[String]) = {
         val wsk = this
@@ -657,8 +657,8 @@ trait WaitFor {
      */
     def waitfor[T](
         step: () => T,
-        initialWait: Duration = 1 seconds,
-        pollPeriod: Duration = 1 seconds,
+        initialWait: Duration = 1 second,
+        pollPeriod: Duration = 1 second,
         totalWait: Duration = 30 seconds): T = {
         Thread.sleep(initialWait.toMillis)
         val endTime = System.currentTimeMillis() + totalWait.toMillis

--- a/tests/src/common/WskCli.java
+++ b/tests/src/common/WskCli.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import common.TestUtils.RunResult;
 
 /**
@@ -546,7 +549,8 @@ public class WskCli {
         String response = invoke(SUCCESS_EXIT, name, params, true).stdout;
         String activationId = extractActivationIdFromCliResult(response);
         String result = extractActivationResultFromCliResult(response);
-        return Pair.make(activationId, result);
+        JsonObject json = new JsonParser().parse(result).getAsJsonObject();
+        return Pair.make(activationId, json.get("response").toString());
     }
 
     /**

--- a/tests/src/whisk/core/controller/test/AuthorizeTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthorizeTests.scala
@@ -68,7 +68,7 @@ class AuthorizeTests extends ControllerTestCommon with Authenticate {
 
     behavior of "Authorize"
 
-    val requestTimeout = 1 seconds
+    val requestTimeout = 1 second
     val someUser = Subject()
     val adminUser = Subject("admin")
     val guestUser = Subject("anonym")

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -328,7 +328,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, binding)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, READ, pkgaccess), 1 seconds)
+        Await.result(entitlementService.grant(auser.subject, READ, pkgaccess), 1 second)
         Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskAction]
@@ -472,7 +472,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, reference)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, ACTIVATE, pkgaccess), 1 seconds)
+        Await.result(entitlementService.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
         Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Accepted)
             val response = responseAs[JsObject]

--- a/tools/cli/wskaction.py
+++ b/tools/cli/wskaction.py
@@ -20,7 +20,6 @@ import base64
 import httplib
 import argparse
 import urllib
-import re
 import subprocess
 from wskitem import Item
 from wskutil import addAuthenticatedCommand, bold, request, getParams, getActivationArgument, getAnnotations, responseError, parseQName, getQName, apiBase, getPrettyJson
@@ -122,7 +121,7 @@ class Action(Item):
                 print getPrettyJson(result['response']['result'])
             elif res.status == httplib.OK :
                 print bold('response:')
-                print getPrettyJson(result['response'])
+                print getPrettyJson(result)
             return 0
         else:
             return responseError(res)


### PR DESCRIPTION
Some error log messages printed the stack trace on separate lines - coalesced them into a single line so that they appear with their correlated transaction id.

Also in this commit, a small to show the activation record completely on a blocking invoke (was previously projecting just the `result`).

