### PR TITLE
Add Go CLI to OpenWhisk - Add CLI Switches to Test Suites

### DIFF
--- a/catalog/util.sh
+++ b/catalog/util.sh
@@ -15,10 +15,16 @@ if [ ! -f "$WHISKPROPS_FILE" ]; then
 fi
 EDGE_HOST=`fgrep edge.host= "$WHISKPROPS_FILE" | cut -d'=' -f2`
 
+USE_PYTHON_CLI=true
+
 function createPackage() {
     PACKAGE_NAME=$1
     REST=("${@:2}")
-    CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" --apihost "$EDGE_HOST" package update --auth "$AUTH_KEY" --shared yes "$PACKAGE_NAME" "${REST[@]}")
+    if [ "$USE_PYTHON_CLI" = true ]; then
+        CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" -i --apihost "$EDGE_HOST" package update --auth "$AUTH_KEY" --shared yes "$PACKAGE_NAME" "${REST[@]}")
+    else
+        CMD_ARRAY=("$OPENWHISK_HOME/bin/go-cli/wsk" -i --apihost "$EDGE_HOST" package update --auth "$AUTH_KEY" --shared yes "$PACKAGE_NAME" "${REST[@]}")
+    fi
     export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
     "${CMD_ARRAY[@]}" &
     PID=$!
@@ -30,7 +36,11 @@ function install() {
     RELATIVE_PATH=$1
     ACTION_NAME=$2
     REST=("${@:3}")
-    CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" --apihost "$EDGE_HOST" action update --auth "$AUTH_KEY" --shared yes "$ACTION_NAME" "$RELATIVE_PATH" "${REST[@]}")
+    if [ "$USE_PYTHON_CLI" = true ]; then
+        CMD_ARRAY=($PYTHON "$OPENWHISK_HOME/bin/wsk" -i --apihost "$EDGE_HOST" action update --auth "$AUTH_KEY" --shared yes "$ACTION_NAME" "$RELATIVE_PATH" "${REST[@]}")
+    else
+        CMD_ARRAY=("$OPENWHISK_HOME/bin/go-cli/wsk" -i --apihost "$EDGE_HOST" action update --auth "$AUTH_KEY" --shared yes "$ACTION_NAME" "$RELATIVE_PATH" "${REST[@]}")
+    fi
     export WSK_CONFIG_FILE= # override local property file to avoid namespace clashes
     "${CMD_ARRAY[@]}" &
     PID=$!

--- a/tests/src/common/WhiskProperties.java
+++ b/tests/src/common/WhiskProperties.java
@@ -109,6 +109,34 @@ public class WhiskProperties {
         System.out.format("test router? %s\n", testRouter);
     }
 
+    /**
+     * The path to the Go CLI directory.
+     */
+    public static String getGoCLIDir() {
+        return whiskHome + "/bin/go-cli";
+    }
+
+    /**
+     * The path to the Go CLI executable.
+     */
+    public static String getGoCLIPath() {
+        return getGoCLIDir() + "/wsk";
+    }
+
+    /**
+     * The path to the Python CLI directory.
+     */
+    public static String getPythonCLIDir() {
+        return whiskHome + "/bin";
+    }
+
+    /**
+     * The path to the Python CLI executable.
+     */
+    public static String getPythonCLIPath() {
+        return getPythonCLIDir() + "/wsk";
+    }
+
     public static File getFileRelativeToWhiskHome(String name) {
         return new File(whiskHome, name);
     }

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -67,21 +67,25 @@ import java.time.Instant
  * It also sets the apihost and apiversion explicitly to avoid ambiguity with
  * a local property file if it exists.
  */
+
+
 case class WskProps(
     authKey: String = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting),
     namespace: String = "_",
     apiversion: String = "v1",
     apihost: String = WhiskProperties.getEdgeHost) {
-    def overrides = Seq("--apihost", apihost, "--apiversion", apiversion)
+    def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
 }
 
-class Wsk extends RunWskCmd {
+class Wsk(val usePythonCLI: Boolean = true) extends RunWskCmd {
     implicit val action = new WskAction()
     implicit val trigger = new WskTrigger()
     implicit val rule = new WskRule()
     implicit val activation = new WskActivation()
     implicit val pkg = new WskPackage()
     implicit val namespace = new WskNamespace()
+
+    Wsk.setUsePythonCLI(usePythonCLI)
 }
 
 trait FullyQualifiedNames {
@@ -719,8 +723,12 @@ trait WaitFor {
 }
 
 object Wsk {
-    private val cliDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
     private val binaryName = "wsk"
+    private var usePythonCLI = true
+
+    def setUsePythonCLI(usePython: Boolean) = {
+        usePythonCLI = usePython
+    }
 
     /** What is the path to a downloaded CLI? **/
     private def getDownloadedCliPath = {
@@ -733,21 +741,53 @@ object Wsk {
             val f = new File(binary)
             assert(f.exists, s"did not find $f")
         } else {
-            val dir = cliDir
-            val exec = new File(dir, binaryName)
+            val cliPath = if (usePythonCLI) {
+                WhiskProperties.getPythonCLIPath();
+            } else {
+                WhiskProperties.getGoCLIPath();
+            }
+
+            val cliDir = if (usePythonCLI) {
+                WhiskProperties.getPythonCLIDir();
+            } else {
+                WhiskProperties.getGoCLIDir();
+            }
+
+            val dir = new File(cliDir)
+            val exec = new File(cliPath)
             assert(dir.exists, s"did not find $dir")
             assert(exec.exists, s"did not find $exec")
         }
     }
 
-    def baseCommand = if (WhiskProperties.useCliDownload()) {
-        Buffer(getDownloadedCliPath)
-    } else {
-        Buffer(WhiskProperties.python, new File(cliDir, binaryName).toString)
+    def baseCommand =  {
+        if (WhiskProperties.useCliDownload()) {
+            Buffer(getDownloadedCliPath)
+        } else {
+            val cliPath = if (usePythonCLI) {
+                WhiskProperties.getPythonCLIPath();
+            } else {
+                WhiskProperties.getGoCLIPath();
+            }
+
+            val cliDir = if (usePythonCLI) {
+                WhiskProperties.getPythonCLIDir();
+            } else {
+                WhiskProperties.getGoCLIDir();
+            }
+
+            if (usePythonCLI) {
+                Buffer(WhiskProperties.python, new File(cliPath).toString)
+
+            } else {
+                Buffer(new File(cliPath).toString)
+            }
+        }
     }
 }
 
 sealed trait RunWskCmd {
+
     /**
      * The base command to run.
      */
@@ -767,25 +807,25 @@ sealed trait RunWskCmd {
         val args = baseCommand
         if (verbose) args += "--verbose"
         if (showCmd) println(params.mkString(" "))
-        val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, env, args ++ params: _*)
+        val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, args ++ params: _*)
         rr.validateExitCode(expectedExitCode)
         rr
     }
 }
 
 object WskAdmin {
-    private val cliDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
+    private val binDir = WhiskProperties.getFileRelativeToWhiskHome("bin")
     private val binaryName = "wskadmin"
 
     def exists = {
-        val dir = cliDir
+        val dir = binDir
         val exec = new File(dir, binaryName)
         assert(dir.exists, s"did not find $dir")
         assert(exec.exists, s"did not find $exec")
     }
 
     def baseCommand = {
-        Buffer(WhiskProperties.python, new File(cliDir, binaryName).toString)
+        Buffer(WhiskProperties.python, new File(binDir, binaryName).toString)
     }
 }
 

--- a/tests/src/common/WskCli.java
+++ b/tests/src/common/WskCli.java
@@ -40,15 +40,18 @@ import common.TestUtils.RunResult;
  */
 public class WskCli {
 
-    private static final File cliDir = WhiskProperties.getFileRelativeToWhiskHome("bin");
+    private static String cliPath;
+    private static String cliDir;
+    private static final File binDir = WhiskProperties.getFileRelativeToWhiskHome("bin");
 
     private static final String adminBinaryName = "wskadmin";
-    private final String binaryName;
     private final File binaryPath;
     public String subject;
     public final String authKey;
 
     private Map<String, String> env = null;
+
+    private static Boolean usePythonCLI = true;
 
     public static enum Item {
         Package("package"), Trigger("trigger"), Action("action"), Rule("rule"), Activation("activation");
@@ -61,30 +64,38 @@ public class WskCli {
     }
 
     public WskCli() {
-        this(WhiskProperties.getAuthFileForTesting());
+        this(usePythonCLI, WhiskProperties.getAuthFileForTesting());
     }
 
-    public WskCli(String authKey) {
-        this("wsk", "default", authKey);
+    public WskCli(Boolean usePythonCLI) {
+        this(usePythonCLI, WhiskProperties.getAuthFileForTesting());
     }
 
-    public WskCli(String subject, String authKey) {
-        this("wsk", subject, authKey);
+    public WskCli(Boolean usePythonCLI, String authKey) {
+        this(usePythonCLI, "default", authKey);
     }
 
-    protected WskCli(File authFile) {
-        this("wsk", "default", authFile);
+    protected WskCli(Boolean usePythonCLI, File authFile) {
+        this(usePythonCLI, "default", authFile);
     }
 
-    protected WskCli(String binaryName, String subject, File authFile) {
-        this(binaryName, subject, WhiskProperties.readAuthKey(authFile));
+    public WskCli(Boolean usePythonCLI, String subject, File authFile) {
+        this(usePythonCLI, subject, WhiskProperties.readAuthKey(authFile));
     }
 
-    protected WskCli(String binaryName, String subject, String authKey) {
-        this.binaryName = binaryName;
-        this.binaryPath = new File(cliDir, binaryName);
+    public WskCli(Boolean usePythonCLI, String subject, String authKey) {
+        if (usePythonCLI) {
+            cliPath = WhiskProperties.getPythonCLIPath();
+            cliDir = WhiskProperties.getPythonCLIDir();
+        } else {
+            cliPath = WhiskProperties.getGoCLIPath();
+            cliDir = WhiskProperties.getGoCLIDir();
+        }
+
+        this.binaryPath = new File(cliPath);
         this.subject = subject;
         this.authKey = authKey;
+        this.usePythonCLI = usePythonCLI;
     }
 
     public void setSubject(String subject) {
@@ -96,12 +107,15 @@ public class WskCli {
     }
 
     public boolean checkExists() {
+        File dir;
+
         if (WhiskProperties.useCliDownload()) {
             String binary = getDownloadedCliPath();
             File f = new File(binary);
             assertTrue("did not find " + f, f.exists());
         } else {
-            assertTrue("did not find " + cliDir, cliDir.exists());
+            dir = new File(cliDir);
+            assertTrue("did not find " + dir, dir.exists());
             assertTrue("did not find " + binaryPath, binaryPath.exists());
         }
         return true;
@@ -353,7 +367,7 @@ public class WskCli {
         }
 
         if (shared) {
-            cmd = Util.concat(cmd, new String[] { "--shared" });
+            cmd = Util.concat(cmd, new String[] { "--shared", "yes"});
         }
 
         RunResult result = cli(expectedCode, cmd);
@@ -968,11 +982,15 @@ public class WskCli {
      * @return RunResult which contains stdout,sterr, exit code
      */
     public RunResult cli(boolean verbose, int expectedExitCode, File workingDir, String... params) throws IllegalArgumentException, IOException {
-        String[] cmd = WhiskProperties.useCliDownload() ? new String[] { getDownloadedCliPath() } : new String[] { WhiskProperties.python, new File(cliDir, binaryName).toString() };
-        String[] args = verbose ? Util.concat(cmd, "--verbose") : cmd;
-        if (binaryName.equals("wsk")) {
-            args = Util.concat(cmd, "--apihost", WhiskProperties.getEdgeHost());
+        String[] cmd;
+        if (usePythonCLI) {
+            cmd = WhiskProperties.useCliDownload() ? new String[] { getDownloadedCliPath() } : new String[] { WhiskProperties.python, new File(cliPath).toString() };
+        } else {
+            cmd = WhiskProperties.useCliDownload() ? new String[] { getDownloadedCliPath() } : new String[] { new File(cliPath).toString() };
         }
+
+        cmd = verbose ? Util.concat(cmd, "--verbose") : cmd;
+        String[] args = Util.concat(cmd, "-i", "--apihost", WhiskProperties.getEdgeHost());
         RunResult rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, this.env, Util.concat(args, params));
         rr.validateExitCode(expectedExitCode);
         return rr;
@@ -986,9 +1004,10 @@ public class WskCli {
      * Since there are many unit tests in Java and some of them need access to
      * WskAdmin, we lightly reflect the admin methods here.
      */
-    public static RunResult admin(String... params) throws IllegalArgumentException, IOException {
+    public RunResult admin(String... params) throws IllegalArgumentException, IOException {
         File workingDir = new File(".");
-        String[] cmd = new String[] { WhiskProperties.python, new File(cliDir, adminBinaryName).toString() };
+        String[] cmd = new String[] { WhiskProperties.python, new File(binDir, adminBinaryName).toString() };
+
         return TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, null, Util.concat(cmd, params));
     }
 
@@ -996,7 +1015,7 @@ public class WskCli {
      * Create a user. The caller is responsible for checking success upon which
      * stdout contains the authKey.
      */
-    public static RunResult createUser(String subject) throws Exception {
+    public RunResult createUser(String subject) throws Exception {
         return admin("user", "create", subject);
     }
 

--- a/tests/src/packages/SamplesTests.java
+++ b/tests/src/packages/SamplesTests.java
@@ -34,8 +34,8 @@ import common.WskCli;
  */
 @RunWith(ParallelRunner.class)
 public class SamplesTests {
-
-    private final WskCli wsk = new WskCli();
+    private static final Boolean usePythonCLI = true;
+    private final WskCli wsk = new WskCli(usePythonCLI);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/tests/src/packages/SlackTests.java
+++ b/tests/src/packages/SlackTests.java
@@ -32,8 +32,8 @@ import common.WskCli;
  */
 @RunWith(ParallelRunner.class)
 public class SlackTests {
-
-  private static final WskCli wsk = new WskCli();
+  private static final Boolean usePythonCLI = true;
+  private static final WskCli wsk = new WskCli(usePythonCLI);
 
   private static final int DEFAULT_WAIT = 100;
 

--- a/tests/src/packages/UtilsTests.scala
+++ b/tests/src/packages/UtilsTests.scala
@@ -27,7 +27,8 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val lines = JsArray(JsString("seven"), JsString("eight"), JsString("nine"))
 
     behavior of "Util Actions"
@@ -37,7 +38,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "concatenate an array of strings using the node.js cat action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             withActivation(wsk.activation, wsk.action.invoke("/whisk.system/util/cat", Map("lines" -> lines))) {
                 _.fields("response").toString should include(""""payload":"seven\neight\nnine"""")
@@ -49,7 +50,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "concatenate an array of strings using the cat action on node.js 6" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/cat.js")
             val actionName = "catNodejs6"
@@ -68,7 +69,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "concatenate an array of strings using the swift cat action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/cat.swift")
             val actionName = "catSwift3"
@@ -88,7 +89,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "split a string into an array of strings using the node.js split action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             withActivation(wsk.activation, wsk.action.invoke("/whisk.system/util/split", Map("payload" -> "seven,eight,nine".toJson, "separator" -> ",".toJson))) {
                 _.fields("response").toString should include (""""lines":["seven","eight","nine"]""")
@@ -100,7 +101,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "split a string into an array of strings using the split action on nodejs 6" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/split.js")
             val actionName = "splitNodejs6"
@@ -119,7 +120,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "split a string into an array of strings using the swift split action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/split.swift")
             val actionName = "splitSwift3"
@@ -138,7 +139,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "extract first n elements of an array of strings using the node.js head action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             withActivation(wsk.activation, wsk.action.invoke("/whisk.system/util/head", Map("lines" -> lines, "num" -> JsNumber(2)))) {
                 _.fields("response").toString should include(""""lines":["seven","eight"]""")
@@ -150,7 +151,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "extract first n elements of an array of strings using the head action on nodejs 6" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/head.js")
             val actionName = "headNodejs6"
@@ -169,7 +170,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "extract first n elements of an array of strings using the swift head action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/head.swift")
             val actionName = "headSwift3"
@@ -188,7 +189,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "sort an array of strings using the node.js sort action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             withActivation(wsk.activation, wsk.action.invoke("/whisk.system/util/sort", Map("lines" -> lines))) {
                 _.fields("response").toString should include(""""lines":["eight","nine","seven"]""")
@@ -200,7 +201,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "sort an array of strings using the sort action on nodejs 6" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/sort.js")
             val actionName = "sortNodejs6"
@@ -219,7 +220,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "sort an array of strings using the swift sort action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("utils/sort.swift")
             val actionName = "sortSwift3"
@@ -238,7 +239,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "count the number of words in a string using the node.js word count action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             withActivation(wsk.activation, wsk.action.invoke("/whisk.system/samples/wordCount", Map("payload" -> "one two three".toJson))) {
                 _.fields("response").toString should include(""""count":3""")
@@ -250,7 +251,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "count the number of words in a string using the word count action on nodejs 6" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("samples/wc.js")
             val actionName = "wcNodejs6"
@@ -269,7 +270,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
       */
     it should "count the number of words in a string using the swift word count action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val wsk = new Wsk()
+            val wsk = new Wsk(usePythonCLI)
 
             val file = TestUtils.getCatalogFilename("samples/wc.swift")
             val actionName = "wcSwift3"

--- a/tests/src/packages/websocket/WebSocketTests.scala
+++ b/tests/src/packages/websocket/WebSocketTests.scala
@@ -42,7 +42,9 @@ class WebSocketTests
         with JsHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+
+    val wsk = new Wsk(usePythonCLI)
 
     val websocketSendAction = "/whisk.system/websocket/send"
 

--- a/tests/src/system/basic/CLIActionTests.java
+++ b/tests/src/system/basic/CLIActionTests.java
@@ -44,8 +44,8 @@ import common.WskCli;
  */
 @RunWith(ParallelRunner.class)
 public class CLIActionTests {
-
-    private static final WskCli wsk = new WskCli();
+    private static final Boolean usePythonCLI = true;
+    private static final WskCli wsk = new WskCli(usePythonCLI);
 
     public static final String[] sampleTestWords = new String[] { "SHERLOCK", "WATSON", "LESTRADE" };
     private static final int DEFAULT_WAIT = 100;  // Wait this long for logs to show up
@@ -175,9 +175,16 @@ public class CLIActionTests {
         String payload = "bob";
         String[] cmd = { "action", "invoke", "/whisk.system/samples/helloWorld", payload };
         RunResult rr = wsk.runCmd(cmd);
-        assertTrue("Expect a cli error exit code", rr.exitCode == 2);
-        assertTrue("Expect a cli usage message", rr.stderr.contains("usage: wsk [-h] [-v]"));
-        assertTrue("Expect a cli error message", rr.stderr.contains("wsk: error: unrecognized arguments: " + payload));
+
+        if (usePythonCLI) {
+            assertTrue("Expect a cli error exit code", rr.exitCode == 2);
+            assertTrue("Expect a cli usage message", rr.stderr.contains("usage: wsk [-h] [-v]"));
+            assertTrue("Expect a cli error message", rr.stderr.contains("wsk: error: unrecognized arguments: " + payload));
+        } else {
+            assertTrue("Expect a cli error exit code", rr.exitCode == 1);
+            assertTrue("Expect a cli usage message", rr.stderr.contains("Run 'wsk --help' for usage."));
+            assertTrue("Expect a cli error message", rr.stderr.contains("error: Invalid argument list."));
+        }
     }
 
     @Test(timeout=120*1000)

--- a/tests/src/system/basic/CLIJavaTests.scala
+++ b/tests/src/system/basic/CLIJavaTests.scala
@@ -39,7 +39,8 @@ class CLIJavaTests
     with Matchers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val expectedDuration = 120 seconds
     val activationPollDuration = 60 seconds
 

--- a/tests/src/system/basic/CLIPythonTests.scala
+++ b/tests/src/system/basic/CLIPythonTests.scala
@@ -47,7 +47,8 @@ class CLIPythonTests
     with Matchers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
 
     behavior of "Native Python Action"
 

--- a/tests/src/system/basic/CLIRuleTests.java
+++ b/tests/src/system/basic/CLIRuleTests.java
@@ -47,8 +47,8 @@ import common.WskCli;
  */
 @RunWith(ParallelRunner.class)
 public class CLIRuleTests {
-
-    private static final WskCli wsk = new WskCli();
+    private static final Boolean usePythonCLI = true;
+    private static final WskCli wsk = new WskCli(usePythonCLI);
     private static final int RULE_DELAY = 30;
     private static final int DELAY = 90;
     // NEGATIVE_DELAY is used for tests when checking that something doesn't

--- a/tests/src/system/basic/CLISequentialTests.java
+++ b/tests/src/system/basic/CLISequentialTests.java
@@ -33,8 +33,8 @@ import common.WskCli;
  * thresholds.
  */
 public class CLISequentialTests {
-
-    private static final WskCli wsk = new WskCli();
+    private static final Boolean usePythonCLI = true;
+    private static final WskCli wsk = new WskCli(usePythonCLI);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/tests/src/system/basic/CLISwiftTests.scala
+++ b/tests/src/system/basic/CLISwiftTests.scala
@@ -39,7 +39,8 @@ class CLISwiftTests
     with Matchers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val expectedDuration = 30 seconds
     val activationPollDuration = 60 seconds
 

--- a/tests/src/system/basic/ConsoleTests.scala
+++ b/tests/src/system/basic/ConsoleTests.scala
@@ -45,7 +45,8 @@ class ConsoleTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
 
     behavior of "Wsk Activation Console"
 

--- a/tests/src/system/basic/PackageTests.scala
+++ b/tests/src/system/basic/PackageTests.scala
@@ -54,7 +54,8 @@ class PackageTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val LOG_DELAY = 80 seconds
 
     behavior of "Wsk Package"
@@ -154,7 +155,7 @@ class PackageTests
         val flatDescription = itemDescription.replace("\n", "").replace("\r", "")
         merged.foreach {
             case (key: String, value: JsValue) =>
-                val toFind = s""""key": "${key}",            "value": ${value.toString}"""
+                val toFind = s""""key": "${key}",.*"value": ${value.toString}"""
                 flatDescription should include regex toFind
         }
     }

--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -39,7 +39,8 @@ class Swift3WhiskObjectTests
     with JsHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
 
     behavior of "Swift 3 Whisk backend API"
 

--- a/tests/src/system/basic/WskActionSequenceTests.scala
+++ b/tests/src/system/basic/WskActionSequenceTests.scala
@@ -45,7 +45,8 @@ class WskActionSequenceTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val defaultAction = Some(TestUtils.getCatalogFilename("samples/hello.js"))
     val allowedActionDuration = 120 seconds
 

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -35,6 +35,7 @@ import common.TestUtils.NOT_FOUND
 import common.TestUtils.SUCCESS_EXIT
 import common.TestUtils.TIMEOUT
 import common.TestUtils.UNAUTHORIZED
+import common.TestUtils.ERROR_EXIT
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
@@ -51,7 +52,8 @@ class WskBasicTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
     val defaultAction = Some(TestUtils.getCatalogFilename("samples/hello.js"))
 
     behavior of "Wsk CLI"
@@ -62,30 +64,38 @@ class WskBasicTests
 
     it should "show help and usage info" in {
         val stdout = wsk.cli(Seq("-h")).stdout
-        stdout should include("usage:")
-        stdout should include("optional arguments")
-        stdout should include("available commands")
-        stdout should include("-help")
+
+        if (usePythonCLI) {
+            stdout should include("usage:")
+            stdout should include("optional arguments")
+            stdout should include("available commands")
+            stdout should include("-help")
+        } else {
+            stdout should include regex ("""(?i)Usage:""")
+            stdout should include regex ("""(?i)Flags""")
+            stdout should include regex ("""(?i)Available commands""")
+            stdout should include regex ("""(?i)--help""")
+        }
     }
 
     it should "show cli build version" in {
         val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
-        stdout should include regex ("""whisk CLI version\s+201.*\n""")
+        stdout should include regex ("""(?i)whisk CLI version\s+201.*""")
     }
 
     it should "show api version" in {
         val stdout = wsk.cli(Seq("property", "get", "--apiversion")).stdout
-        stdout should include regex ("""whisk API version\s+v1\n""")
+        stdout should include regex ("""(?i)whisk API version\s+v1""")
     }
 
     it should "show api build version" in {
         val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuild")).stdout
-        stdout should include regex ("""whisk API build*.*201.*\n""")
+        stdout should include regex ("""(?i)whisk API build\s+201.*""")
     }
 
     it should "show api build number" in {
         val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuildno")).stdout
-        stdout should include regex ("""whisk API build*.*.*\n""")
+        stdout should include regex ("""(?i)whisk API build.*\s+.*""")
     }
 
     it should "set auth in property file" in {
@@ -139,9 +149,9 @@ class WskBasicTests
         implicit val wskprops = WskProps("xxx") // shadow properties
         val errormsg = "The supplied authentication is invalid"
         wsk.namespace.list(expectedExitCode = UNAUTHORIZED).
-            stdout should include(errormsg)
+            stderr should include(errormsg)
         wsk.namespace.get(expectedExitCode = UNAUTHORIZED).
-            stdout should include(errormsg)
+            stderr should include(errormsg)
     }
 
     it should "reject deleting action in shared package not owned by authkey" in {
@@ -165,17 +175,27 @@ class WskBasicTests
     }
 
     it should "reject bad command" in {
-        wsk.cli(Seq("bogus"), expectedExitCode = MISUSE_EXIT).
+        if (usePythonCLI) {
+            wsk.cli(Seq("bogus"), expectedExitCode = MISUSE_EXIT).
             stderr should include("usage:")
+        } else {
+            val result = wsk.cli(Seq("bogus"), expectedExitCode = ERROR_EXIT)
+            result.stderr should include regex ("""(?i)Run 'wsk --help' for usage""")
+        }
     }
 
     it should "reject authenticated command when no auth key is given" in {
         // override wsk props file in case it exists
         val wskprops = File.createTempFile("wskprops", ".tmp")
         val env = Map("WSK_CONFIG_FILE" -> wskprops.getAbsolutePath())
-        val stderr = wsk.cli(Seq("list"), env = env, expectedExitCode = MISUSE_EXIT).stderr
-        stderr should include("usage:")
-        stderr should include("--auth is required")
+
+        if (usePythonCLI) {
+            val stderr = wsk.cli(Seq("list"), env = env, expectedExitCode = MISUSE_EXIT).stderr
+            stderr should include("usage:")
+            stderr should include("--auth is required")
+        } else {
+            val result = wsk.cli(Seq("list"), env = env, expectedExitCode = UNAUTHORIZED)
+        }
     }
 
     behavior of "Wsk Package CLI"
@@ -258,13 +278,19 @@ class WskBasicTests
 
     it should "reject delete of action that does not exist" in {
         wsk.action.sanitize("deleteFantasy").
-            stdout should include regex ("""error: The requested resource does not exist. \(code \d+\)""")
+            stderr should include regex ("""error: The requested resource does not exist. \(code \d+\)""")
     }
 
     it should "reject create with missing file" in {
-        wsk.action.create("missingFile", Some("notfound"),
-            expectedExitCode = MISUSE_EXIT).
-            stdout should include("not a valid file")
+        if (usePythonCLI) {
+            wsk.action.create("missingFile", Some("notfound"),
+                expectedExitCode = MISUSE_EXIT).
+              stderr should include("not a valid file")
+        } else {
+            wsk.action.create("missingFile", Some("notfound"),
+                expectedExitCode = ERROR_EXIT).
+              stderr should include("Unable to parse action")
+        }
     }
 
     /**

--- a/tests/src/system/basic/WskSdkTests.scala
+++ b/tests/src/system/basic/WskSdkTests.scala
@@ -33,7 +33,8 @@ class WskSdkTests
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()
-    val wsk = new Wsk()
+    var usePythonCLI = true
+    val wsk = new Wsk(usePythonCLI)
 
     behavior of "Wsk SDK"
 
@@ -42,7 +43,7 @@ class WskSdkTests
         dir.delete()
         dir.mkdir() should be(true)
 
-        wsk.cli(Seq("sdk", "install", "docker"), workingDir = dir).
+        wsk.cli(Seq("-i", "sdk", "install", "docker"), workingDir = dir).
             stdout should include("The docker skeleton is now installed at the current directory.")
 
         val sdk = new File(dir, "dockerSkeleton")
@@ -71,7 +72,7 @@ class WskSdkTests
     }
 
     it should "preview swift sdk" in {
-        wsk.cli(Seq("sdk", "install", "swift")).
+        wsk.cli(Seq("-i", "sdk", "install", "swift")).
             stdout should include("Swift SDK coming soon.")
     }
 

--- a/tools/cli/wsk
+++ b/tools/cli/wsk
@@ -67,7 +67,7 @@ def main():
         if (args.verbose):
             print props
         if apihost is None and (args.cmd != 'property' or args.cmd == 'property' and args.subcmd != 'set'):
-            print 'error: API host is not set. Set it with "wsk property set --apihost <host>".'
+            print >> sys.stderr, 'error: API host is not set. Set it with "wsk property set --apihost <host>".'
             return 2
 
         exitCode = {
@@ -100,6 +100,7 @@ def parseArgs(props):
 
     parser.add_argument('--apihost', help='whisk API host', dest='apihostOverride', metavar='hostname')
     parser.add_argument('--apiversion', help='whisk API version', dest='apiversionOverride', metavar='version')
+    parser.add_argument('-i', '--insecure', help='reserved command option', action='store_true')
 
     Action().getCommands(subparsers, props)
     Activation().getCommands(subparsers, props)
@@ -163,7 +164,7 @@ def propCmd(args, props, userprops, propsLocation):
             else:
                 auth = userprops.get('AUTH')
             if auth is None:
-                print 'error: cannot set namespace without an authentication key'
+                print >> sys.stderr, 'error: cannot set namespace without an authentication key'
                 return 1
             res = request('GET', url, auth=auth, verbose=args.verbose)
             namespaces = None
@@ -182,7 +183,7 @@ def propCmd(args, props, userprops, propsLocation):
                         wskprop.updateProps('NAMESPACE', '%s' % choice, propsLocation)
                         print 'ok: namespace set to %s' % choice
                         return 0
-                print 'error: you are either not entitled to a namespace or you made an invalid choice'
+                print >> sys.stderr, 'error: you are either not entitled to a namespace or you made an invalid choice'
                 return 1
             else:
                 return responseError(res)

--- a/tools/cli/wskaction.py
+++ b/tools/cli/wskaction.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import sys
 import os
 import json
 import base64
@@ -102,9 +103,9 @@ class Action(Item):
             return self.put(args, props, update, json.dumps(payload))
         else:
             if not args.copy:
-                print 'the artifact "%s" is not a valid file. If this is a docker image, use --docker.' % args.artifact
+                print >> sys.stderr, 'the artifact "%s" is not a valid file. If this is a docker image, use --docker.' % args.artifact
             else:
-                print 'the action "%s" does not exit, is malformed, or your are not entitled to it.' % args.artifact
+                print >> sys.stderr, 'the action "%s" does not exit, is malformed, or your are not entitled to it.' % args.artifact
             return 2
 
     def invoke(self, args, props):

--- a/tools/cli/wskutil.py
+++ b/tools/cli/wskutil.py
@@ -103,31 +103,31 @@ def request(method, urlString, body = '', headers = {}, auth = None, verbose = F
 
 def responseError(res, prefix = 'error:', flatten = True):
     if prefix:
-        print prefix,
+        print >> sys.stderr, prefix,
     response = None
     try:
         response = res.read()
         result = json.loads(response)
         if 'error' in result and 'code' in result:
-            print '%s (code %s)' % (result['error'], result['code'])
+            print >> sys.stderr, '%s (code %s)' % (result['error'], result['code'])
         elif 'error' in result and flatten:
-            print result['error']
+            print >> sys.stderr, result['error']
         else:
-            print getPrettyJson(result)
+            print >> sys.stderr, getPrettyJson(result)
     except:
         if res.status == 502:
-            print 'connection failed or timed out'
+            print >> sys.stderr, 'connection failed or timed out'
         elif isinstance(res, collections.Iterable):
             if 'read' in res:
-                print res.read()
+                print >> sys.stderr,  res.read()
             elif 'error' in res:
-                print res['error']
+                print >> sys.stderr,  res['error']
             else:
-                print 'unrecognized failure'
+                print >> sys.stderr, 'unrecognized failure'
         elif response is not None:
-            print response
+            print >> sys.stderr, response
         else:
-            print 'unrecognized failure'
+            print >> sys.stderr,  'unrecognized failure'
     return res.status
 
 # creates [ { key: "key name", value: "the value" }* ] from annotations.

--- a/tools/go-cli/go-whisk-cli/main.go
+++ b/tools/go-cli/go-whisk-cli/main.go
@@ -66,7 +66,8 @@ func main() {
             exitCode = werr.ExitCode
         } else {
             whisk.Debug(whisk.DbgError, "Got some other error - %s\n", err)
-            fmt.Printf("%s\n", err)
+            fmt.Fprintf(os.Stderr, "%s\n", err)
+
             displayUsage = false   // Cobra already displayed the usage message
             exitCode = 1;
         }
@@ -74,12 +75,13 @@ func main() {
         // If the err msg should be displayed to the console and it has not already been
         // displayed, display it now.
         if displayMsg && !msgDisplayed {
-            fmt.Println(err)
+            fmt.Fprintf(os.Stderr, "%s\n", err)
         }
 
+        // Displays usage
         if displayUsage {
-            fmt.Printf("Run '%v --help' for usage.\n", commands.WskCmd.CommandPath())
-        } // Displays usage
+            fmt.Fprintf(os.Stderr, "Run '%v --help' for usage.\n", commands.WskCmd.CommandPath())
+        }
     }
     os.Exit(exitCode)
     return


### PR DESCRIPTION
- Provides switches to run the Python CLI, or Go CLI against automated tests, and catalog installation