### PR TITLE
issue #672: improve ansible setup.yml

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -25,7 +25,7 @@ brew install python
 pip install ansible==2.0.2.0
 
 cd ansible
-ansible-playbook setup.yml [-e docker_machine_name=whisk]
+ansible-playbook -i environments/mac setup.yml [-e docker_machine_name=whisk]
 ```
 
 **Hint:** If you omit the optional `-e docker_machine_name` parameter, it will default to "whisk".  
@@ -72,7 +72,7 @@ After the playbook is done you should see a file called `db_local.ini` in your a
 If you want to use the ephemeral CouchDB, run this command
 
 ```
-ansible-playbook setup.yml
+ansible-playbook -i environments/<environment> setup.yml
 ```
 
 #####  Persistent CouchDB
@@ -87,7 +87,7 @@ export OW_DB_PROTOCOL=<your couchdb protocol>
 export OW_DB_HOST=<your couchdb host>
 export OW_DB_PORT=<your couchdb port>
 
-ansible-playbook setup.yml
+ansible-playbook -i environments/<environment> setup.yml
 ```
 
 ##### Cloudant
@@ -102,7 +102,7 @@ export OW_DB_PROTOCOL=https
 export OW_DB_HOST=<your cloudant user>.cloudant.com
 export OW_DB_PORT=443
 
-ansible-playbook setup.yml
+ansible-playbook -i environments/<environment> setup.yml
 ```
 
 #### Install Prerequisites

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -17,6 +17,7 @@
     local_action: template src="{{playbook_dir}}/environments/mac/hosts.j2.ini" dest="{{ playbook_dir }}/environments/mac/hosts"
     when: "'environments/mac' in inventory_dir"
 
+  # at the beginning, we don't have the hosts file, so we need this step in order to get step "prepare db_local.ini" working
   - name: add new db host on-the-fly
     add_host: name={{ docker_machine_ip }} groups=db
     when: "'environments/mac' in inventory_dir"

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -6,14 +6,20 @@
   - name: find the ip of docker-machine
     local_action: shell "docker-machine" "ip" "{{docker_machine_name | default('whisk')}}"
     register: result
-    ignore_errors: true
+    when: "'environments/mac' in inventory_dir"
 
-  - set_fact: 
+  - name: get the docker-machine ip
+    set_fact:
       docker_machine_ip: "{{ result.stdout }}"
-  
+    when: "'environments/mac' in inventory_dir"
+
   - name: gen hosts for docker-machine 
     local_action: template src="{{playbook_dir}}/environments/mac/hosts.j2.ini" dest="{{ playbook_dir }}/environments/mac/hosts"
-    when: result.rc == 0
+    when: "'environments/mac' in inventory_dir"
+
+  - name: add new db host on-the-fly
+    add_host: name={{ docker_machine_ip }} groups=db
+    when: "'environments/mac' in inventory_dir"
 
   - name: prepare db_local.ini
     local_action: template src="db_local.ini.j2" dest="{{ playbook_dir }}/db_local.ini"


### PR DESCRIPTION
* only use docker-machine commands in mac env. 
* add db host on-the-fly to ansible runtime once mac env is used. 
* improve README.md