### PR TITLE
Provide support for tests to access a VCAP Services JSON object

### DIFF
--- a/config/writePropertyFile.sh
+++ b/config/writePropertyFile.sh
@@ -47,6 +47,9 @@ echo "whisk.ssl.cert=$WHISK_SSL_CERTIFICATE" >> "$WHISK_HOME/whisk.properties"
 echo "whisk.ssl.key=$WHISK_SSL_KEY" >> "$WHISK_HOME/whisk.properties"
 echo "whisk.ssl.challenge=$WHISK_SSL_CHALLENGE" >> "$WHISK_HOME/whisk.properties"
 
+# VCAP Services file to use for tests
+echo "vcap.services.file=$VCAP_SERVICES_FILE" >> "$WHISK_HOME/whisk.properties"
+
 #Hosts
 echo "activator.host="$ACTIVATOR_HOST >> "$WHISK_HOME/whisk.properties"
 echo "consulserver.host="$CONSULSERVER_HOST >> "$WHISK_HOME/whisk.properties"

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -19,6 +19,8 @@ package common;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -27,6 +29,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
@@ -54,6 +58,9 @@ public class TestUtils {
 
     private static final File catalogDir = WhiskProperties.getFileRelativeToWhiskHome("catalog");
     private static final File testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions");
+    private static final File vcapFile = WhiskProperties.getVCAPServicesFile();
+    private static final String envServices = System.getenv("VCAP_SERVICES");
+
 
     static {
         logger.setLevel(Level.WARNING);
@@ -77,6 +84,25 @@ public class TestUtils {
      */
     public static String getTestActionFilename(String name) {
         return new File(testActionsDir, name).toString();
+    }
+
+    /**
+     * Gets the value of VCAP_SERVICES
+     * @return VCAP_SERVICES as a JSON object
+     */
+    public static JsonObject getVCAPServices() {
+        JsonObject jsonObject;
+        if (envServices != null) {
+            jsonObject = new JsonParser().parse(envServices).getAsJsonObject();
+        }
+        else  {
+            try {
+                jsonObject = new JsonParser().parse(new FileReader(vcapFile)).getAsJsonObject();
+            } catch (FileNotFoundException e) {
+                return new JsonObject();
+            }
+        }
+        return jsonObject;
     }
 
     /**

--- a/tests/src/common/WhiskProperties.java
+++ b/tests/src/common/WhiskProperties.java
@@ -257,6 +257,18 @@ public class WhiskProperties {
     }
 
     /**
+     * @return the path to a file holding the VCAP_SERVICES used during junit testing
+     */
+    public static File getVCAPServicesFile() {
+        String vcapServices = whiskProperties.getProperty("vcap.services.file");
+        if (vcapServices.startsWith(File.separator)) {
+            return new File(vcapServices);
+        } else {
+            return WhiskProperties.getFileRelativeToWhiskHome(vcapServices);
+        }
+    }
+
+    /**
      * are we running on Mac OS X?
      */
     public static boolean onMacOSX() {


### PR DESCRIPTION
Allow tests to access service credentials via the VCAP_SERVICES environment variable or thru a JSON file that is specified in whisk.properties.