### PR TITLE
Add DOCKER_HOST into the environment variables

### DIFF
--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -20,6 +20,10 @@ sudo apt-get install -y --force-yes docker-engine=1.9.1-0~trusty
 sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' >> /etc/default/docker'
 sudo gpasswd -a `whoami` docker
 
+# Set DOCKER_HOST as an environment variable
+sudo -E bash -c 'echo '\''export DOCKER_HOST="tcp://0.0.0.0:4243"'\'' >> /etc/bash.bashrc'
+source /etc/bash.bashrc
+
 sudo service docker restart
 
 # do not run this command without a vagrant reload during provisioning


### PR DESCRIPTION
After "vagrant up" is done, all the docker commands will be able to
run in the terminal after "vagrant ssh", since DOCKER_HOST is set
as an environment variable.

Closes-Bug: #533