### PR TITLE
fix gateway timeout to controller 

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -37,6 +37,7 @@ http {
         }
         location /api/v1 {
             proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+            proxy_read_timeout 310s;
         }
         location /openwhisk-0.1.0.tar.gz {
             root /etc/nginx;


### PR DESCRIPTION
Fix gateway timeout to controller - wait up 5 minutes which is max allowed action duration.