### PR TITLE
WIP - Removed gevent as a WSGI wrapper for Flask proxies

### DIFF
--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get clean
 # Install Python CGI helpers.
 RUN apt-get -y install --fix-missing python-distribute python-pip
 RUN pip install -U flask
-RUN pip install -U gevent
  
 ENV FLASK_PROXY_PORT 8080
 

--- a/core/pythonAction/pythonaction.py
+++ b/core/pythonAction/pythonaction.py
@@ -21,7 +21,6 @@ import subprocess
 import codecs
 import traceback
 import flask
-from gevent.wsgi import WSGIServer
 
 proxy = flask.Flask(__name__)
 proxy.debug = False
@@ -81,5 +80,4 @@ def run():
 # start server in a forever loop
 if __name__ == "__main__":
     PORT = int(os.getenv("FLASK_PROXY_PORT", 8080))
-    server = WSGIServer(('', PORT), proxy, log=None)
-    server.serve_forever()
+    proxy.run(port=PORT)

--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get -y purge && \
     apt-get -y install --fix-missing python-distribute && \
     apt-get -y install --fix-missing python-pip && \
     apt-get clean && \
-    pip install -U flask && \
-    pip install -U gevent
+    pip install -U flask
 
 # Upgrade and install Swift dependencies.
 RUN apt-get -y dist-upgrade

--- a/core/swift3Action/proxy.py
+++ b/core/swift3Action/proxy.py
@@ -22,8 +22,6 @@ import codecs
 
 import flask
 
-from gevent.wsgi import WSGIServer
-
 proxy = flask.Flask(__name__)
 proxy.debug = False
 
@@ -132,5 +130,4 @@ def run():
 
 if __name__ == "__main__":
     PORT = int(os.getenv("FLASK_PROXY_PORT", 8080))
-    server = WSGIServer(('', PORT), proxy, log=None)
-    server.serve_forever()
+    proxy.run(port=PORT)

--- a/core/swiftAction/Dockerfile
+++ b/core/swiftAction/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get clean
 # Install Python CGI helpers.
 RUN apt-get -y install python-distribute python-pip
 RUN pip install -U flask
-RUN pip install -U gevent
 
 # Install Swift keys
 RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \

--- a/core/swiftAction/proxy.py
+++ b/core/swiftAction/proxy.py
@@ -22,8 +22,6 @@ import codecs
 
 import flask
 
-from gevent.wsgi import WSGIServer
-
 proxy = flask.Flask(__name__)
 proxy.debug = False
 
@@ -129,5 +127,4 @@ def run():
 
 if __name__ == "__main__":
     PORT = int(os.getenv("FLASK_PROXY_PORT", 8080))
-    server = WSGIServer(('', PORT), proxy, log=None)
-    server.serve_forever()
+    proxy.run(port=PORT)


### PR DESCRIPTION
Rationale is that this is acceptable given the very limited set of (non-concurrent) requests that action containers must respond to.