### PR TITLE
Make sequencing abstract

### DIFF
--- a/common/scala/src/whisk/core/entity/Pipecode.scala
+++ b/common/scala/src/whisk/core/entity/Pipecode.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+/**
+ * A copy of pipe.js code is here as we work on supporting
+ * sequencing as a first class entity.  Moving pipe.js
+ * into the system and out of the CLI moves us closer to
+ * the final abstraction.
+ */
+protected[core] object Pipecode {
+
+    val code = """
+/**
+ * Invokes a sequence of actions, piping the output of each to the input of the next.
+ *
+ * @param _actions An array of action names to invoke.
+ * @param <everything else> Passed as input to the first action.
+ */
+function main(msg) {
+    // The actions to invoke sequentially.
+    var actions = msg['_actions'];
+
+    if (typeof actions === 'string') {
+        try {
+            actions = JSON.parse(actions);
+        } catch (e) {
+            return whisk.error('invalid sequence of actions');
+        }
+    }
+
+    if (!Array.isArray(actions)) {
+        return whisk.error('invalid sequence of actions');
+    }
+
+    console.log(actions.length, 'actions to invoke:', actions);
+
+    // The input to the first action.
+    var input = msg;
+    delete input['_actions'];
+    console.log('input to first action:', JSON.stringify(input));
+    invokeActions(actions, input, function(result) {
+        console.log('chain ending with result', JSON.stringify(result));
+        whisk.done(result);
+    });
+
+    return whisk.async();
+}
+
+/**
+ * Invokes a sequence of actions.
+ *
+ * @param actions Array of action names.
+ * @param input Input to the first action.
+ * @param terminate Continuation to which the result from the final successful action is passed.
+ */
+function invokeActions(actions, input, terminate) {
+    if (Array.isArray(actions) && actions.length > 0) {
+        var params = {
+           name: actions[0],
+           parameters: input,
+           blocking: true,
+           next: function(error, activation) {
+               if (!error) {
+                   console.log('invoke action', actions[0]);
+                   console.log('  id:', activation.activationId);
+                   console.log('  input:', input);
+                   console.log('  result:', activation.result);
+                   actions.shift();
+                   invokeActions(actions, activation.result, terminate);
+               } else {
+                   console.log('stopped chain at', actions[0], 'because of an error:', error);
+                   whisk.error(error);
+               }
+           }
+        };
+        whisk.invoke(params);
+    } else terminate(input);
+}
+"""
+
+}

