### PR TITLE
Add package binding annotation

### DIFF
--- a/common/scala/src/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/whisk/core/entity/WhiskAction.scala
@@ -91,7 +91,7 @@ case class WhiskAction(
      * Merges parameters (usually from package) with existing action parameters.
      * Existing parameters supersede those in p.
      */
-    def ++(p: Parameters) = {
+    def inherit(p: Parameters) = {
         WhiskAction(namespace, name, exec, p ++ parameters, limits, version, publish, annotations)
     }
 

--- a/common/scala/src/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/whisk/core/entity/WhiskPackage.scala
@@ -81,7 +81,7 @@ case class WhiskPackage(
      * Merges parameters into existing set of parameters for package.
      * Existing parameters supersede those in p.
      */
-    def ++(p: Parameters) = {
+    def inherit(p: Parameters) = {
         WhiskPackage(namespace, name, binding, p ++ parameters, version, publish, annotations)
     }
 

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -295,7 +295,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
     override def fetch(namespace: Namespace, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
         val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
         getEntity(WhiskAction, entityStore, docid, Some { action: WhiskAction =>
-            val mergedAction = env map { action ++ _ } getOrElse action
+            val mergedAction = env map { action inherit _ } getOrElse action
             complete(OK, mergedAction)
         })
     }
@@ -502,7 +502,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         } getOrElse {
             // a subject has implied rights to all resources in a package, so dispatch
             // operation without further entitlement checks
-            val params = { ref map { _ ++ wp.parameters } getOrElse wp } parameters
+            val params = { ref map { _ inherit wp.parameters } getOrElse wp } parameters
             val ns = wp.namespace.addpath(wp.name) // the package namespace
             val resource = Resource(ns, collection, Some { action() }, Some { params })
             val right = collection.determineRight(method, resource.entity)

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -212,7 +212,7 @@ class WskAction()
                 } getOrElse Seq()
             } ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { timeout map { t => Seq("-t", t.toMillis.toString) } getOrElse Seq() } ++
             { memory map { m => Seq("-m", m.toString) } getOrElse Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
@@ -283,7 +283,7 @@ class WskTrigger()
         val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
             { feed map { f => Seq("--feed", fqn(f)) } getOrElse Seq() } ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }
@@ -334,7 +334,7 @@ class WskRule()
         expectedExitCode: Int = SUCCESS_EXIT)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name), (trigger), (action)) ++
-            { annotations flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { if (enable) Seq("--enable") else Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         val result = cli(wp.overrides ++ params, expectedExitCode)
@@ -630,7 +630,7 @@ class WskPackage()
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
-            { annotations flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }
@@ -646,10 +646,12 @@ class WskPackage()
         provider: String,
         name: String,
         parameters: Map[String, JsValue] = Map(),
+        annotations: Map[String, JsValue] = Map(),
         expectedExitCode: Int = SUCCESS_EXIT)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, "bind", "--auth", wp.authKey, fqn(provider), fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } }
+            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } }
         cli(wp.overrides ++ params, expectedExitCode)
     }
 }

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -42,6 +42,7 @@ import common.TestHelpers
 import common.WskTestHelpers
 import common.TestHelpers
 import common.WskProps
+import whisk.core.entity.WhiskPackage
 
 @RunWith(classOf[JUnitRunner])
 class WskBasicTests
@@ -205,6 +206,22 @@ class WskBasicTests
             stdout should include regex (""""publish": true""")
             stdout should include regex (""""version": "0.0.2"""")
             wsk.pkg.list().stdout should include(name)
+    }
+
+    it should "create a package binding" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "bindPackage"
+            val provider = "/whisk.system/samples"
+            val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    pkg.bind(provider, name, annotations = annotations)
+            }
+            val stdout = wsk.pkg.get(name).stdout
+            stdout should include regex (""""key": "a"""")
+            stdout should include regex (""""value": "A"""")
+            stdout should include regex (s""""key": "${WhiskPackage.bindingFieldName}"""")
+            stdout should not include regex(""""key": "xxx"""")
     }
 
     behavior of "Wsk Action CLI"

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -275,7 +275,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             Get(s"$collectionPath/${provider.name}/${action.name}") ~> sealRoute(routes(creds)) ~> check {
                 status should be(OK)
                 val response = responseAs[WhiskAction]
-                response should be(action ++ provider.parameters)
+                response should be(action inherit provider.parameters)
             }
         }
     }
@@ -293,7 +293,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
                 status should be(OK)
                 val response = responseAs[WhiskAction]
-                response should be(action ++ (provider.parameters ++ binding.parameters))
+                response should be(action inherit (provider.parameters ++ binding.parameters))
             }
         }
     }
@@ -311,7 +311,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
                 status should be(OK)
                 val response = responseAs[WhiskAction]
-                response should be(action ++ (provider.parameters ++ binding.parameters))
+                response should be(action inherit (provider.parameters ++ binding.parameters))
             }
         }
     }
@@ -332,7 +332,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskAction]
-            response should be(action ++ (provider.parameters ++ binding.parameters))
+            response should be(action inherit (provider.parameters ++ binding.parameters))
         }
     }
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -283,13 +283,13 @@ class SchemaTests extends FlatSpec with BeforeAndAfter {
             Parameters.serdes.read(null: JsValue)
         }
         intercept[IllegalArgumentException] {
-            Parameters(null, null)
+            Parameters(null, null: String)
         }
         intercept[IllegalArgumentException] {
-            Parameters("", null)
+            Parameters("", null: JsValue)
         }
         intercept[IllegalArgumentException] {
-            Parameters(" ", null)
+            Parameters(" ", null: String)
         }
         intercept[IllegalArgumentException] {
             Parameters(null, "")
@@ -303,7 +303,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter {
     }
 
     it should "serialize to json" in {
-        assert(Parameters("k", null).toString == JsArray(JsObject("key" -> "k".toJson, "value" -> JsNull)).compactPrint)
+        assert(Parameters("k", null: String).toString == JsArray(JsObject("key" -> "k".toJson, "value" -> JsNull)).compactPrint)
         assert(Parameters("k", "").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
         assert(Parameters("k", " ").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "".toJson)).compactPrint)
         assert(Parameters("k", "v").toString == JsArray(JsObject("key" -> "k".toJson, "value" -> "v".toJson)).compactPrint)


### PR DESCRIPTION
Constructs a "binding" annotation. This is redundant with the binding information available in `WhiskPackage` but necessary for some clients which fetch package lists but cannot determine which package may be bound. An alternative is to include the binding in the package list "view" but this
will require an API change. So using an annotation instead.

@markusthoemmes @psuter for review.