### PR TITLE
Make ephemeral couchdb persistent in deploy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,7 +57,7 @@
     </target>
 
     <!-- teardown and deploy all services -->
-    <target name="redeploy" depends="teardown,deploy" />
+    <target name="redeploy" depends="teardownRedeploy,deploy" />
 
     <target name="teardownLocal">
         <exec executable="/bin/bash">
@@ -65,6 +65,13 @@
         </exec>
     </target>
 
+    <target name="teardownLocalRedeploy">
+        <exec executable="/bin/bash">
+            <arg value="tools/docker/cleanDocker.sh" />
+        	<arg value="couchdb" />
+        </exec>
+    </target>
+ 
     <!-- kill all containers, garbage collect docker images -->
     <target name="teardown" depends="teardownLocal,writePropertyFile">
         <var file="whisk.properties" />
@@ -72,6 +79,16 @@
             <env key="DOCKER_PORT" value="${docker.port}" />
             <arg value="tools/docker/cleanAllDockers.sh" />
             <arg value="${basedir}/whisk.properties" />
+        </exec>
+    </target>
+
+    <target name="teardownRedeploy" depends="teardownLocalRedeploy,writePropertyFile">
+        <var file="whisk.properties" />
+        <exec executable="/bin/bash">
+            <env key="DOCKER_PORT" value="${docker.port}" />
+            <arg value="tools/docker/cleanAllDockers.sh" />
+            <arg value="${basedir}/whisk.properties" />
+        	<arg value="couchdb" />
         </exec>
     </target>
 

--- a/tools/docker/cleanAllDockers.sh
+++ b/tools/docker/cleanAllDockers.sh
@@ -20,6 +20,8 @@ SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
 WHISKPROPS=$1
 : ${WHISKPROPS:?"WHISKPROPS must be set and non-empty"}
 
+DATABASE_EXEMPT=$2
+
 #
 # run cleanDocker.sh on each docker endpoint
 #
@@ -29,6 +31,6 @@ DEFAULT_DOCKER_PORT=4243
 for h in $ALL_HOSTS
 do
     echo "Cleaning docker at $h:${DOCKER_PORT:-$DEFAULT_DOCKER_PORT}"
-    DOCKER_ENDPOINT=$h:${DOCKER_PORT:-$DEFAULT_DOCKER_PORT} "$SCRIPTDIR/cleanDocker.sh" &
+    DOCKER_ENDPOINT=$h:${DOCKER_PORT:-$DEFAULT_DOCKER_PORT} "$SCRIPTDIR/cleanDocker.sh" "$DATABASE_EXEMPT" &
 done
 wait

--- a/tools/docker/cleanDocker.sh
+++ b/tools/docker/cleanDocker.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+DATABASE_EXEMPT=$1
+
 # Kill all running containers and remove all dangling (non-leaf) images
 # Add "--purge" to remove all images
 if [ -n "${DOCKER_ENDPOINT+1}" ]; then
@@ -38,7 +40,13 @@ fi
 # *catalog*
 # *swarm*
 #
-RUNNING=$($DOCKER ps -a | fgrep -v "whisk_docker_registry" | fgrep -v "whiskrouter" | fgrep -v "catalog" | fgrep -v "swarm" | sed '1d' | awk '{print $1}')
+
+if [ "$DATABASE_EXEMPT" == "couchdb" ];
+then
+    RUNNING=$($DOCKER ps -a | fgrep -v "whisk_docker_registry" | fgrep -v "whiskrouter" | fgrep -v "catalog" | fgrep -v "swarm" | fgrep -v "couchdb" | sed '1d' | awk '{print $1}')
+else
+    RUNNING=$($DOCKER ps -a | fgrep -v "whisk_docker_registry" | fgrep -v "whiskrouter" | fgrep -v "catalog" | fgrep -v "swarm" | sed '1d' | awk '{print $1}')
+fi
 
 if [ -n "$RUNNING" ]
 then


### PR DESCRIPTION
If the user chooses to use the ephemeral couchdb, we should keep it
from being deleted in redeploy.

Closes-Bug: #532