### PR TITLE
[Ready] Series of doc updates 

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -235,8 +235,8 @@ This example invokes a Yahoo Weather service to get the current conditions at a 
   ```
     var request = require('request');
     
-    function main(msg) {
-        var location = msg.location || 'Vermont';
+    function main(params) {
+        var location = params.location || 'Vermont';
         var url = 'https://query.yahooapis.com/v1/public/yql?q=select item.condition from weather.forecast where woeid in (select woeid from geo.places(1) where text="' + location + '")&format=json';
     
         request.get(url, function(error, response, body) {
@@ -338,8 +338,8 @@ An action is simply a top-level Python function, which means it is necessary to 
 
 ```
     def main(dict):
-        name = dict.get("name", “stranger")
-        greeting = "Hello " + name + “!"
+        name = dict.get("name", "stranger")
+        greeting = "Hello " + name + "!"
         print(greeting)
         return {"greeting": greeting}
 ```

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -513,14 +513,13 @@ The `/whisk.system/github/webhook` feed configures a service to fire a trigger w
 - `username`: The username of the GitHub repository.
 - `repository`: The GitHub repository.
 - `accessToken`: Your GitHub personal access token. When you [create your token](https://github.com/settings/tokens), be sure to select the repo:status and public_repo scopes. Also, make sure you don't have any Webhooks already defined for your repository.
-- `events`: The [GitHub activity type](https://developer.github.com/v3/activity/events/types/) of interest.
+- `events`: The [GitHub event type](https://developer.github.com/v3/activity/events/types/) of interest.
 
 The following is an example of creating a trigger that will be fired each time that there is a new commit to a GitHub repository.
 
 1. Generate a GitHub [personal access token](https://github.com/settings/tokens).
 
-  The access token will be used in the next step.
-
+   The access token will be used in the next step.
 
 2. Create a package binding configured for your GitHub respository and with your accesss token.
 
@@ -533,3 +532,7 @@ The following is an example of creating a trigger that will be fired each time t
   ```
   $ wsk trigger create myGitTrigger --feed myGit/webhook --param events push
   ```
+
+A commit to the Github repository via a git push will cause the trigger to be fired by the webhook. If there is a rule that matches the trigger, then the associated action will be invoke. 
+The action receives the Github webhook payload as an input parameter. Each Github webhook event has a similar JSON schema, but a unique payload object that is determined by its event type.
+For more information on the payload content see the [Github events and payload](https://developer.github.com/v3/activity/events/types/) API documentation.

--- a/docs/mobile_sdk.md
+++ b/docs/mobile_sdk.md
@@ -51,6 +51,13 @@ To install the starter app example, enter the following command:
 wsk sdk install iOS
 ```
 
+This will download a zip file containing the starter app. Inside the project directory there is a Podfile. 
+
+To install the SDK, enter the following command:
+```
+pod install
+``` 
+
 ## Getting started with the SDK
 
 To get up and running quickly, create a WhiskCredentials object with your OpenWhisk API credentials and create an OpenWhisk instance from that.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -30,9 +30,9 @@ examples of the fully qualified names of a number of entities and their aliases.
 
 | Fully qualified name | Alias | Namespace | Package | Name |
 | --- | --- | --- | --- | --- |
-| `/whisk.system/cloudant/read` | - | `/whisk.system` | `cloudant` | `read` |
+| `/whisk.system/cloudant/read` |  | `/whisk.system` | `cloudant` | `read` |
 | `/myOrg/video/transcode` | `video/transcode` | `/myOrg` | `video` | `transcode` |
-| `/myOrg/filter` | `filter` | `/myOrg` | - | `filter` |
+| `/myOrg/filter` | `filter` | `/myOrg` |  | `filter` |
 
 You will be using this naming scheme when you use the OpenWhisk CLI, among other places.
 
@@ -226,7 +226,7 @@ The `whisk.getAuthKey()` function returns the authorization key under which the 
 
 ### Runtime environment
 
-JavaScript actions are executed in a Node.js version 0.12.9 environment with the following packages available to be used by the action:
+JavaScript actions are executed in a Node.js version 0.12.14 environment with the following packages available to be used by the action:
 
 - apn
 - async
@@ -287,25 +287,30 @@ All the capabilites in the system are available through a REST API. There are co
 
 These are the collection endpoints:
 
-- `https://$BASEURL/api/v1/namespaces`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/actions`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/triggers`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/rules`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/packages`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/activations`
+- `https://{BASE URL}/api/v1/namespaces`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/actions`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/triggers`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/rules`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/packages`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/activations`
+
+The `{BASE URL}` is the OpenWhisk API hostname (i.e. openwhisk.ng.bluemix.net, 172.17.0.1, etc..)
+
+For the `{namespace}` the character `_` can be use to specify the user's *default
+namespace* (i.e. email address)
 
 You can perform a GET request on the collection endpoints to fetch a list of entites in the collection.
 
 There are entity endpoints for each type of entity:
 
-- `https://$BASEURL/api/v1/namespaces/{namespace}`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/actions/[{packageName}/]{actionName}`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/triggers/{triggerName}`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/rules/{ruleName}`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/packages/{packageName}`
-- `https://$BASEURL/api/v1/namespaces/{namespace}/activations/{activationName}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/actions/[{packageName}/]{actionName}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/triggers/{triggerName}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/rules/{ruleName}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/packages/{packageName}`
+- `https://{BASE URL}/api/v1/namespaces/{namespace}/activations/{activationName}`
 
-The namespace and activation endpoints only support GET requests. The actions, triggers, rules and packages endpoints support GET, PUT and DELETE requests. The endpoints of actions, triggers and rules also support POST requests, which are used to invoke actions and triggers and enable or disable rules. Refer to the [API reference](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/openwhisk/openwhisk/master/core/controller/src/resources/whiskswagger.json) for details.
+The namespace and activation endpoints only support GET requests. The actions, triggers, rules and packages endpoints support GET, PUT and DELETE requests. The endpoints of actions, triggers and rules also support POST requests, which are used to invoke actions and triggers and enable or disable rules. Refer to the [API reference](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/openwhisk/openwhisk/master/core/controller/src/main/resources/whiskswagger.json) for details.
 
 All APIs are protected with HTTP Basic authentication. The Basic auth credentials are in the `AUTH` property in your `~/.wskprops` file, delimited by a colon. You can also retrieve these credentials in the [CLI configuration steps](../README.md#setup-cli).
 
@@ -359,13 +364,29 @@ OpenWhisk has a few system limits, including how much memory an action uses and 
 * A user can change the limit when creating the action.
 * A container cannot have more memory allocated than the limit.
 
-### Per namespace #Concurrent Invocation (#) (Default: 100)
+### Per action artifact (MB) (Fixed: 1MB)
+* The maximum code size for the action is 1MB.
+* It's recommended for a JavaScript action to use a tool to concatenate all source code including dependencies into a single bundled file 
+
+### Per activation payload size (MB) (Fixed: 1MB)
+* The maximum POST content size plus any curried parameters for an action invocation or trigger firing is 1MB.
+
+### Per namespace concurrent invocation (Default: 100)
 * The number of activations that are currently processed for a namespace cannot exceed 100.
 * The default limit can be statically configured by whisk in consul kvstore.
 * A user is currently not able to change the limits.
 
-
-### Invocations per minute/hour (#) (Fixed: 120/3600)
+### Invocations per minute/hour (Fixed: 120/3600)
 * The rate limit N is set to 120/3600 and limits the number of action invocations in one minute/hour windows.
 * A user cannot change this limit when creating the action.
 * A CLI call that exceeds this limit receives an error code corresponding to TOO_MANY_REQUESTS.
+
+### Per Docker action open files ulimit (Fixed: 64:64)
+* The maximum number of open file is 64 (this applies to both hard and soft limits).
+* The docker run command use the argument `--ulimit nofile=64:64`.
+* For more information on the ulimit for open files see the [docker run](https://docs.docker.com/engine/reference/commandline/run) documentation.
+
+### Per Docker action number of processes ulimit (Fixed: 512:512)
+* The maximum number of processes available to a user is 512 (this applies to both hard and soft limits).
+* The docker run command use the argument `--ulimit nproc=512:512`.
+* For more information on the ulimit for maximum number of processes see the [docker run](https://docs.docker.com/engine/reference/commandline/run) documentation.

--- a/docs/triggers_rules.md
+++ b/docs/triggers_rules.md
@@ -80,8 +80,9 @@ As an example, create a trigger to send user location updates, and manually fire
   ok: triggered locationUpdate with id fa495d1223a2408b999c3e0ca73b2677
   ```
 
-   Any events that you fire to the statusUpdate trigger currently don't do anything. To be useful, the trigger needs a rule that associates it with an action.
+  Any events that you fire to the statusUpdate trigger currently don't do anything. To be useful, the trigger needs a rule that associates it with an action.
 
+  Triggers may not be created inside a package, they must be created directly under a namespace.
 
 ## Using rules to associate triggers and actions
 
@@ -141,3 +142,6 @@ As an example, create a rule that calls the hello action whenever a location upd
   You see that the hello action received the event payload and returned the expected string.
 
   You can create multiple rules that associate the same trigger with different actions.
+
+  The trigger and action that make a rule must be in the same namespace, which is in fact private.
+  If you want to use an action that belongs to a pacakge you can copy the action into the namespace for example `wsk action create echo --copy /whisk.system/samples/echo`

--- a/docs/triggers_rules.md
+++ b/docs/triggers_rules.md
@@ -143,5 +143,5 @@ As an example, create a rule that calls the hello action whenever a location upd
 
   You can create multiple rules that associate the same trigger with different actions.
 
-  The trigger and action that make a rule must be in the same namespace, which is in fact private.
+  The trigger and action that make a rule must be in the same namespace.
   If you want to use an action that belongs to a pacakge you can copy the action into the namespace for example `wsk action create echo --copy /whisk.system/samples/echo`


### PR DESCRIPTION
- Update docs for ulmit limits for docker actions
  - Fixes #342
- Update docs with limits for action artifact and parameters
  - Fixes #340
- Update docs to define BASE URL and default namespace _
  - Fixes #307 #551
- Remove dash - since it can get confuse with default namespace underscore _
  - Fixes #306 
- Update docs on github payload content
  - Fixes #240
- Document restriction on creating triggers and rules
  - Fixes #239
- Update docs wrong type of quotes in code snippets
  - Fixes #682
- Update actions docs to consistent use params and not msg
  - Fixes #683
- Docs missing step to install pod for ios starter app 
  - Fixes #684
- Update version of nodejs from 0.12.9 to the correct version 0.12.14
- Update API url for swagger.json
  - Fixes #710