### PR TITLE
Do not rely on the logs field for expected output

### DIFF
--- a/tests/src/common/JsHelpers.scala
+++ b/tests/src/common/JsHelpers.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import spray.json.JsObject
+import spray.json.JsValue
+
+trait JsHelpers {
+    implicit class JsObjectHelper(js: JsObject) {
+        def getFieldPath(path: String*): Option[JsValue] = {
+            if (path.size == 1) {
+                Some(js.fields(path(0)))
+            } else if (js.getFields(path(0)).size > 0) {
+                // current segment exists, but there are more...
+                js.fields(path(0)).asJsObject.getFieldPath(path.tail: _*)
+            } else {
+                None
+            }
+        }
+
+        def fieldPathExists(path: String*): Boolean = {
+            !js.getFieldPath(path: _*).isEmpty
+        }
+    }
+}

--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -30,11 +30,13 @@ import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.BooleanJsonFormat
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.pimpAny
+import common.JsHelpers
 
 @RunWith(classOf[JUnitRunner])
 class Swift3WhiskObjectTests
     extends TestHelpers
-    with WskTestHelpers {
+    with WskTestHelpers
+    with JsHelpers {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk()
@@ -60,8 +62,8 @@ class Swift3WhiskObjectTests
                     // should have a field named "activationId" which is the date action's activationId
                     activation.fields("response").asJsObject.fields("result").asJsObject.fields("activationId").toString.length should be >= 32
 
-                    // should have somewhere in the "result" field the phrase "It is now" printed from the invoked date action
-                    activation.fields("response").asJsObject.fields("result").toString should include("It is now")
+                    // check for "date" field that comes from invoking the date action
+                    activation.fieldPathExists("response", "result", "response", "result", "date") should be(true)
             }
     }
 


### PR DESCRIPTION
Instead check for the presence of the result of invoking the date action. This verification is more robust.