### PR TITLE
Whisk object does not return the correct results

### DIFF
--- a/catalog/samples/invoke.swift
+++ b/catalog/samples/invoke.swift
@@ -1,21 +1,16 @@
 import SwiftyJSON
 
 func main(args: [String:Any]) -> [String:Any] {
-  let response = Whisk.invoke(actionNamed: "/whisk.system/util/date", withParameters: [:])
+  let invokeResult = Whisk.invoke(actionNamed: "/whisk.system/util/date", withParameters: [:])
+  let dateActivation = JSON(invokeResult)
 
-  let jsonString = response["response"] as! String
-
-  if let dataFromString = jsonString.data(using: NSUTF8StringEncoding, allowLossyConversion: true) {
-    let json = JSON(data: dataFromString)
-    if let date = json["response", "result", "date"].string {
-      print("It is now \(date)")
-      return ["response" : json["response"].stringValue]
-    } else {
-      print("Could not parse date of of the response.")
-      return ["error" : "Could not parse date of of the response."]
-    }
+  // the date we are looking for is the result inside the date activation
+  if let dateString = dateActivation["response"]["result"]["date"].string {
+    print("It is now \(dateString)")
   } else {
-    print("Could not invoke date action.")
-    return ["error" : "Could not invoke date action."]
+    print("Could not parse date of of the response.")
   }
+
+  // return the entire invokeResult
+  return invokeResult
 }

--- a/catalog/samples/trigger.swift
+++ b/catalog/samples/trigger.swift
@@ -1,6 +1,6 @@
 func main(args: [String:Any]) -> [String:Any] {
   if let triggerName = args["triggerName"] as? String {
-    print("Tigger Name: \(triggerName)")
+    print("Trigger Name: \(triggerName)")
     return Whisk.trigger(eventNamed: triggerName, withParameters: [:])
   } else {
     return ["error": "You must specify a triggerName parameter!"]

--- a/core/swift3Action/spm-build/Whisk.swift
+++ b/core/swift3Action/spm-build/Whisk.swift
@@ -53,7 +53,7 @@ class Whisk {
         if let edgeHostEnv : String = env["EDGE_HOST"] {
             edgeHost = "\(edgeHostEnv)"
         } else {
-          fatalError("EDGE_HOST environment variable was not set.")
+            fatalError("EDGE_HOST environment variable was not set.")
         }
 
         let hostComponents = edgeHost.components(separatedBy: ":")
@@ -94,11 +94,15 @@ class Whisk {
         let request = HTTP.request(requestOptions) { response in
             if response != nil {
                 do {
-                    let responseString = try response!.readString()!
-                    print(responseString)
-                    callback(["response": responseString])
+                    // this is odd, but that's just how KituraNet has you get
+                    // the response as NSData
+                    let jsonData = NSMutableData()
+                    try response!.readAllData(into: jsonData)
+
+                    let resp = try NSJSONSerialization.jsonObject(with: jsonData, options: [])
+                    callback(resp as! [String:Any])
                 } catch {
-                    callback(["error": "Action did not produce a valid JSON response."])
+                    callback(["error": "Could not parse a valid JSON response."])
                 }
             } else {
                 callback(["error": "Did not receive a response."])

--- a/tests/src/system/basic/CLISwiftTests.scala
+++ b/tests/src/system/basic/CLISwiftTests.scala
@@ -73,7 +73,7 @@ class CLISwiftTests
     /**
      * Test the Swift 3 example
      */
-    ignore should "invoke a swift:3 action" in withAssetCleaner(wskprops) {
+    it should "invoke a swift:3 action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "helloSwift3"
             assetHelper.withCleaner(wsk.action, name) {

--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -28,19 +28,20 @@ import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.StringJsonFormat
+import spray.json.DefaultJsonProtocol.BooleanJsonFormat
 import spray.json.pimpAny
 
 @RunWith(classOf[JUnitRunner])
 class Swift3WhiskObjectTests
-    extends TestHelpers
-    with WskTestHelpers {
+        extends TestHelpers
+        with WskTestHelpers {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk()
 
     behavior of "Swift 3 Whisk backend API"
 
-    ignore should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
+    it should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // use CLI to create action from dat/actions/invokeAction.swift
             val file = TestUtils.getCatalogFilename("/samples/invoke.swift")
@@ -50,18 +51,24 @@ class Swift3WhiskObjectTests
             }
 
             // invoke the action
-            val run = wsk.action.invoke(actionName, Map("key0" -> "value0".toJson))
+            val run = wsk.action.invoke(actionName)
             withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) {
                 activation =>
-                    val logs = activation.fields("logs").toString
+                    // should be successful
+                    activation.fields("response").asJsObject.fields("success") should be(true.toJson)
 
-                    logs should include("It is now")
-                    logs should not include ("Could not parse date of of the response.")
-                    logs should not include ("Could not invoke date action.")
+                    // should have a result field
+                    activation.fields("response").asJsObject.fields("result") should not be(null)
+
+                    // should have a field named "activationId" which is the date action's activationId
+                    activation.fields("response").asJsObject.fields("result").asJsObject.fields("activationId").toString.length should be >= 32
+
+                    // should have somewhere in the "result" field the phrase "It is now" printed from the invoked date action
+                    activation.fields("response").asJsObject.fields("result").toString should include("It is now")
             }
     }
 
-    ignore should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
+    it should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // create a trigger
             val triggerName = s"TestTrigger ${System.currentTimeMillis()}"
@@ -80,14 +87,20 @@ class Swift3WhiskObjectTests
             val run = wsk.action.invoke(actionName, Map("triggerName" -> triggerName.toJson))
             withActivation(wsk.activation, run, initialWait = 5 seconds, totalWait = 60 seconds) {
                 activation =>
-                    activation.fields("logs").toString should include(s"Tigger Name: $triggerName")
+                    // should be successful
+                    activation.fields("response").asJsObject.fields("success") should be(true.toJson)
 
-                    // wait for trigger activation
+                    // should have a result field
+                    activation.fields("response").asJsObject.fields("result") should not be(null)
+
+                    // should have a field named "activationId" which is the date action's activationId
+                    activation.fields("response").asJsObject.fields("result").asJsObject.fields("activationId").toString.length should be >= 32
+
+                    // should result in an activation for triggerName
                     val triggerActivations = wsk.activation.pollFor(1, Some(triggerName), retries = 20)
                     withClue(s"trigger activations for $triggerName:") {
                         triggerActivations.length should be(1)
                     }
             }
     }
-
 }


### PR DESCRIPTION
The problem is that the response from the `POST` is not properly serialized. The causes the result to always be returned as `["response": ""]`