### PR TITLE
Be sure to pass along all environment variables when running a Swift action

### DIFF
--- a/core/swift3Action/proxy.py
+++ b/core/swift3Action/proxy.py
@@ -89,7 +89,9 @@ def run():
         response.status_code = 502
         return response
 
-    swift_env_in = { "WHISK_INPUT" : json.dumps(value) }
+    # make sure to include all the env vars passed in by the invoker
+    swift_env_in = os.environ
+    swift_env_in["WHISK_INPUT"] = json.dumps(value)
 
     p = subprocess.Popen(
         RUN_PROCESS,

--- a/core/swiftAction/proxy.py
+++ b/core/swiftAction/proxy.py
@@ -87,7 +87,9 @@ def run():
         response.status_code = 502
         return response
 
-    swift_env_in = { "WHISK_INPUT" : json.dumps(value) }
+    # make sure to include all the env vars passed in by the invoker
+    swift_env_in = os.environ
+    swift_env_in["WHISK_INPUT"] = json.dumps(value)
 
     p = subprocess.Popen(
         RUN_PROCESS,


### PR DESCRIPTION
Without this change, environment variables passed in by the invoker (e.g. EDGE_HOST) are not available when the Swift action runs.