### PR TITLE
Adding -f option to docker tag again

### DIFF
--- a/docker.gradle
+++ b/docker.gradle
@@ -33,7 +33,7 @@ task distDocker << {
     retry(cmd, dockerRetries, dockerTimeout)
 }
 task tagImage << {
-    def cmd = dockerBinary + ['tag', dockerImageName, dockerRegistry + dockerImageName + ':' + dockerImageTag]
+    def cmd = dockerBinary + ['tag', '-f', dockerImageName, dockerRegistry + dockerImageName + ':' + dockerImageTag]
     retry(cmd, dockerRetries, dockerTimeout)
 }
 task pushImage << {


### PR DESCRIPTION
This option is expected to be dropped by docker 1.12. Readding it in for the moment.