### PR TITLE
issue #208: couchdb should use cloudant initdb task only in openwhisk code structure

### DIFF
--- a/ansible/roles/consul/handlers/main.yml
+++ b/ansible/roles/consul/handlers/main.yml
@@ -4,4 +4,4 @@
 
 # TODO: avoid py script? persist a file in the role would be better
 - name: fill consul kv
-  local_action: command python "{{ playbook_dir }}/../tools/health/kvstore" --import -d "{{ playbook_dir }}/../"
+  local_action: command python "{{ openwhisk_home }}/tools/health/kvstore" --import -d "{{ playbook_dir }}/../"

--- a/ansible/roles/couchdb/tasks/initdb.yml
+++ b/ansible/roles/couchdb/tasks/initdb.yml
@@ -4,4 +4,4 @@
 
 # Same as cloudant, so include here.
 
-- include: roles/cloudant/tasks/initdb.yml
+- include: "{{ openwhisk_home }}/ansible/roles/cloudant/tasks/initdb.yml"


### PR DESCRIPTION
Signed-off-by: Dominik Jall <djall@de.ibm.com>