### PR TITLE
Enable new Spray-based Cloudant API.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -89,7 +89,7 @@
     <target name="deployDatabase">
         <var file="whisk.properties" />
         <echo message="wiping databases with prefix ${db.prefix}" />
-        <exec dir="${openwhisk.home}/tools/db" executable="/bin/bash">
+        <exec dir="${openwhisk.home}/tools/db" executable="/bin/bash" failonerror="true">
             <arg value="wipeTransientDBs.sh" />
         </exec>
     </target>

--- a/common/scala/src/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/whisk/core/entity/WhiskStore.scala
@@ -75,19 +75,19 @@ protected[core] trait WhiskDocument
 }
 
 protected[core] object Util {
-    def makeStore[R, D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig=>String)(
+    def makeStore[R, D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
         implicit jsonFormat: RootJsonFormat[D],
-        actorSystem: ActorSystem) : ArtifactStore[R, D] = {
+        actorSystem: ActorSystem): ArtifactStore[R, D] = {
         require(config != null && config.isValid, "config is undefined or not valid")
         require(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB", "Unsupported db.provider: " + config.dbProvider)
 
-        if(config.dbProvider == "Cloudant") {
+        if (false && config.dbProvider == "Cloudant") { // use new spray-based API
             CloudantStore.make(config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
         } else {
             // CouchDbStore.make(config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
             // New Spray-based API.
             import whisk.core.database.CouchDbRestStore
-            new CouchDbRestStore[R,D](config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
+            new CouchDbRestStore[R, D](config.dbProtocol, config.dbHost, config.dbPort.toInt, config.dbUsername, config.dbPassword, name(config))
         }
     }
 }

--- a/core/dispatcher/src/whisk/core/activator/Activator.scala
+++ b/core/dispatcher/src/whisk/core/activator/Activator.scala
@@ -42,6 +42,7 @@ import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskRule
 import whisk.http.BasicRasService
+import whisk.utils.ExecutionContextFactory
 
 /**
  * A kafka message handler that interprets a database of whisk rules, and
@@ -221,7 +222,7 @@ object ActivatorService {
 
         if (config.isValid) {
             val dispatcher = new Dispatcher(config, "whisk", "activator")
-            val activator = new Activator(config, dispatcher, actorSystem, Dispatcher.executionContext)
+            val activator = new Activator(config, dispatcher, actorSystem, ExecutionContextFactory.makeExecutionContext())
 
             activator.setVerbosity(Verbosity.Loud)
             dispatcher.setVerbosity(Verbosity.Loud)


### PR DESCRIPTION
Enable new Spray-based Cloudant API.
Use custom thread pool in activator for db operations.
Fail deployment on error to deploy database.
