### PR TITLE
helper for testing activations

### DIFF
--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -240,20 +240,20 @@ public class TestUtils {
         public void validateExitCode(int expectedExitCode) {
             if (expectedExitCode == TestUtils.DONTCARE_EXIT)
                 return;
-            boolean ok = (exitCode == expectedExitCode) ||
-                         (expectedExitCode == TestUtils.ANY_ERROR_EXIT &&
-                          exitCode != 0);
+            boolean ok = (exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && exitCode != 0);
             if (!ok) {
-                System.out.format("exit code = %d\n", exitCode);
-                System.out.format("expected exit code = %d\n", expectedExitCode);
-                System.out.println("stdout:");
-                System.out.print(stdout);
-                System.out.println();
-                System.out.println("stderr:");
-                System.out.print(stderr);
-                System.out.println();
+                System.out.format("expected exit code = %d\n%s", expectedExitCode, toString());
                 assertTrue("Exit code:" + exitCode, exitCode == expectedExitCode);
             }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder fmt = new StringBuilder();
+            fmt.append(String.format("exit code = %d\n", exitCode));
+            fmt.append(String.format("stdout: %s\n", stdout));
+            fmt.append(String.format("stderr: %s\n", stderr));
+            return fmt.toString();
         }
     }
 

--- a/tests/src/system/basic/CLIPythonTests.scala
+++ b/tests/src/system/basic/CLIPythonTests.scala
@@ -57,7 +57,9 @@ class CLIPythonTests
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, Some(TestUtils.getCatalogFilename("samples/hello.py")))
             }
-            wsk.action.invoke(name, Map("name" -> "Prince".toJson), blocking = true, result = true)
-                .stdout should include regex ("""Prince""")
+
+            withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Prince".toJson))) {
+                _.fields("response").toString should include("Prince")
+            }
     }
 }

--- a/tests/src/system/basic/CLISwiftTests.scala
+++ b/tests/src/system/basic/CLISwiftTests.scala
@@ -63,11 +63,13 @@ class CLISwiftTests
             }
 
             val start = System.currentTimeMillis()
-            wsk.action.invoke(name, blocking = true, result = true)
-                .stdout should include("Hello stranger!")
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                _.fields("response").toString should include("Hello stranger!")
+            }
 
-            wsk.action.invoke(name, Map("name" -> "Sir".toJson), blocking = true, result = true)
-                .stdout should include("Hello Sir!")
+            withActivation(wsk.activation, wsk.action.invoke(name, Map("name" -> "Sir".toJson))) {
+                _.fields("response").toString should include("Hello Sir!")
+            }
 
             withClue("Test duration exceeds expectation (ms)") {
                 val duration = System.currentTimeMillis() - start
@@ -85,8 +87,10 @@ class CLISwiftTests
                 (action, _) => action.create(name, Some(TestUtils.getCatalogFilename("samples/httpGet.swift")), kind = Some("swift:3"))
             }
 
-            val stdout = wsk.action.invoke(name, blocking = true, result = true).stdout
-            stdout should include(""""url": "https://httpbin.org/get"""")
-            stdout should not include("Error")
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                activation =>
+                    activation.fields("response").toString should include(""""url":"https://httpbin.org/get"""")
+                    activation.fields("response").toString should not include ("Error")
+            }
     }
 }

--- a/tests/src/system/basic/PackageTests.scala
+++ b/tests/src/system/basic/PackageTests.scala
@@ -136,11 +136,11 @@ class PackageTests
 
             // Check that inherited parameters are passed to the action.
             val now = new Date().toString()
-            val activation = wsk.action.invoke(bindActionName, Map("payload" -> now.toJson))
-            val activationId = wsk.action.extractActivationId(activation)
-            val expected = String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now)
-            val (found, logs) = wsk.activation.contains(activationId.get, expected, totalWait = LOG_DELAY)
-            assert(found, s"Did not find '$expected' in activation($activationId) ${logs getOrElse "empty"}")
+            val run = wsk.action.invoke(bindActionName, Map("payload" -> now.toJson))
+            withActivation(wsk.activation, run, totalWait = LOG_DELAY) {
+                _.fields("logs").toString should include regex (
+                    String.format(".*key0: value0.*key1a: value1a.*key1b: value2b.*key2a: value2a.*payload: %s", now))
+            }
     }
 
     /**


### PR DESCRIPTION
This commit adds a test helper which captures a common pattern of extracting activation id, polling for activation to be completed, and then checking the result. This method will always the activation id, activation record, and any command failures should invariants fail. In doing this, turned some unnecessarily blocking activations to non-blocking ones. This makes the tests more focused and reduces likely hood of false failures.

@psuter should also review.
PPG 513.