### PR TITLE
WIP: Get gevent from apt, not from pip

### DIFF
--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -11,9 +11,8 @@ RUN apt-get -y install --fix-missing python2.7-dev
 RUN apt-get clean
 
 # Install Python CGI helpers.
-RUN apt-get -y install --fix-missing python-distribute python-pip
+RUN apt-get -y install --fix-missing python-distribute python-pip python-gevent
 RUN pip install -U flask
-RUN pip install -U gevent
  
 ENV FLASK_PROXY_PORT 8080
 

--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get -y purge && \
     apt-get -y install --fix-missing python2.7-dev && \
     apt-get -y install --fix-missing python-distribute && \
     apt-get -y install --fix-missing python-pip && \
+    apt-get -y install --fix-missing python-gevent && \
     apt-get clean && \
-    pip install -U flask && \
-    pip install -U gevent
+    pip install -U flask
 
 # Upgrade and install Swift dependencies.
 RUN apt-get -y dist-upgrade

--- a/core/swiftAction/Dockerfile
+++ b/core/swiftAction/Dockerfile
@@ -13,9 +13,8 @@ RUN apt-get -y install git-core
 RUN apt-get clean
 
 # Install Python CGI helpers.
-RUN apt-get -y install python-distribute python-pip
+RUN apt-get -y install python-distribute python-pip python-gevent
 RUN pip install -U flask
-RUN pip install -U gevent
 
 # Install Swift keys
 RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \


### PR DESCRIPTION
`pip install gevent` compiles it locally, which takes forever