### PR TITLE
Add issue template to repository

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. If there is a duplicate, please close your issue and add a comment
+to the existing issue.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the information shown below.
+
+For more information about reporting issues, see
+https://github.com/openwhisk/openwhisk/blob/master/CONTRIBUTING.md#raising-issues
+
+
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a feature request
+-->
+> note: obfuscate all passwords, credentials or other confidential information
+
+## Environment details:
+
+* local deployment, vagrant, native ubuntu, Mac OS, Bluemix, ...   
+* version of docker, vagrant, ubuntu, ...
+
+## Steps to reproduce the issue:
+
+1.   
+2.   
+3.   
+
+
+## Provide the expected results and outputs:
+
+```
+output comes here
+```
+
+
+## Provide the actual results and outputs:
+
+```
+output comes here
+```
+
+## Additional information you deem important:
+* issue happens only occasionally or under certain circumstances   
+* changes you did or observed in the environment


### PR DESCRIPTION
This PR adds an issue template for github to the repository which provides a clear structure how a good issue should look like. 

It is located in the `.github` folder, find more information on GitHub templates over [here](https://github.com/blog/2111-issue-and-pull-request-templates).

