### PR TITLE
Increase wait time for log sentinel marker to 1.5 seconds

### DIFF
--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -288,7 +288,7 @@ class Invoker(
 
     // The nodeJsAction runner inserts this line in the logs at the end
     // of each activation
-    private val LogRetryCount = 10
+    private val LogRetryCount = 15
     private val LogRetry = 100 // millis
     private val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
     private val nodejsImageName = WhiskAction.containerImageName(NodeJSExec("", None), config.dockerRegistry, config.dockerImageTag)


### PR DESCRIPTION
Occasionally, particularly when running invokers on the same machine as other components, we need more time for logs to propagate.  I am being parsimonious so we can understand how bad this gets.

PPG 522 passed