### PR TITLE
Getting rid of warning in TestUtils

### DIFF
--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -122,7 +122,7 @@ public class TestUtils {
             return map;
         } catch (Throwable t) {
             System.out.println("failed to parse VCAP" + t);
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
     }
 


### PR DESCRIPTION
`Collections.EMPTY_MAP` is not typesafe which the compiler complains about. Let's keep the repository warning-free.