### PR TITLE
Go CLI binary file compression

### DIFF
--- a/tools/go-cli/Dockerfile
+++ b/tools/go-cli/Dockerfile
@@ -5,6 +5,10 @@ ADD . /src/github.com/
 # The BUILDTIME argument is used as the CLI build time property (wsk property get --all)
 ARG BUILDTIME
 
+# Install zip
+RUN apt-get -y update && \
+    apt-get -y install zip
+
 # Download and install the godep tool
 RUN echo "Installing the godep tool"
 ENV GOPATH=/
@@ -23,17 +27,30 @@ RUN cd /src/github.com/go-whisk-cli && echo "Dependencies list requires restruct
 ENV GOOS=windows
 ENV EXEC=wsk.exe
 ENV ARCHS="386 amd64"
-
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go; done
+RUN for GOARCH in $ARCHS; do \
+      cd /src/github.com/go-whisk-cli && \
+      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
+      zip $GOOS/$GOARCH/openwhisk-win-$GOARCH.zip $GOOS/$GOARCH/$EXEC; \
+    done
 
 ENV GOOS=darwin
 ENV ARCHS="386 amd64 arm arm64"
 ENV EXEC=wsk
-
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/$EXEC main.go; done
+RUN for GOARCH in $ARCHS; do \
+      cd /src/github.com/go-whisk-cli && \
+      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/$EXEC main.go && \
+      tar -cf mac/$GOARCH/openwhisk-mac-$GOARCH.tar mac/$GOARCH/$EXEC && \
+      gzip < mac/$GOARCH/openwhisk-mac-$GOARCH.tar > mac/$GOARCH/openwhisk-mac-$GOARCH.tar.gz && \
+      rm -f mac/$GOARCH/openwhisk-mac-$GOARCH.tar; \
+    done
 
 ENV GOOS=linux
 ENV ARCHS="386 amd64 arm arm64 ppc64 ppc64le mips64 mips64le"
 ENV EXEC=wsk
-
-RUN for GOARCH in $ARCHS; do cd /src/github.com/go-whisk-cli && go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go; done
+RUN for GOARCH in $ARCHS; do \
+      cd /src/github.com/go-whisk-cli && \
+      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
+      tar -cf $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar $GOOS/$GOARCH/$EXEC && \
+      gzip < $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar > $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar.gz && \
+      rm -f $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar; \
+    done

--- a/tools/go-cli/build.xml
+++ b/tools/go-cli/build.xml
@@ -35,15 +35,18 @@
 
         <!-- Copy binary into open/bin -->
         <delete dir="${openwhisk.home}/bin/go-cli" failonerror="false" />
+        <!-- Copy the Windows Go CLI binaries -->
         <mkdir dir="${openwhisk.home}/bin/go-cli" />
         <exec executable="docker" failonerror="true">
             <arg line="${docker.tls.cmd}" />
             <arg line="cp go-cli:/src/github.com/go-whisk-cli/windows '${openwhisk.home}/bin/go-cli/windows'" />
         </exec>
+        <!-- Copy the Mac Go CLI binaries -->
         <exec executable="docker" failonerror="true">
             <arg line="${docker.tls.cmd}" />
             <arg line="cp go-cli:/src/github.com/go-whisk-cli/mac '${openwhisk.home}/bin/go-cli/mac'" />
         </exec>
+        <!-- Copy the Linux Go CLI binaries -->
         <exec executable="docker" failonerror="true">
             <arg line="${docker.tls.cmd}" />
             <arg line="cp go-cli:/src/github.com/go-whisk-cli/linux '${openwhisk.home}/bin/go-cli/linux'" />
@@ -52,6 +55,7 @@
             <arg line="${docker.tls.cmd}" />
             <arg line="rm -f go-cli" />
         </exec>
+        
     </target>
 
 </project>


### PR DESCRIPTION
Compress Go CLi binaries for faster downloads.  See #577

For all architectures:
Windows: wsk.exe -> wsk.exe.zip
Mac:     wsk     -> wsk.tar.gz
Linux:   wsk     -> wsk.tar.gz
