### PR TITLE
Fixes issue 568

### DIFF
--- a/common/scala/src/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/whisk/core/entity/ActivationId.scala
@@ -74,6 +74,14 @@ protected[core] object ActivationId extends ArgNormalizer[ActivationId] {
      */
     protected[core] def apply(): ActivationId = new ActivationId(java.util.UUID.randomUUID())
 
+    /**
+     * Overrides factory method so that string is not interpreted as number
+     * e.g., 2e11.
+     */
+    override protected[entity] def factory(s: String): ActivationId = {
+        serdes.read(JsString(s))
+    }
+
     override protected[core] implicit val serdes = new RootJsonFormat[ActivationId] {
         def write(d: ActivationId) = JsString(d.toString)
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -17,6 +17,8 @@
 package whisk.core.entity.test
 
 import scala.Vector
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
 
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfter
@@ -34,6 +36,7 @@ import spray.json.JsValue
 import spray.json.pimpAny
 import spray.json.pimpString
 import whisk.core.entity.ActionLimits
+import whisk.core.entity.ActivationId
 import whisk.core.entity.AuthKey
 import whisk.core.entity.DocId
 import whisk.core.entity.DocInfo
@@ -46,8 +49,6 @@ import whisk.core.entity.Secret
 import whisk.core.entity.SemVer
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.UUID
-import scala.language.postfixOps
-import scala.language.reflectiveCalls
 
 @RunWith(classOf[JUnitRunner])
 class SchemaTests extends FlatSpec with BeforeAndAfter {
@@ -350,5 +351,10 @@ class SchemaTests extends FlatSpec with BeforeAndAfter {
         intercept[IllegalArgumentException] {
             ActionLimits(TimeLimit(TimeLimit.MAX_DURATION.toMillis.toInt + 1), MemoryLimit(MemoryLimit.MAX_MEMORY + 1))
         }
+    }
+
+    it should "parse activation id as uuid" in {
+        val id = "213174381920559471141441e1111111"
+        assert(ActivationId.unapply(id).isDefined)
     }
 }


### PR DESCRIPTION
Treats activation id as string to prevent parsing into an number which will cause the deserialization to fail.