### PR TITLE
Refactored ActivationThrottle to use ConsulClient

### DIFF
--- a/common/scala/src/whisk/common/Scheduler.scala
+++ b/common/scala/src/whisk/common/Scheduler.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import akka.actor.Actor
+import akka.actor.ActorSystem
+import akka.actor.Props
+
+/**
+ * Scheduler utility functions to execute tasks in a repetetive way with controllable behaviour
+ * even for asynchronous tasks.
+ */
+object Scheduler extends Logging {
+    private case object Work
+
+    /**
+     * Sets up an Actor to send itself a message to mimic schedulers behaviour in a more controllable way.
+     *
+     * @param interval the time to wait between two runs
+     * @param alwaysWait always wait for the given amount of time or calculate elapsed time to wait
+     * @param closure the closure to be executed
+     */
+    private class Worker(interval: FiniteDuration, alwaysWait: Boolean, closure: () => Future[Any]) extends Actor {
+        implicit val ec = context.dispatcher
+
+        override def preStart() = {
+            self ! Work
+        }
+
+        def receive = {
+            case Work =>
+                Try(closure()) match {
+                    case Success(result) =>
+                        result onComplete { _ =>
+                            context.system.scheduler.scheduleOnce(interval, self, Work)
+                        }
+                    case Failure(e) => error(this, s"next iteration could not be scheduled because of ${e.getMessage}. Scheduler is halted")
+                }
+        }
+    }
+
+    /**
+     * Schedules a closure to run continuously scheduled, with at least the given interval in between runs.
+     * This waits until the Future of the closure has finished, ignores its result and then
+     * waits for the given interval.
+     *
+     * @param interval the time to wait between two runs of the closure
+     * @param f the function to run
+     */
+    def scheduleWaitAtLeast(interval: FiniteDuration)(f: () => Future[Any])(implicit system: ActorSystem) = {
+        require(interval > Duration.Zero)
+        system.actorOf(Props(new Worker(interval, true, f)))
+    }
+}

--- a/core/loadBalancer/src/whisk/core/loadBalancer/ActivationThrottle.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/ActivationThrottle.scala
@@ -16,150 +16,149 @@
 
 package whisk.core.loadBalancer;
 
-import scala.BigInt
-import scala.collection.concurrent.TrieMap
-import scala.math.BigInt.int2bigInt
-import scala.util.Try
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 
-import spray.json.JsNumber
+import akka.actor.ActorSystem
+import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
-import spray.json.JsValue
+import spray.json.pimpAny
+import spray.json.pimpString
+import whisk.common.ConsulClient
 import whisk.common.ConsulKV
 import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.Counter
 import whisk.common.Logging
-import scala.language.postfixOps
+import whisk.common.Scheduler
+import whisk.core.WhiskConfig
 
