### PR TITLE
[Ready] Add hotswap capability to components and shortcuts for most build steps.

### DIFF
--- a/config/writePropertyFile.sh
+++ b/config/writePropertyFile.sh
@@ -11,10 +11,10 @@ WHISK_CONFIG_NAME=`echo $WHISK_CONFIG_NAME | sed -e 's/Env.sh//'`
 # Where am I? Get config.
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-OPENWHISK_HOME="$(dirname $DIR)"
+OPENWHISK_HOME=$(dirname "$DIR")
 
 # Get root project directory
-WHISK_HOME="$(dirname "$DIR")"
+WHISK_HOME=$(dirname "$DIR")
 rm -f "$WHISK_HOME/whisk.properties"
 
 touch "$WHISK_HOME/whisk.properties"

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import argparse
+import shlex
+import subprocess
+
+# the default openwhisk location in openwhisk checkouts
+defaultOpenwhisk = os.path.dirname(os.path.realpath(__file__)) + '/../../'
+# the openwhisk env var overrides if it exists
+openwhiskHome = os.getenv('OPENWHISK_HOME', defaultOpenwhisk)
+cliDir = os.path.join(openwhiskHome, 'tools/cli')
+sys.path.insert(1, cliDir)
+import wskprop
+
+def main():
+    args = getArgs()
+
+    if (not args.build and
+        not args.teardown and
+        not args.deploy):
+        args.build = True
+        args.teardown = True
+        args.deploy = True
+
+    # args.dir is either explicitly set or default to openwhisk home per environment
+    wskhome = args.dir
+    # change to wsk home to use build/deploy scripts
+    os.chdir(wskhome)
+
+    props = {}
+    props['ENV'] = args.target
+    props['WSK_HOME'] = wskhome
+    props['MAIN_DOCKER_ENDPOINT'] = getDockerHost()
+
+    for c in args.component:
+        component = getComponent(c)
+        if not component:
+            print 'unknown component %s' % c
+            exit(1)
+        else:
+            doOne(component, args, props)
+
+def getArgs():
+    parser = argparse.ArgumentParser(description='[re]build and [re]deploy a whisk component if no args are given, otherwise do what is instructed')
+    parser.add_argument('-b', '--build', help='build component', action='store_const', const=True, default=False)
+    parser.add_argument('-x', '--teardown', help='teardown component', action='store_const', const=True, default=False)
+    parser.add_argument('-d', '--deploy', help='deploy component', action='store_const', const=True, default=False)
+    parser.add_argument('-t', '--target', help='deploy target', default='mac')
+    parser.add_argument('-n', '--just-print', help='prints the component configuration but does not run any targets', action='store_const', const=True, default=False, dest='skiprun')
+    parser.add_argument('-c', '--list-components', help='list known component names and exit', action='store_const', const=True, default=False, dest='list')
+    parser.add_argument('component', nargs = '*', help='component name')
+    parser.add_argument('--dir', help='whisk home directory')
+
+    args = parser.parse_args()
+
+    if args.dir is None:
+        if openwhiskHome is None:
+            print 'Must specify whisk home directory with --dir'
+            exit(-1)
+        else:
+            args.dir = openwhiskHome
+
+    if args.list:
+        print "{:<27}{:<40}".format(bold('component'), bold('description'))
+        for c in Components:
+            print "{:<30}{:<40}".format(hilite(c['name']), c['description'])
+        exit(0)
+    elif not args.component:
+        parser.print_usage()
+        exit(0)
+    else:
+        return args
+
+class Playbook:
+    cmd = 'ansible-playbook'
+        
+    dir = False
+    file = False
+    modes = False
+    env = False
+
+    # dir: the ansible directory containing the yaml files, roles, etc.
+    # file: the yml file for the playbook
+    # modes: the modes supported for the playbook as a comma separated string (e.g., 'clean')
+    # env: the environments directory (e.g., 'environment) or None if not environment specific playbook 
+    def __init__(self, dir, file, modes, env):
+        self.dir = dir
+        self.file = file
+        self.modes = modes.split(',')
+        self.env = env
+    
+    def path(self, basedir):
+        return basedir + '/' + self.dir
+
+    def execcmd(self, props, mode = False):
+        if self.dir and self.file and (mode in self.modes or mode is False):
+            cmd = [ self.cmd ]
+            if self.env:
+                cmd.append('-i %s/%s' % (self.env, props['ENV']))
+            cmd.append(self.file)
+            if mode:
+                cmd.append('-e mode=%s' % mode)
+            return ' '.join(cmd)
+
+class Gradle:
+    cmd = 'gradlew'
+
+    tasks = False
+    components = False
+
+    def __init__(self, tasks, components = False):
+        self.tasks = tasks.split(',')
+        self.components = components
+
+    def execcmd(self, props, task):
+        if task:
+            if self.components and self.components is not True:
+                parts = map(lambda c: '%s:%s' % (c, task), self.components.split(','))
+                parts = ' '.join(parts)
+            else:
+                parts = task
+
+            dh = props['MAIN_DOCKER_ENDPOINT']
+            return '%s %s --parallel %s' % (
+                   props['WSK_HOME'] + '/' + self.cmd,
+                   parts,
+                   ('-PdockerHost=%s' % dh) if dh else '')
+
+def getDockerHost():
+    dh = os.getenv('DOCKER_HOST')
+    if dh is not None and dh.startswith('tcp://'):
+        return dh[6:]
+
+def makeComponent(name,                   # component name, implies playbook default and gradle tasks roots
+                  description,
+                  yaml = True,            # true for default file name else the file name
+                  modes = '',
+                  env = 'environments',
+                  dir = 'ansible',
+                  gradle = False,         # gradle buildable iff true
+                  tasks = 'distDocker'):
+    yaml = ('%s.yml' % name) if yaml is True else yaml
+    playbook = Playbook(dir, yaml, modes, env) if yaml is not False else None
+    gradle = Gradle(tasks, gradle) if gradle is not False else None
+    return { 'name': name, 'description': description, 'playbook': playbook, 'gradle': gradle }
+    
+Components = [ 
+    makeComponent('setup',
+                  'system setup',
+                  env = False),
+
+    makeComponent('prereq',
+                  'install requisites'),
+
+    makeComponent('couchdb',
+                  'deploy couchdb',
+                  modes = 'clean'),
+
+    makeComponent('initdb',
+                  'initialize db with guest/system keys'),
+
+    makeComponent('wipedb',
+                  'recreate main db for entities',
+                  yaml = 'wipe.yml'),
+
+    makeComponent('deploy',
+                  'deploy system',
+                  yaml = 'openwhisk.yml',
+                  modes = 'clean',
+                  gradle = True),
+
+    makeComponent('consul',
+                  'build/deploy consul (includes registrator)',
+                  modes = 'clean',
+                  gradle = 'services:consul'),
+
+    makeComponent('kafka',
+                  'build/deploy kafka (includes zookeeper)',
+                  modes = 'clean',
+                  gradle = ':services:kafka, :services:zookeeper'),
+
+    makeComponent('controller',
+                  'build/deploy controller',
+                  modes = 'clean',
+                  gradle = 'core:controller'),
+
+    makeComponent('invoker',
+                  'build/deploy invoker',
+                  modes = 'clean',
+                  gradle = ':core:dispatcher'),
+
+    makeComponent('edge',
+                  'deploy edge',
+                  gradle = ':tools:cli',
+                  tasks = 'distTar'),
+
+    makeComponent('catalog',
+                  'install catalog',
+                  yaml = 'postDeploy.yml'),
+
+    # the following (re)build images via gradle
+    makeComponent('nodejsaction',
+                  'build node.js action container',
+                  yaml = False,
+                  gradle = 'core:nodejsAction'),
+
+    makeComponent('nodejs6action',
+                  'build node.js v6 action container',
+                  yaml = False,
+                  gradle = 'core:nodejs6Action'),
+
+    makeComponent('pythonaction',
+                  'build python action container',
+                  yaml = False,
+                  gradle = 'core:pythonAction'),
+
+    makeComponent('swiftaction',
+                  'build swift action container',
+                  yaml = False,
+                  gradle = 'core:swiftAction'),
+
+    makeComponent('swift3action',
+                  'build swift v3 action container',
+                  yaml = False,
+                  gradle = 'core:swift3Action'),
+
+    makeComponent('javaaction',
+                  'build java action container',
+                  yaml = False,
+                  gradle = 'core:javaAction'),
+
+    makeComponent('dockersdk',
+                  'build docker action SDK (to deploy, use edge component)',
+                  yaml = False,
+                  gradle = 'sdk:docker'),
+
+    makeComponent('zookeeper',
+                  'build zookeepr only (to deploy, use kakfa component)',
+                  yaml = False,
+                  gradle = ':services:zookeeper'),
+
+    makeComponent('cli',
+                  'build CLI (to deploy, use edge component)',
+                  yaml = False,
+                  gradle = ':tools:cli',
+                  tasks = 'distTar'),
+
+    # required for tests
+    makeComponent('props',
+                  'build whisk.properties file (required for tests)',
+                  yaml = 'properties.yml'),
+
+    # convenient to run all tests
+    makeComponent('tests',
+                  'run all tests',
+                  yaml = False,
+                  gradle = True,
+                  tasks = 'test')
+]
+
+def getComponent(component):
+    for c in Components:
+        if c['name'] == component:
+            return c
+    return False
+
+def bold(string):
+    if sys.stdin.isatty():
+        attr = []
+        attr.append('1')
+        return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), string)
+    else:
+        return string
+
+def hilite(string, isError = False):
+    if sys.stdin.isatty():
+        attr = []
+        attr.append('34' if not isError else '31')  # blue or red if isError
+        attr.append('1')
+        return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), string)
+    else:
+        return string
+
+def run(cmd, dir, skiprun, allowToFail = False):
+    if cmd is not None:
+        print hilite(cmd)
+        if not skiprun:
+            args = shlex.split(cmd)
+            p = subprocess.Popen(args, cwd = dir)
+            p.wait()
+            if p.returncode and not allowToFail:
+               abort('command failed', p.returncode)
+
+def runAndGetStdout(cmd):
+    print hilite(cmd)
+    args = shlex.split(cmd)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode:
+        print hilite(out)
+        print hilite(err, True)
+        abort('command failed', p.returncode)
+    return out
+
+def abort(msg, code = -1):
+    print hilite(msg, True)
+    exit(code)
+
+def doOne(component, args, props):
+    basedir = props['WSK_HOME']
+    playbook = component['playbook']
+    gradle = component['gradle']
+    print bold(component['description'])
+
+    if args.build and gradle is not None:
+        cmd = gradle.execcmd(props, gradle.tasks[0])
+        run(cmd, basedir, args.skiprun)
+
+    if args.teardown and playbook is not None:
+        cmd = playbook.execcmd(props, 'clean')
+        run(cmd, playbook.path(basedir), args.skiprun)
+
+    if args.deploy and playbook is not None:
+        cmd = playbook.execcmd(props)
+        run(cmd, playbook.path(basedir), args.skiprun)
+
+if __name__ == '__main__':
+    main()

