### PR TITLE
Fix invoker lifecycle

### DIFF
--- a/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
@@ -78,8 +78,7 @@ trait ContainerUtils extends Logging {
         runDockerCmd(cmd: _*)
     }
 
-    def killContainer(name: String)(implicit transid: TransactionId): DockerOutput =
-        runDockerCmd("kill", name)
+    def killContainer(name: String)(implicit transid: TransactionId): DockerOutput = killContainer(Some(name))
 
     def killContainer(container: ContainerName)(implicit transid: TransactionId): DockerOutput = {
         container map { name => runDockerCmd("kill", name) } getOrElse None
@@ -97,8 +96,10 @@ trait ContainerUtils extends Logging {
         runDockerCmd(true, Array("unpause", name))
     }
 
+    def rmContainer(container: String)(implicit transid: TransactionId): DockerOutput = rmContainer(Some(container))
+
     /**
-     * Forcefully removes a container, can be used on a running container.
+     * Forcefully removes a container, can be used on a running container but not a paused one.
      */
     def rmContainer(container: ContainerName)(implicit transid: TransactionId): DockerOutput = {
         container map { name => runDockerCmd("rm", "-f", name) } getOrElse None

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -92,6 +92,7 @@ import whisk.http.BasicHttpService
 class Invoker(
     config: WhiskConfig,
     instance: Int,
+    verbosity: Verbosity.Level = Verbosity.Loud,
     runningInContainer: Boolean = true)(implicit actorSystem: ActorSystem)
     extends DispatchRule("invoker", "/actions/invoke", s"""(.+)/(.+)/(.+),(.+)/(.+)""") {
 
@@ -422,21 +423,6 @@ class Invoker(
         count
     }
 
-    /**
-     * Destroys all activte containers and starts new warm containers.
-     * This method should be called only once and only at startup.
-     */
-    private var started = false
-    def start() = if (!started) {
-        started = true
-
-        // This will remove leftover action containers
-        pool.killStragglers()(TransactionId.invoker)
-
-        // Start warm containers after removing stragglers
-        pool.warmupContainers()
-    }
-
     private def getUserActivationCounts(): Map[String, JsObject] = {
         val subjects = userActivationCounter.keySet toList
         val groups = subjects.groupBy { user => user.substring(0, 1) } // Any sort of partitioning will be ok wrt load balancer
@@ -483,7 +469,7 @@ class Invoker(
     private val entityStore = WhiskEntityStore.datastore(config)
     private val authStore = WhiskAuthStore.datastore(config)
     private val activationStore = WhiskActivationStore.datastore(config)
-    private val pool = new ContainerPool(config, instance)
+    private val pool = new ContainerPool(config, instance, getVerbosity())
     private val activationCounter = new Counter() // global activation counter
     private val userActivationCounter = new TrieMap[String, Counter]
 
@@ -504,6 +490,8 @@ class Invoker(
     private val activationIdMap = new TrieMap[ActivationId, String]
     def putContainerName(activationId: ActivationId, containerName: String) = activationIdMap += (activationId -> containerName)
     def getContainerName(activationId: ActivationId): Option[String] = activationIdMap get activationId
+
+    setVerbosity(verbosity)
 }
 
 object Invoker {
@@ -543,19 +531,16 @@ object InvokerService {
         if (config.isValid) {
             val instance = if (args.length > 0) args(1).toInt else 0
             val dispatcher = new Dispatcher(config, s"invoke${instance}", "invokers")
+            dispatcher.setVerbosity(Verbosity.Loud)
             implicit val ec = Dispatcher.executionContext
 
             implicit val actorSystem = ActorSystem(
                 name = "invoker-actor-system",
                 defaultExecutionContext = Some(ec))
 
-            val invoker = new Invoker(config, instance)
-
             SimpleExec.setVerbosity(Verbosity.Loud)
-            invoker.setVerbosity(Verbosity.Loud)
-            invoker.start()
+            val invoker = new Invoker(config, instance, Verbosity.Loud)
 
-            dispatcher.setVerbosity(Verbosity.Loud)
             dispatcher.addHandler(invoker, true)
             dispatcher.start()
 

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -72,8 +72,7 @@ class ContainerPoolTests extends FlatSpec
             ++ WhiskAuthStore.requiredProperties)
     assert(config.isValid)
 
-    val pool = new ContainerPool(config, 0, false)
-    pool.setVerbosity(Verbosity.Loud)
+    val pool = new ContainerPool(config, 0, Verbosity.Loud, false)
     pool.logDir = "/tmp"
 
     val datastore = WhiskEntityStore.datastore(config)

--- a/tests/src/whisk/core/invoker/test/InvokerTests.scala
+++ b/tests/src/whisk/core/invoker/test/InvokerTests.scala
@@ -93,8 +93,7 @@ class InvokerTests extends FlatSpec
         val message = Message(transid, "", auth.subject, ActivationId(), Some(payload), None)
         implicit val stream = new java.io.ByteArrayOutputStream
         val activationDoc = Console.withOut(stream) {
-            val rule = new Invoker(config, 1, false)
-            rule.setVerbosity(Verbosity.Loud)
+            val rule = new Invoker(config, 1, Verbosity.Loud, false)
             val future = rule.doit("someTopic", message, rule.matches(s"/actions/invoke/${wsk.docid}"))
             val docinfo = Await.result(future, 10 seconds)
             val activationResult = Await.result(WhiskActivation.get(activationstore, docinfo), dbOpTimeout)


### PR DESCRIPTION
This PR fixes several related bugs involving the invoker's life cycle.

1. Fix startup of container pool to be abstract so invoker cannot get it wrong.  The stragglers are now killed concurrently with the invoker starting up so the http server is not blocked causing deployment failure.  Stragglers are however not killed while regular container pool operations are allows so that there is no interference with either the warmup thread or other container pool clients.

2. Verbosity of container pool was updated imperatively causing a race and missing output in the log files.  We maintain the setVerbosity method but call them during construction to avoid inconsistency.

3. A shutdown hook is attached so that if `docker stop` (ie SIGTERM) is sent the invoker will shutdown action containers and leave docker in a clean state.  This goes towards invoker restartability.

For example:
```
$ docker ps -a
CONTAINER ID        IMAGE                                      COMMAND                  CREATED              STATUS                       PORTS                     NAMES
0829e28aefa4        localhost:5000/whisk/nodejsaction:latest   "/bin/sh -c 'node app"   About a minute ago   Up About a minute (Paused)                             wsk0_2_warmJsContainer_20160524T005330865Z
34f1e1787c24        localhost:5000/whisk/nodejsaction:latest   "/bin/sh -c 'node app"   About a minute ago   Up About a minute (Paused)                             wsk0_1_warmJsContainer_20160524T005328891Z
962bfcc61b85        localhost:5000/whisk/dispatcher:latest     "/dispatcher/bin/disp"   About a minute ago   Up About a minute            0.0.0.0:12001->8080/tcp   invoker0
69e293c978d7        localhost:5000/whisk/forwarder:latest      "/configAndStartForwa"   2 minutes ago        Up 2 minutes                                           forwarder
24005656c5d7        gliderlabs/registrator                     "/bin/registrator -ip"   3 minutes ago        Up 3 minutes                                           registrator
$ docker stop 962b
962b
$ docker ps -a
CONTAINER ID        IMAGE                                    COMMAND                  CREATED              STATUS                        PORTS               NAMES
962bfcc61b85        localhost:5000/whisk/dispatcher:latest   "/dispatcher/bin/disp"   About a minute ago   Exited (143) 12 seconds ago                       invoker0
69e293c978d7        localhost:5000/whisk/forwarder:latest    "/configAndStartForwa"   3 minutes ago        Up 3 minutes                                      forwarder
24005656c5d7        gliderlabs/registrator                   "/bin/registrator -ip"   3 minutes ago        Up 3 minutes                                      registrator
```