+/**
+ * Determines user limits and activation counts as seen by the invoker and the loadbalancer
+ * in a scheduled, repeating task for other services to get the cached information to be able
+ * to calculate and determine whether the namespace currently invoking a new action should
+ * be allowed to do so
+ *
+ * @param config containing the config information needed (consulServer)
+ */
+class ActivationThrottle(config: WhiskConfig)(
+    implicit val system: ActorSystem,
+    val ec: ExecutionContext) extends Logging {
 
-class ActivationThrottle(consulServer: String,
-                         invokerHealth : InvokerHealth) extends Logging {
+    val DEFAULT_NAMESPACE_CONCURRENCY_LIMITS_KEY = "whiskprops/DEFAULT_NAMESPACE_CONCURRENCY_LIMITS"
+    val DEFAULT_LIMIT = 100L
 
-    private val DEFAULT_NAMESPACE_CONCURRENCY_LIMITS_KEY = "whiskprops/DEFAULT_NAMESPACE_CONCURRENCY_LIMITS"
-    private val DEFAULT_LIMIT: BigInt = BigInt(100)
+    /**
+     * holds the values of the last run of the scheduler below to be gettable by outside
+     * services to be able to determine whether a namespace should be throttled or not based on
+     * the number of concurrent invocations it has in the system
+     */
+    private var userActivationCounter = Map[String, Long]()
+    private var userActivationLimits = Map[String, Long]()
 
-    def countForNamespace(ns: String) = userActivationCounter.getOrElse(ns, BigInt(0))
+    private val healthCheckInterval = 2 seconds
+    private val kvStore = new ConsulClient(config.consulServer)
+
+    /**
+     * Returns the activation count for a specific namespace
+     *
+     * @param ns the namespace to get the activation count for
+     * @returns activation count for the given namespace, defaults to 0
+     */
+    def countForNamespace(ns: String) = userActivationCounter.getOrElse(ns, 0L)
+
+    /**
+     * Returns the limit for a specific namespace
+     *
+     * @param ns the namespace to get the limits for
+     * @returns limit of concurrent activations for the given namespace
+     */
     def limitForNamespace(ns: String) = userActivationLimits.getOrElse(ns, DEFAULT_LIMIT)
 
-    private val userActivationCounter: TrieMap[String, BigInt] = new TrieMap[String, BigInt]
-    private val userActivationLimits: TrieMap[String, BigInt] = new TrieMap[String, BigInt]
-
-    private def printUserActivationCounter = {
-        userActivationCounter.map {
-            case (user, count) => info(this, s"controller: activation count of user ${user} is ${count}")
+    /**
+     * Returns the concurrency limits for all namespaces
+     *
+     * @returns a map where each namespace maps to the concurrency limit set for it
+     */
+    private def getConcurrencyLimits(): Future[Map[String, Long]] =
+        kvStore.get(DEFAULT_NAMESPACE_CONCURRENCY_LIMITS_KEY) map { limits =>
+            limits.parseJson.convertTo[Map[String, Long]]
         }
-    }
 
-    new Thread() {
-        /** query the KV store this often */
-        private val healthCheckPeriodMillis = 2000
-        /** allow the last invoker update to be this far behind */
-        private val maximumAllowedDelayMilli = 5000
+    /**
+     * Returns the per-namespace activation count as seen by the loadbalancer
+     *
+     * @returns a map where each namespace maps to the activations for it counted
+     *     by the loadbalancer
+     */
+    private def getLoadBalancerActivationCount(): Future[Map[String, Long]] =
+        kvStore.getRecurse(ConsulKV.LoadBalancerKeys.userActivationCountKey) map {
+            _ map {
+                case (_, users) => users.parseJson.convertTo[Map[String, Long]]
+            } reduce { _ ++ _ } // keys are unique in every sub map, no adding necessary
+        }
 
-        private val kvStore = new ConsulKV(consulServer)
+    /**
+     * Returns the per-namespace activation count as seen by all invokers combined
+     *
+     * @returns a map where each namespace maps to the activations for it counted
+     *     by all the invokers combined
+     */
+    private def getInvokerActivationCount(): Future[Map[String, Long]] =
+        kvStore.getRecurse(ConsulKV.InvokerKeys.allInvokersData) map { rawMaps =>
+            val activationCountPerInvoker = rawMaps map {
+                case (_, users) => users.parseJson.convertTo[Map[String, Long]]
+            }
 
-        /** temporary map for holding the values */
-        private val tempCounter: TrieMap[String, BigInt] = new TrieMap[String, BigInt]
-
-        private def decrementCounter(values: JsObject) = {
-            tempCounter foreach {
-                case (user, count) =>
-                    values.getFields(user) match {
-                        case Seq(JsNumber(x)) =>
-                            val newCount = count - BigInt(x.intValue)
-                            if (newCount >= 0) {
-                                info(this, s"activation count for user ${user} decremented ${count} -> ${newCount}")
-                                tempCounter(user) = newCount
-                            } else {
-                                warn(this, s"activation count for user ${user} is negative ${count} -> ${newCount}")
-                                tempCounter(user) = 0
-                            }
-                        case _ => // do nothing
-                    }
+            // merge all maps and sum values with identical keys
+            activationCountPerInvoker.foldLeft(Map[String, Long]()) { (a, b) =>
+                (a.keySet ++ b.keySet) map { k =>
+                    (k, a.getOrElse(k, 0L) + b.getOrElse(k, 0L))
+                } toMap
             }
         }
 
-        /**
-         * Continuously read from the KV store to get user activation counts from invoker and loadbalancer.
-         * Reject action invocation if there are more than n number of concurrent invocations active.
-         */
-        override def run() = {
-            while (true) {
-                Try {
-                    val limitInfo = kvStore.get(DEFAULT_NAMESPACE_CONCURRENCY_LIMITS_KEY).asJsObject.fields
-                    val limits = limitInfo.flatMap {
-                        case (k: String, v: JsNumber) => Some(k, BigInt(v.value.toInt))
-                        case _                        => None
-                    }.toMap
-                    userActivationLimits.clear()
-                    userActivationLimits ++= limits
-                    info(this, s"Got user activation limits from consul: ${limits.keys} ${limits.values}")
-                } getOrElse {
-                    warn(this, "Could not get user activation limits from kvstore")
-                }
+    Scheduler.scheduleWaitAtLeast(healthCheckInterval) { () =>
+        for {
+            concurrencyLimits <- getConcurrencyLimits
+            loadbalancerActivationCount <- getLoadBalancerActivationCount
+            invokerActivationCount <- getInvokerActivationCount
+        } yield {
+            userActivationLimits = concurrencyLimits
+            userActivationCounter = invokerActivationCount map {
+                case (subject, invokerCount) =>
+                    val loadbalancerCount = loadbalancerActivationCount(subject)
+                    subject -> (loadbalancerCount - invokerCount)
+            }
 
-                Try {
-                    val loadBalancerInfo = ActivationThrottle.fetchLoadBalancerUserActivation(kvStore)
-                    val limits = loadBalancerInfo.flatMap {
-                        case (k: String, v: JsNumber) => Some(k, BigInt(v.value.toInt))
-                        case _                        => None
-                    }.toMap
-                    tempCounter.clear()
-                    tempCounter ++= limits
-                    info(this, s"""Got user activation count from loadbalancer: ${limits.keys} ${limits.values}""")
-
-                    val indices = invokerHealth.getInvokerIndices()
-                    val invokerCounts = indices flatMap {
-                        index => ActivationThrottle.getOneInvokerUserActivationCounts(kvStore, index)
-                    }
-                    invokerCounts.foreach { invCount => decrementCounter(invCount) }
-
-                    info(this, s"""Finally got user activation counts: ${limits.keys} ${limits.values}""")
-                    userActivationCounter.clear()
-                    userActivationCounter ++= tempCounter
-                    printUserActivationCounter
-                } getOrElse {
-                    warn(this, "Could not get user activation counts from loadbalancer kvstore")
-                }
-
-                Thread.sleep(healthCheckPeriodMillis)
-            } // while
+            userActivationCounter foreach {
+                case (user, count) => info(this, s"controller: activation count of user ${user} is ${count}")
+            }
         }
-    }.start()
+    }
 }
 
-/*
+/**
  * Isolate here the concrete representation of load-balancer generated user action count information.
  */
 object ActivationThrottle {
+    val requiredProperties = WhiskConfig.consulServer
 
-    // Obtain from consul the the load-balancer generated user activation count information
-    def fetchLoadBalancerUserActivation(kvStore : ConsulKV) : Map[String, JsValue] = {
-        kvStore.getRecurse(ConsulKV.LoadBalancerKeys.userActivationCountKey) flatMap {
-            case (_, v) => v.asJsObject.fields
+    /**
+     * Convert user activation counters into a map of JsObjects to be written into consul kv
+     *
+     * @param userActivationCounter the counters for each user's activations
+     * @returns a map where the key represents the final nested key structure for consul and a JsObject
+     *     containing the activation counts for each user
+     */
+    def encodeLoadBalancerUserActivation(userActivationCounter: Map[String, Counter]): Map[String, JsObject] = {
+        userActivationCounter mapValues {
+            _.cur
+        } groupBy {
+            case (key, _) => LoadBalancerKeys.userActivationCountKey + "/" + key.substring(0, 1)
+        } mapValues { map =>
+            map.toJson.asJsObject
         }
     }
-
-    //  Convert the in-core representation of user activation counts into an opaque bundle of consule kv pairs
-    //  Note: TrieMap is not a Map but we should find a beter supertype)
-    def encodeLoadBalancerUserActivation(userActivationCounter : TrieMap[String, Counter]) : Map[String, JsObject] = {
-
-        val subjects = userActivationCounter.keySet toList
-        val groups = subjects.groupBy { user => user.substring(0, 1) }
-        groups.keySet map { prefix =>
-          val key = LoadBalancerKeys.userActivationCountKey + "/" + prefix
-          val users = groups.getOrElse(prefix, Set())
-          val items = users map { u => (u, JsNumber(userActivationCounter.get(u) map { c => c.cur } getOrElse 0))}
-          key -> JsObject(items toMap)
-        } toMap
-    }
-
-    // Fetches everything under the user activation count for one invoker.
-    // Because we are getting all subkeys, the way it's split up by the invoker doesn't matter.
-    def getOneInvokerUserActivationCounts(kvStore : ConsulKV, index : Int) = {
-        val invokerInfo = kvStore.getRecurse(ConsulKV.InvokerKeys.userActivationCount(index))
-        invokerInfo flatMap {
-            case (_, userActivationCount) => Some(userActivationCount.asJsObject)
-        }
-    }
-
 }

--- a/core/loadBalancer/src/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/InvokerHealth.scala
@@ -41,6 +41,7 @@ import whisk.common.Verbosity
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 import whisk.core.connector.{ ActivationMessage => Message }
+import whisk.common.Scheduler
 
 object InvokerHealth {
     val requiredProperties = consulServer
@@ -136,8 +137,8 @@ class InvokerHealth(
     /** query the KV store this often */
     private val healthCheckInterval = 2 seconds
 
-    system.scheduler.schedule(0 seconds, healthCheckInterval) {
-        kv.getRecurse(InvokerKeys.allInvokers) foreach { invokerInfo =>
+    Scheduler.scheduleWaitAtLeast(healthCheckInterval) { () =>
+        kv.getRecurse(InvokerKeys.allInvokers) map { invokerInfo =>
             // keys are like invokers/invokerN/count
             val flattened = ConsulClient.dropKeyLevel(invokerInfo)
             val nested = ConsulClient.toNestedMap(flattened)

--- a/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerToKafka.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerToKafka.scala
@@ -117,7 +117,7 @@ trait LoadBalancerToKafka extends Logging {
     }
 
     protected def getUserActivationCounts(): Map[String, JsObject] = {
-        ActivationThrottle.encodeLoadBalancerUserActivation(userActivationCounter)
+        ActivationThrottle.encodeLoadBalancerUserActivation(userActivationCounter.toMap)
     }
 
     // A count of how many activations have been posted to Kafka based on invoker index or user/subject.

--- a/tests/src/whisk/common/SchedulerTests.scala
+++ b/tests/src/whisk/common/SchedulerTests.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import java.time.Instant
+
+import scala.collection.mutable.Buffer
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import akka.actor.ActorSystem
+import akka.actor.PoisonPill
+
+@RunWith(classOf[JUnitRunner])
+class SchedulerTests extends FlatSpec with Matchers {
+    implicit val system = ActorSystem()
+    implicit val ec = system.dispatcher
+
+    val minimumTimeBetweenCalls = 50 milliseconds
+    val callsToProduce = 5
+
+    /**
+     * Calculates the duration between two consecutive elements
+     *
+     * @param times the points in time to calculate the difference between
+     * @return duration between each element of the given sequence
+     */
+    def calculateDifferences(times: Seq[Instant]) = {
+        times sliding (2) map {
+            case Seq(a, b) => Duration.fromNanos(java.time.Duration.between(a, b).toNanos)
+        } toList
+    }
+
+    /**
+     * Waits for the calls to be scheduled and executed. Adds one call-interval as additional slack
+     */
+    def waitForCalls() = Thread.sleep((callsToProduce + 1) * minimumTimeBetweenCalls toMillis)
+
+    "Scheduler" should "be killable by sending it a poison pill" in {
+        var callCount = 0
+        val scheduled = Scheduler.scheduleWaitAtLeast(minimumTimeBetweenCalls) { () =>
+            callCount += 1
+            Future successful true
+        }
+
+        waitForCalls()
+        scheduled ! PoisonPill
+
+        val countAfterKill = callCount
+        callCount should be >= callsToProduce
+
+        waitForCalls()
+
+        callCount shouldBe countAfterKill
+    }
+
+    it should "throw an expection when passed a negative duration" in {
+        an[IllegalArgumentException] should be thrownBy Scheduler.scheduleWaitAtLeast(-100 milliseconds) { () =>
+            Future.successful(true)
+        }
+    }
+
+    it should "wait at least the given interval between scheduled calls" in {
+        val calls = Buffer[Instant]()
+
+        val scheduled = Scheduler.scheduleWaitAtLeast(minimumTimeBetweenCalls) { () =>
+            calls += Instant.now
+            Future successful true
+        }
+
+        waitForCalls()
+        scheduled ! PoisonPill
+
+        val differences = calculateDifferences(calls)
+        all(differences) should be > minimumTimeBetweenCalls
+    }
+
+    it should "stop the scheduler if an uncaught exception is thrown by the passed closure" in {
+        var callCount = 0
+        val scheduled = Scheduler.scheduleWaitAtLeast(minimumTimeBetweenCalls) { () =>
+            callCount += 1
+            throw new Exception
+            Future successful true
+        }
+
+        waitForCalls()
+
+        callCount shouldBe 1
+    }
+
+    it should "not stop the scheduler if the future from the closure is failed" in {
+        var callCount = 0
+
+        val scheduled = Scheduler.scheduleWaitAtLeast(minimumTimeBetweenCalls) { () =>
+            callCount += 1
+            Future failed new Exception
+        }
+
+        waitForCalls()
+        scheduled ! PoisonPill
+
+        callCount shouldBe callsToProduce
+    }
+}


### PR DESCRIPTION
Forgot that one in my last refactoring session

@perryibm should review aswell, although travis and PPG517 + PPG518 are green i'm a bit sensible with this change.

**Note:** Kept the handling of the kv queries and formatting locally as it was before. We should really implement a wrapper around `ConsulClient` that abstracts all of this away and gives clients a nicer interface to use for common queries to key value stores. The method to combine the partitioned user activation maps for loadbalancer and invokers are good candidates for example.

**Note 2:** The scheduler pattern I used to replace the Threads should probably implement a pattern to be safe against jobs interfering with each other as shown here http://stackoverflow.com/a/31658345/3269863 (edit: **Done**)