### PR TITLE
[Ready] Replaced ConsulKV by ConsulClient in Entitlement

### DIFF
--- a/common/scala/src/whisk/common/ConsulClient.scala
+++ b/common/scala/src/whisk/common/ConsulClient.scala
@@ -17,7 +17,6 @@
 package whisk.common
 
 import scala.annotation.implicitNotFound
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.language.postfixOps
 
@@ -53,9 +52,9 @@ object ConsulEntry extends DefaultJsonProtocol {
  * Client to access Consul's <a href="https://www.consul.io/docs/agent/http/kv.html">
  * key/value store</a>
  */
-class ConsulClient(host: String)(
-    implicit val actorSystem: ActorSystem,
-    val executionContext: ExecutionContext) {
+class ConsulClient(host: String)(implicit val actorSystem: ActorSystem) {
+
+    private implicit val executionContext = actorSystem.dispatcher
 
     private val kv = Path("/v1/kv")
 

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -53,8 +53,6 @@ import spray.json.JsObject
 import spray.json.pimpString
 import spray.json.pimpAny
 import spray.routing.RequestContext
-import whisk.common.ConsulKV
-import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.LoggingMarkers
 import whisk.common.LoggingMarkers._
 import whisk.common.TransactionId

--- a/core/controller/src/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/whisk/core/entitlement/LocalEntitlement.scala
@@ -16,8 +16,9 @@
 
 package whisk.core.entitlement
 
+import akka.actor.ActorSystem
+
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import whisk.common.TransactionId
@@ -31,8 +32,10 @@ private object LocalEntitlementService {
 
 protected[core] class LocalEntitlementService(
     private val config : WhiskConfig)
-    (implicit ec: ExecutionContext)
+    (implicit actorSystem: ActorSystem)
     extends EntitlementService(config) {
+
+    private implicit val executionContext = actorSystem.dispatcher
 
     private val matrix = LocalEntitlementService.matrix
 

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -72,14 +72,16 @@ protected trait ControllerTestCommon
     override val actorRefFactory = null
     implicit val routeTestTimeout = RouteTestTimeout(90 seconds)
 
+    implicit val actorSystem = ActorSystem("controllertests")
+
     val config = new WhiskConfig(WhiskActionsApi.requiredProperties)
     assert(config.isValid)
 
     val entityStore = WhiskEntityStore.datastore(config)
     val activationStore = WhiskActivationStore.datastore(config)
     val authStore = WhiskAuthStore.datastore(config)
-    val entitlementService: EntitlementService = new LocalEntitlementService(config)(executionContext)
-    val actorSystem = ActorSystem("controllertests")
+    val entitlementService: EntitlementService = new LocalEntitlementService(config)
+
     val activationId = ActivationId() // need a static activation id to test activations api
     val performLoadBalancerRequest = (lbr: WhiskServices.LoadBalancerReq) => Future {
         LoadBalancerResponse.id(activationId)


### PR DESCRIPTION
Also replaces the infinite-polling thread by a `Scheduler`-produced actor.

Other assorted changes, such as pushing `ActorContext` implicit arguments throughout the system, and removing implicit `ExecutionContext` args when it can be obtained from the `ActorSystem`.

After this change, there is still a use of `ConsulKV` in `Config`, but it's once, at construction time only. (There are other uses in the invoker, still.)

This mimics the work done in 349da264f7b9def36b0d7dc189ad7170082e8dc1.