### PR TITLE
expose port 8443 in nginx

### DIFF
--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -26,6 +26,8 @@
     volumes:
       - "{{ whisk_logs_dir }}/nginx:/logs"
       - "{{ nginx_conf_dir }}:/etc/nginx"
+    expose:
+      - 8443
     ports:
       - "{{ nginx.port.http }}:80"
       - "{{ nginx.port.api }}:443"


### PR DESCRIPTION
until now, the port 8443 is not yet exposed so that the port mapping (via ansible docker module) does not work yet. So we have to expose the port 8443 explicitly.

Signed-off-by: Dominik Jall <djall@de.ibm.com>