### PR TITLE
Fixes issue #506

### DIFF
--- a/core/controller/src/whisk/core/controller/Packages.scala
+++ b/core/controller/src/whisk/core/controller/Packages.scala
@@ -33,6 +33,7 @@ import spray.routing.Directive.pimpApply
 import spray.routing.RequestContext
 import spray.routing.directives.OnCompleteFutureMagnet.apply
 import spray.routing.directives.ParamDefMagnet.apply
+import org.lightcouch.NoDocumentException
 import whisk.common.TransactionId
 import whisk.core.entitlement.Collection
 import whisk.core.entity.Binding
@@ -219,7 +220,11 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
                                 (content.annotations getOrElse Parameters()) ++ bindingAnnotation(resolvedBinding))
                         }
                         else promise failure {
-                            RejectRequest(BadRequest, "entity specified in binding is not a package")
+                            RejectRequest(BadRequest, "cannot bind to another package binding")
+                        }
+                    case Failure(t: NoDocumentException) =>
+                        promise failure {
+                            RejectRequest(BadRequest, "binding references a package that does not exist")
                         }
                     case Failure(t) => promise failure RejectRequest(BadRequest, t)
                 }

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -388,6 +388,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
+            responseAs[ErrorResponse].error should include ("binding references a package that does not exist")
         }
     }
 
@@ -399,6 +400,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, reference)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
+            responseAs[ErrorResponse].error should include ("cannot bind to another package binding")
         }
     }
 


### PR DESCRIPTION
Fixes #506. Add appropriate error message when referencing non-existing package in a bind operation. Update unit test.