### PR TITLE
Implement websocket/send action

### DIFF
--- a/catalog/installCatalog.sh
+++ b/catalog/installCatalog.sh
@@ -18,6 +18,7 @@ runPackageInstallScript "$SCRIPTDIR" installGit.sh
 runPackageInstallScript "$SCRIPTDIR" installSlack.sh
 runPackageInstallScript "$SCRIPTDIR" installWatson.sh
 runPackageInstallScript "$SCRIPTDIR" installWeather.sh
+runPackageInstallScript "$SCRIPTDIR" installWebSocket.sh
 
 waitForAll
 

--- a/catalog/installWebSocket.sh
+++ b/catalog/installWebSocket.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# use the command line interface to install websocket package.
+#
+: ${WHISK_SYSTEM_AUTH:?"WHISK_SYSTEM_AUTH must be set and non-empty"}
+AUTH_KEY=$WHISK_SYSTEM_AUTH
+
+SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
+CATALOG_HOME=$SCRIPTDIR
+source "$CATALOG_HOME/util.sh"
+
+echo Installing WebSocket package.
+
+createPackage websocket \
+    -a description "Utilities for communicating with WebSockets"
+    -a parameters '[ {"name":"uri", "required":true, "bindTime":true} ]'
+
+waitForAll
+
+install "$CATALOG_HOME/websocket/sendWebSocketMessageAction.js" \
+    websocket/send \
+    -a description 'Send a message to a WebSocket' \
+    -a parameters '[
+      {
+        "name": "uri",
+        "required": true,
+        "description": "The URI of the websocket server."
+      },
+      {
+        "name": "payload",
+        "required": true,
+        "description": "The data you wish to send to the websocket server."
+      }
+    ]' \
+    -a sampleInput '{"uri":"ws://MyAwesomeService.com/sweet/websocket", "payload":"Hi there, WebSocket!"}' \
+    -a sampleOutput '{"result":{"payload":"Hi there, WebSocket!"},"status":"success","success":true}'
+
+waitForAll
+
+echo WebSocket package ERRORS = $ERRORS
+exit $ERRORS

--- a/catalog/websocket/sendWebSocketMessageAction.js
+++ b/catalog/websocket/sendWebSocketMessageAction.js
@@ -1,0 +1,50 @@
+/**
+ * Sends a payload message to the designated WebSocket URI
+ *
+ * @param uri       String representation of the WebSocket uri
+ * @param payload   Message to send to the WebSocket
+ * @return  Standard OpenWhisk success/error response
+ */
+function main(params) {
+    if (!params.uri) {
+        return whisk.error('You must specify a uri parameter.');
+    }
+    var uri = params.uri;
+
+    console.log("URI param is " + params.uri);
+
+    if (!params.payload) {
+        return whisk.error('You must specify a payload parameter.');
+    }
+    var payload = params.payload;
+
+    console.log("Payload param is " + params.payload);
+
+    var WebSocket = require('ws');
+    var ws = new WebSocket(uri);
+
+    ws.on('open', function() {
+        console.log("Sending payload: " + payload);
+        ws.send(payload, function(error) {
+            if (error) {
+                console.log("Error received communicating with websocket: " + error);
+                ws.close();
+                whisk.error(error)
+            } else {
+                console.log("Send was successful.")
+                ws.close();
+                whisk.done({
+                    'payload': payload
+                });
+            }
+        });
+    });
+
+    ws.on('error', function(error) {
+        console.log("Error communicating with websocket: " + error);
+        ws.close();
+        whisk.error(error);
+    });
+
+    return whisk.async();
+}

--- a/tests/src/packages/websocket/WebSocketTests.scala
+++ b/tests/src/packages/websocket/WebSocketTests.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packages.websocket
+
+import java.net.URI
+
+import scala.concurrent.duration.DurationInt
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.junit.JUnitRunner
+
+import common.JsHelpers
+import common.TestHelpers
+import common.Wsk
+import common.WskProps
+import common.WskTestHelpers
+import spray.json.DefaultJsonProtocol.BooleanJsonFormat
+import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.json.pimpAny
+
+@RunWith(classOf[JUnitRunner])
+class WebSocketTests
+        extends TestHelpers
+        with WskTestHelpers
+        with BeforeAndAfterAll
+        with JsHelpers {
+
+    implicit val wskprops = WskProps()
+    val wsk = new Wsk()
+
+    val websocketSendAction = "/whisk.system/websocket/send"
+
+    behavior of "Websocket action"
+
+    /**
+     * This test requires a websocket server running on Bluemix.
+     * A very simple CF app has been deployed to the "IBM Whisk" org
+     * and "dev" space using the lime account.
+     *
+     * If the test fails, the first thing to check would be ensure
+     * the "TestAppForWebSocketAction" app is actually running.
+     */
+    var serverURI: URI = new URI("ws://owwebsocketserver.mybluemix.net:80")
+
+    it should "Use the websocket action to send a payload" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val uniquePayload = s"The cow says ${System.currentTimeMillis()}".toJson
+            val run = wsk.action.invoke(websocketSendAction, Map("uri" -> serverURI.toString.toJson, "payload" -> uniquePayload))
+            withActivation(wsk.activation, run, 1 second, 1 second, 180 seconds) {
+                activation =>
+                    activation.getFieldPath("response", "success") should be(Some(true.toJson))
+                    activation.getFieldPath("response", "result", "payload") should be(Some(uniquePayload))
+            }
+    }
+
+    it should "Return an error due to a malformed URI" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val badURI = new URI("ws://localhost:80")
+
+            val run = wsk.action.invoke(websocketSendAction, Map("uri" -> badURI.toString.toJson, "payload" -> "This is the message to send".toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.getFieldPath("response", "success") should be(Some(false.toJson))
+
+                    // the exact error content comes from the ws Node module
+                    activation.fieldPathExists("response", "result", "error") should be(true)
+            }
+    }
+
+    it should "Require a payload parameter" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val run = wsk.action.invoke(websocketSendAction, Map("uri" -> serverURI.toString.toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.getFieldPath("response", "success") should be(Some(false.toJson))
+
+                    activation.getFieldPath("response", "result", "error") should be(Some("You must specify a payload parameter.".toJson))
+            }
+    }
+
+    it should "Require a uri parameter" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val run = wsk.action.invoke(websocketSendAction, Map("payload" -> "This is the message to send".toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.getFieldPath("response", "success") should be(Some(false.toJson))
+
+                    activation.getFieldPath("response", "result", "error") should be(Some("You must specify a uri parameter.".toJson))
+            }
+    }
+}


### PR DESCRIPTION
This creates a new package called websocket

Implementation is in Node.JS which required adding the `ws` package to the Node.JS runtime (see #523).
Added unit tests which confirm that a message can be sent to a running WebSocket, as well as handle various error cases.