### PR TITLE
Silence out download progress info in `Dockerfile`s

### DIFF
--- a/core/controller/Dockerfile
+++ b/core/controller/Dockerfile
@@ -3,7 +3,7 @@ FROM whisk/scala
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install swagger-ui
-Run wget https://github.com/swagger-api/swagger-ui/archive/v2.1.4.tar.gz && \
+RUN wget --no-verbose https://github.com/swagger-api/swagger-ui/archive/v2.1.4.tar.gz && \
     mkdir swagger-ui && \
     tar zxf v2.1.4.tar.gz -C /swagger-ui --strip-components=2 swagger-ui-2.1.4/dist && \ 
     rm v2.1.4.tar.gz && \

--- a/core/dispatcher/Dockerfile
+++ b/core/dispatcher/Dockerfile
@@ -2,7 +2,7 @@ FROM whisk/scala
 
 # Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
 # Install docker 1.9.0
-RUN wget -O /usr/bin/docker "https://get.docker.com/builds/Linux/x86_64/docker-1.9.0" && \
+RUN wget --no-verbose -O /usr/bin/docker "https://get.docker.com/builds/Linux/x86_64/docker-1.9.0" && \
 chmod +x /usr/bin/docker
 
 COPY build/distributions/dispatcher.tar ./

--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y install autoconf libtool libkqueue-dev libkqueue0 libdispatch-dev
 RUN apt-get clean
 
 # Install Swift keys
-RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
+RUN wget --no-verbose -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
     gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
 
 # Install Swift Ubuntu 14.04 Snapshot
@@ -29,8 +29,8 @@ ENV SWIFT_PLATFORM ubuntu14.04
 
 RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
     SWIFT_URL=https://swift.org/builds/development/$(echo "$SWIFT_PLATFORM" | tr -d .)/swift-$SWIFT_VERSION/$SWIFT_ARCHIVE_NAME.tar.gz && \
-    wget -nv $SWIFT_URL && \
-    wget -nv $SWIFT_URL.sig && \
+    wget --no-verbose $SWIFT_URL && \
+    wget --no-verbose $SWIFT_URL.sig && \
     gpg --verify $SWIFT_ARCHIVE_NAME.tar.gz.sig && \
     tar -xzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
     rm -rf $SWIFT_ARCHIVE_NAME* /tmp/* /var/tmp/*

--- a/core/swiftAction/Dockerfile
+++ b/core/swiftAction/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -y install build-essential wget clang libedit-dev libicu52 libxml2-d
 RUN apt-get clean
 
 # Install Swift keys
-RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
+RUN wget --no-verbose -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
     gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
 
 # Install Swift Ubuntu 14.04 Snapshot
@@ -26,8 +26,8 @@ ENV SWIFT_PLATFORM ubuntu14.04
 
 RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
     SWIFT_URL=https://swift.org/builds/$(echo "$SWIFT_PLATFORM" | tr -d .)/swift-$SWIFT_VERSION/$SWIFT_ARCHIVE_NAME.tar.gz && \
-    wget -nv $SWIFT_URL && \
-    wget -nv $SWIFT_URL.sig && \
+    wget --no-verbose $SWIFT_URL && \
+    wget --no-verbose $SWIFT_URL.sig && \
     gpg --verify $SWIFT_ARCHIVE_NAME.tar.gz.sig && \
     tar -xzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
     rm -rf $SWIFT_ARCHIVE_NAME* /tmp/* /var/tmp/*

--- a/services/consul/Dockerfile
+++ b/services/consul/Dockerfile
@@ -6,7 +6,7 @@ RUN cd / && mkdir consul && mkdir consul/data && \
 apt-get update && \
 apt-get install -y unzip bc python && \
 cd /tmp && \
-wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
+wget --no-verbose https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
 mv consul_${CONSUL_VERSION}_linux_amd64.zip consul.zip && \
 cd /bin && \
 unzip /tmp/consul.zip &&  \
@@ -14,7 +14,7 @@ chmod +x /bin/consul && \
 rm /tmp/consul.zip && \
 cd /consul && \
 mkdir ui && cd ui && \
-wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_web_ui.zip && \
+wget --no-verbose https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_web_ui.zip && \
 unzip consul_${CONSUL_VERSION}_web_ui.zip && \
 rm consul_${CONSUL_VERSION}_web_ui.zip 
 

--- a/services/kafka/Dockerfile
+++ b/services/kafka/Dockerfile
@@ -28,8 +28,8 @@ ENV KAFKA_RELEASE_ARCHIVE kafka_2.11-0.9.0.0.tgz
 # Install Kafka to /kafka
 
 WORKDIR /tmp
-RUN wget http://www.us.apache.org/dist/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE} && \
-    wget https://dist.apache.org/repos/dist/release/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE}.md5  && \
+RUN wget --no-verbose http://www.us.apache.org/dist/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE} && \
+    wget --no-verbose https://dist.apache.org/repos/dist/release/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE}.md5  && \
     npm install -g express@4.8.0 nano@5.10.0 process@0.10.1 websocket@1.0.17 && \
   echo VERIFY CHECKSUM: && \
   gpg --print-md MD5 ${KAFKA_RELEASE_ARCHIVE} 2>/dev/null && \
@@ -42,7 +42,7 @@ RUN wget http://www.us.apache.org/dist/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE} &&
 ADD monitor  /monitor
 RUN cd /monitor && npm install
 
-RUN cd /kafka/libs/ && wget https://jcenter.bintray.com/org/slf4j/slf4j-log4j12/1.7.6/slf4j-log4j12-1.7.6.jar
+RUN cd /kafka/libs/ && wget --no-verbose https://jcenter.bintray.com/org/slf4j/slf4j-log4j12/1.7.6/slf4j-log4j12-1.7.6.jar
 ADD config /kafka/config
 ADD start.sh /start.sh
 

--- a/services/zookeeper/Dockerfile
+++ b/services/zookeeper/Dockerfile
@@ -1,6 +1,6 @@
 FROM whisk/scala
 
-RUN wget -q -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /opt \
+RUN wget --no-verbose -O - http://apache.mirrors.pair.com/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz | tar -xzf - -C /opt \
     && mv /opt/zookeeper-3.4.6 /opt/zookeeper \
     && cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg \
     && mkdir -p /tmp/zookeeper


### PR DESCRIPTION
Trying to use `wget --no-verbose` consistently to avoid progress report but preserve error/warning messages.

(Makes Travis logs fit in the main view.)