### PR TITLE
Fixes issue #352.

### DIFF
--- a/common/scala/src/whisk/common/Logging.scala
+++ b/common/scala/src/whisk/common/Logging.scala
@@ -32,6 +32,10 @@ object Verbosity extends Enumeration {
  * A logging facility in which output is one line and fields are bracketed.
  */
 trait Logging {
+    /**
+     * The output stream, defaults to Console.out.
+     * This is mutable to allow unit tests to capture the stream.
+     */
     var outputStream: PrintStream = Console.out
 
     def setVerbosity(level: Verbosity.Level) =

--- a/common/scala/src/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/whisk/core/entity/WhiskAuth.scala
@@ -17,22 +17,19 @@
 package whisk.core.entity
 
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
 import scala.util.Try
 
-import spray.caching.Cache
+import org.lightcouch.NoDocumentException
+
 import spray.json.JsObject
 import spray.json.JsString
 import spray.json.JsValue
 import spray.json.RootJsonFormat
 import spray.json.deserializationError
-import spray.json.pimpAny
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.database.ArtifactStore
 import whisk.core.database.DocumentFactory
-import whisk.core.database.InMemoryCache
 import whisk.core.entity.schema.AuthRecord
 
 /**
@@ -134,7 +131,7 @@ object WhiskAuth extends DocumentFactory[AuthRecord, WhiskAuth] {
                         }
                     case 0 =>
                         logger.info(this, s"$viewName[$uuid] does not exist")
-                        throw new IllegalStateException("uuid does not exist")
+                        throw new NoDocumentException("uuid does not exist")
                     case _ =>
                         logger.error(this, s"$viewName[$uuid] is not unique")
                         throw new IllegalStateException("uuid is not unique")

--- a/common/scala/src/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/whisk/http/BasicHttpService.scala
@@ -36,7 +36,9 @@ import spray.http.HttpResponse
 import spray.http.MediaTypes.`text/plain`
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
 import spray.httpx.marshalling
+import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.routing.Directive.pimpApply
+import spray.routing.Directives
 import spray.routing.HttpService
 import spray.routing.RejectionHandler
 import spray.routing.Route
@@ -84,20 +86,10 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
     protected val assignId = extract(_ => transid())
 
     /** Rejection handler to terminate connection on a bad request. Delegates to Spray handler. */
-    protected def badRequestHandler(implicit transid: TransactionId) = RejectionHandler {
+    protected def customRejectionHandler(implicit transid: TransactionId) = RejectionHandler {
         case rejections =>
             info(this, s"[REJECT] $rejections")
-            rejections match {
-                // get default rejection message, package it as an ErrorResponse instance
-                // which gets serialized into a Json object
-                case r if RejectionHandler.Default.isDefinedAt(r) =>
-                    ctx => RejectionHandler.Default(r) {
-                        ctx.withHttpResponseMapped {
-                            case resp @ HttpResponse(_, HttpEntity.NonEmpty(ContentType(`text/plain`, _), msg), _, _) =>
-                                resp.withEntity(marshalling.marshalUnsafe(ErrorResponse(msg.asString, transid)))
-                        }
-                    }
-            }
+            BasicHttpService.customRejectionHandler.apply(rejections)
     }
 
     /** Generates log entry for every request. */
@@ -110,12 +102,28 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
     }
 }
 
-object BasicHttpService {
+object BasicHttpService extends Directives {
     def startService[T <: Actor](name: String, interface: String, port: Integer, service: Creator[T]) = {
         val system = ActorSystem(name)
         val actor = system.actorOf(Props.create(service), s"$name-service")
 
         implicit val timeout = Timeout(5 seconds)
         IO(Http)(system) ? Http.Bind(actor, interface, port)
+    }
+
+    /** Rejection handler to terminate connection on a bad request. Delegates to Spray handler. */
+    def customRejectionHandler(implicit transid: TransactionId) = RejectionHandler {
+        // get default rejection message, package it as an ErrorResponse instance
+        // which gets serialized into a Json object
+        case r if RejectionHandler.Default.isDefinedAt(r) => {
+            ctx =>
+                RejectionHandler.Default(r) {
+                    ctx.withHttpResponseMapped {
+                        case resp @ HttpResponse(_, HttpEntity.NonEmpty(ContentType(`text/plain`, _), msg), _, _) =>
+                            resp.withEntity(marshalling.marshalUnsafe(ErrorResponse(msg.asString, transid)))
+                    }
+                }
+        }
+        case CustomRejection(status, cause) :: _ => complete(status, ErrorResponse(cause, transid))
     }
 }

--- a/core/controller/src/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/whisk/core/controller/Authenticate.scala
@@ -21,7 +21,8 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
+
+import org.lightcouch.NoDocumentException
 
 import spray.routing.authentication.UserPass
 import whisk.common.Logging
@@ -71,9 +72,12 @@ trait Authenticate extends Logging {
             } onComplete {
                 case Success(s) =>
                     promise.success(s)
+                case Failure(_: NoDocumentException | _: IllegalArgumentException) =>
+                    info(this, s"authentication not valid")
+                    promise.success(None)
                 case Failure(t) =>
                     info(this, s"authentication error: $t")
-                    promise.success(None)
+                    promise.failure(t)
             }
         } getOrElse {
             info(this, s"credentials are malformed")

--- a/core/controller/src/whisk/core/controller/Controller.scala
+++ b/core/controller/src/whisk/core/controller/Controller.scala
@@ -41,7 +41,7 @@ class Controller(
     override def actorRefFactory = context
 
     override def routes(implicit transid: TransactionId) = {
-        handleRejections(badRequestHandler) {
+        handleRejections(customRejectionHandler) {
             super.routes ~ apiv1.routes
         }
     }

--- a/tools/cli/wskadmin
+++ b/tools/cli/wskadmin
@@ -48,7 +48,7 @@ ROOT_DIR = os.path.join(os.path.join(CLI_DIR, os.pardir), os.pardir)
 
 def main():
     requiredprops = [ DB_PROTOCOL, DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_WHISK_AUTHS, DB_WHISK_ACTIONS ]
-    whiskprops = wskprop.importPropsIfAvailable(wskprop.propfile(os.getcwd()))
+    whiskprops = wskprop.importPropsIfAvailable(wskprop.propfile(ROOT_DIR))
     (valid, props, deferredInfo) = wskprop.checkRequiredProperties(requiredprops, whiskprops)
 
     exitCode = 0 if valid else 2


### PR DESCRIPTION
AuthenticatedRoute overrides BasicHttpAuthenticator.apply to provide a custom rejection (either 500 or 503 response).
Added unit tests for authenticated route to confirm custom rejection is generated and served as HTTP response by custom rejection handler.

@markusthoemmes should review as well. 