### PR TITLE
invokers use the local consul agent instead of using the first consul server in core machines

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -23,7 +23,7 @@
     hostname: "invoker{{play_hosts.index(inventory_hostname)}}"
     env:
       "COMPONENT_NAME": "invoker{{play_hosts.index(inventory_hostname)}}"
-      "CONSULSERVER_HOST": "{{ groups['consul_servers'] | first }}"
+      "CONSULSERVER_HOST": "{{inventory_hostname}}"
       "CONSUL_HOST_PORT4": "{{consul.port.http}}"
       "SELF_DOCKER_ENDPOINT": "{{inventory_hostname}}:{{docker.port}}"
       "SERVICE_NAME": "invoker{{play_hosts.index(inventory_hostname)}}"


### PR DESCRIPTION
Signed-off-by: Dominik Jall <djall@de.ibm.com>