### PR TITLE
downgrade docker to version 1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: true
 
 before_install:
   - sudo apt-get -y update -qq
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" --force-yes -y install docker-engine=1.11.0-0~trusty
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" --force-yes -y install docker-engine=1.9.1-0~trusty
   - docker --version
   - sudo apt-get -y install python-pip
   - pip install --user jsonschema

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -14,7 +14,7 @@ sudo apt-cache policy docker-engine
 sudo apt-get -y install linux-image-extra-$(uname -r)
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.11.0-0~trusty
+sudo apt-get install -y --force-yes docker-engine=1.9.1-0~trusty
 
 # enable (security - use 127.0.0.1)
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' >> /etc/default/docker'


### PR DESCRIPTION
This PR downgrades docker to version 1.9.1 in the `docker.sh` script used to provision vagrant boxes. This resolves #536.