--- a/tools/build/scanCode.py
+++ b/tools/build/scanCode.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import collections
 import fnmatch
 import itertools


### PR DESCRIPTION
Two scripts as syntactic sugar around gradle/ant/ansible with controller over individual component build/teardown/deploy management. (See note at the end, only of these may survive this pr.)

With the second commit, a deployment with couchdb will look like this:

### initialize environment and docker-machine (for mac)
`redo setup prereqs`

### start couchdb container and initialize db with system and guest keys
`redo couchdb initdb`

Could tie the two above steps together so that `redo couchdb` does both.

### deploy
`redo deploy`

and optionally to run tests
`redo props tests`

*Or* to do it all with one line for a first time run `redo setup prereqs couchdb initdb deploy tests` as each of these is executed sequentially

I called the script `redo` because for most development, one will want to "redo" the compilation and deployment of a unit as in `redo controller` which will `gradle` build the `controller`, teardown down the previous container and replace it with a new container.

To only build: `redo controller -b`.
To only teardown: `redo controller -x`.
To redeploy only: `redo controller -d`.
To do all at once: `redo controller -bxd` which is the default.

This script works just like `hotswap` but removes all `ant` dependencies. I am inclined to remove `hotswap` in favor of `redo` (so that only the first commit is dropped from this pr).

Note that with ansible, the teardown of the couchdb container no longer happens because it does not use the brute force `ant teardown` method (related to #548).

Lastly this is partially dependent on #605 (which includes the `initdb` role) and related to #581.

@lehoanganh @domdom82 