### PR TITLE
issue #309 revert back to installing ansible via apt. pip install on …

### DIFF
--- a/tools/ubuntu-setup/ansible.sh
+++ b/tools/ubuntu-setup/ansible.sh
@@ -1,7 +1,8 @@
-
-sudo pip install ansible==2.0.2.0
-sudo pip install docker-py
-
+sudo apt-get install -y software-properties-common
+sudo apt-add-repository -y ppa:ansible/ansible
+sudo apt-get update
+sudo apt-get install -y ansible=2.0.2.0-1ppa~trusty
+sudo pip install docker-py==1.8.1
 
 ansible --version
 ansible-playbook --version


### PR DESCRIPTION
…vagrant requires lots of dev packages as it wants to compile deps. we don't want that. also pinned docker-py version.