### PR TITLE
fix name clash for consul agents with ansible environments that have …

### DIFF
--- a/ansible/roles/consul/tasks/deploy.yml
+++ b/ansible/roles/consul/tasks/deploy.yml
@@ -22,7 +22,6 @@
 - name: (re)start consul server/agent
   docker:
     name: consul
-    hostname: "consul{{play_hosts.index(inventory_hostname)}}"
     image: "{{ docker_registry }}whisk/consul:{{ docker_image_tag }}"
     state: reloaded
     command: /bin/consul agent -config-file=/consul/config/config.json 

--- a/ansible/roles/consul/templates/config.json.j2
+++ b/ansible/roles/consul/templates/config.json.j2
@@ -22,6 +22,7 @@
     "data_dir": "/consul/data",
     "ui_dir": "/consul/ui",
     "log_level": "WARN",
+    "node_name": "{{ ansible_host | default(inventory_hostname) }}",
     "client_addr": "0.0.0.0",
     "advertise_addr": "{{ ansible_host | default(inventory_hostname) }}",
     "ports": {


### PR DESCRIPTION
…multiple groups

We encountered a problem with the naming schema for consul nodes.
With the recently introduced host groups "core" and "shared", we are now in the situation where a consul agent can be in two different groups, each of which have indices 0...n so consul agents of group "core" with index 0 and "invoker" with index 0 will end up both having the consul node name of "consul0". 

This clash can lead to confusion and hiccups in the gossip protocol and should be avoided.

This PR removes the clash by inserting the actual IP of the docker host as the consul agent node name. This also makes it easier to find out which service runs on which host.