### PR TITLE
Issue #584: Pin Go CLI dependency versions via godep

### DIFF
--- a/tools/go-cli/Dockerfile
+++ b/tools/go-cli/Dockerfile
@@ -2,22 +2,38 @@ FROM golang:1.6
 
 ADD . /src/github.com/
 
+# The BUILDTIME argument is used as the CLI build time property (wsk property get --all)
 ARG BUILDTIME
 
+# Download and install the godep tool
+RUN echo "Installing the godep tool"
+ENV GOPATH=/
+RUN go get github.com/tools/godep
+
+# Load all of the dependencies from the previously generated/saved godep generated godeps.json file
+RUN echo "Restoring Go dependencies"
+RUN cd /src/github.com/go-whisk-cli && /bin/godep restore -v
+
+# Generate a Go package dependency list
+# NOTE: Currently, the 'go list' command will not work against the current Go CLI non-standard file structure
+#RUN cd /src/github.com/go-whisk-cli && go list -f '{{join .Deps "\n"}}' > ../../../wsk.deps.out
+RUN cd /src/github.com/go-whisk-cli && echo "Dependencies list requires restructuring the GO CLI packages" > ../../../wsk.deps.out
+
+# Build the Go wsk CLI binaries
 ENV GOOS=windows
 ENV EXEC=wsk.exe
 ENV ARCHS="386 amd64"
 
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go get -d -v && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go; done
+RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go; done
 
 ENV GOOS=darwin
 ENV ARCHS="386 amd64 arm arm64"
 ENV EXEC=wsk
 
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go get -d -v && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/wsk main.go; done
+RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/$EXEC main.go; done
 
 ENV GOOS=linux
 ENV ARCHS="386 amd64 arm arm64 ppc64 ppc64le mips64 mips64le"
 ENV EXEC=wsk
 
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go get -d -v && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/wsk main.go; done
+RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go; done

--- a/tools/go-cli/go-whisk-cli/Godeps/Godeps.json
+++ b/tools/go-cli/go-whisk-cli/Godeps/Godeps.json
@@ -1,0 +1,52 @@
+{
+	"ImportPath": "go-whisk-cli",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v74",
+	"Packages": [
+		"go-whisk-cli"
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/fatih/color",
+			"Comment": "v0.1-19-g87d4004",
+			"Rev": "87d4004f2ab62d0d255e0a38f1680aa534549fe3"
+		},
+		{
+			"ImportPath": "github.com/google/go-querystring/query",
+			"Rev": "9235644dd9e52eeae6fa48efd539fdc351a0af53"
+		},
+		{
+			"ImportPath": "github.com/hokaccha/go-prettyjson",
+			"Rev": "f75235bd99dad4e98ff360db8372d5c0ef1d054a"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+		},
+		{
+			"ImportPath": "github.com/mattn/go-colorable",
+			"Comment": "v0.0.5",
+			"Rev": "9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59"
+		},
+		{
+			"ImportPath": "github.com/mattn/go-isatty",
+			"Rev": "56b76bdf51f7708750eac80fa38b952bb9f32639"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/go-homedir",
+			"Rev": "1111e456ffea841564ac0fa5f69c26ef44dafec9"
+		},
+		{
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "1238ba19d24b0b9ceee2094e1cb31947d45c3e86"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "367864438f1b1a3c7db4da06a2f55b144e6784e0"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "7f918dd405547ecb864d14a8ecbbfe205b5f930f"
+		}
+	]
+}

--- a/tools/go-cli/go-whisk-cli/Godeps/Readme
+++ b/tools/go-cli/go-whisk-cli/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.


### PR DESCRIPTION
See issue #584
- Check in the godeps json snapshot of the CLI Go dependencies
  NOTE: This was generated via 'godep save' and had to be manually tweaked
        due to the current file structure not following Go best practices.
- Update the Go CLI build to
  1. Install godeps dynamically
  2. Use godeps to install the dependencies at the version specified in the godep json
  3. Remove the existing 'go get' command which is no longer needed (replaced by 'godep restore'