--- a/common/scala/src/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/whisk/core/entity/WhiskAction.scala
@@ -103,6 +103,16 @@ case class WhiskAction(
      */
     def containerImageName(registry: String = null, tag: String = "latest") = WhiskAction.containerImageName(exec, registry, tag)
 
+    private def getNodeInitializer(code: String, optInit: Option[String]): JsObject = {
+        val init = JsObject(
+            "name" -> name.toJson,
+            "main" -> JsString("main"),
+            "code" -> JsString(code))
+        optInit map { lib =>
+            JsObject(init.fields + "lib" -> lib.toJson)
+        } getOrElse init
+    }
+
     /**
      * Gets initializer for action.
      * If the action is a black box action, return an empty initializer since
@@ -110,48 +120,28 @@ case class WhiskAction(
      * { name, main, code, lib } required to run the action.
      */
     def containerInitializer: JsObject = exec match {
-        case NodeJSExec(code, optInit) =>
-            val init = JsObject(
-                "name" -> name.toJson,
-                "main" -> JsString("main"),
-                "code" -> JsString(code))
-            optInit map { lib =>
-                JsObject(init.fields + "lib" -> lib.toJson)
-            } getOrElse init
-
+        case NodeJSExec(code, optInit)  => getNodeInitializer(code, optInit)
+        case NodeJS6Exec(code, optInit) => getNodeInitializer(code, optInit)
+        case SequenceExec(code, components) => getNodeInitializer(code, None)
         case SwiftExec(code) =>
             JsObject(
                 "name" -> name.toJson,
                 "code" -> code.toJson)
-
         case PythonExec(code) =>
             JsObject(
                 "name" -> name.toJson,
                 "code" -> code.toJson)
-
         case JavaExec(jar, main) =>
             JsObject(
                 "name" -> name.toJson,
                 "jar" -> jar.toJson,
                 "main" -> main.toJson)
-
         case Swift3Exec(code) =>
             JsObject(
                 "name" -> name.toJson,
                 "code" -> code.toJson)
-
-        case NodeJS6Exec(code, optInit) =>
-            val init = JsObject(
-                "name" -> name.toJson,
-                "main" -> JsString("main"),
-                "code" -> JsString(code))
-            optInit map { lib =>
-                JsObject(init.fields + "lib" -> lib.toJson)
-            } getOrElse init
-
         case _: BlackBoxExec =>
             JsObject()
-
     }
 
     def toJson = WhiskAction.serdes.write(this).asJsObject
@@ -167,7 +157,7 @@ object WhiskAction
 
     def containerImageName(exec: Exec, registry: String = null, tag: String = "latest"): String = {
         exec match {
-            case _: NodeJSExec | _: NodeJS6Exec | _: PythonExec | _: SwiftExec | _: Swift3Exec | _: JavaExec =>
+            case _: NodeJSExec | _: SequenceExec | _: NodeJS6Exec | _: PythonExec | _: SwiftExec | _: Swift3Exec | _: JavaExec =>
                 Option(registry).filter { _.nonEmpty }.map { r =>
                     val prefix = if (r.endsWith("/")) r else s"$r/"
                     s"${prefix}${exec.image}:${tag}"

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -47,8 +47,7 @@ import spray.json.DefaultJsonProtocol.RootJsObjectFormat
 import spray.json.DefaultJsonProtocol.mapFormat
 import spray.json.DefaultJsonProtocol.JsValueFormat
 import spray.json.RootJsonFormat
-import spray.json.JsString
-import spray.json.JsObject
+import spray.json.{ JsArray, JsObject, JsString }
 import spray.json.pimpString
 import spray.json.pimpAny
 import whisk.common.ConsulKV
@@ -62,10 +61,10 @@ import whisk.core.entity.ActivationId
 import whisk.core.entity.DocId
 import whisk.core.entity.DocInfo
 import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
+import whisk.core.entity.{Exec, SequenceExec}
 import whisk.core.entity.MemoryLimit
 import whisk.core.entity.Namespace
-import whisk.core.entity.Parameters
+import whisk.core.entity.{ Parameters, ParameterName, ParameterValue }
 import whisk.core.entity.SemVer
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.WhiskAction
@@ -347,17 +346,26 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
     /** Creates a WhiskAction from PUT content, generating default values where necessary. */
     private def make(content: WhiskActionPut, namespace: Namespace, name: EntityName)(implicit transid: TransactionId) = {
         if (content.exec.isDefined) Future successful {
+            val exec = content.exec.get
             val limits = content.limits map { l =>
                 ActionLimits(
                     l.timeout getOrElse TimeLimit(),
                     l.memory getOrElse MemoryLimit())
             } getOrElse ActionLimits()
 
+            /* This is temporary while we are making sequencing directly supported in the controller.
+             * The parameter override allows this to work with Pipecode.code
+             */
+            val parameters = exec match {
+                case seqExec: SequenceExec => Parameters("_actions", JsArray(seqExec.components map { JsString(_) }))
+                case _ => content.parameters getOrElse Parameters()
+            }
+
             WhiskAction(
                 namespace,
                 name,
-                content.exec.get, // do NOT create a default exec
-                content.parameters getOrElse Parameters(),
+                exec,
+                parameters,
                 limits,
                 content.version getOrElse SemVer(),
                 content.publish getOrElse false,


### PR DESCRIPTION
Remove CLI manual use of pipe.js and use of parameters and use a new sequence kind and components field.

Use SequenceExec for sequences but with a NodejsExec-like implementation for now where the compoments meta-data is converted to parameters.