### PR TITLE
Limitation of entites

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -18,6 +18,8 @@ package whisk.core.entity
 
 import java.util.Base64
 
+import scala.language.postfixOps
+
 import spray.json.DefaultJsonProtocol
 import spray.json.DeserializationException
 import spray.json.JsArray
@@ -26,6 +28,8 @@ import spray.json.JsString
 import spray.json.JsValue
 import spray.json.RootJsonFormat
 import whisk.core.entity.ArgNormalizer.trim
+import whisk.core.entity.size.SizeInt
+import whisk.core.entity.size.SizeString
 
 /**
  * Exec encodes the executable details of an action. For black
@@ -43,7 +47,7 @@ import whisk.core.entity.ArgNormalizer.trim
  *         jar   : a base64-encoded JAR file when kind is "java",
  *         name  : a fully-qualified class name when kind is "java" }
  */
-sealed abstract class Exec(val kind: String) {
+sealed abstract class Exec(val kind: String) extends ByteSizeable {
     def image: String
 
     override def toString = Exec.serdes.write(this).compactPrint
@@ -51,32 +55,41 @@ sealed abstract class Exec(val kind: String) {
 
 protected[core] case class NodeJSExec(code: String, init: Option[String]) extends Exec(Exec.NODEJS) {
     val image = "whisk/nodejsaction"
+    def size = (code sizeInBytes) + init.map(_.sizeInBytes).getOrElse(0 B)
 }
 
 protected[core] case class NodeJS6Exec(code: String, init: Option[String]) extends Exec(Exec.NODEJS6) {
     val image = "whisk/nodejs6action"
+    def size = (code sizeInBytes) + init.map(_.sizeInBytes).getOrElse(0 B)
 }
 
 protected[core] case class PythonExec(code: String) extends Exec(Exec.PYTHON) {
     val image = "whisk/pythonaction"
+    def size = code sizeInBytes
 }
 
 protected[core] case class SwiftExec(code: String) extends Exec(Exec.SWIFT) {
     val image = "whisk/swiftaction"
+    def size = code sizeInBytes
 }
 
 protected[core] case class Swift3Exec(code: String) extends Exec(Exec.SWIFT3) {
     val image = "whisk/swift3action"
+    def size = code sizeInBytes
 }
 
 protected[core] case class JavaExec(jar: String, main: String) extends Exec(Exec.JAVA) {
     val image = "whisk/javaaction"
+    def size = (jar sizeInBytes) + (main sizeInBytes)
 }
 
-protected[core] case class BlackBoxExec(image: String) extends Exec(Exec.BLACKBOX)
+protected[core] case class BlackBoxExec(image: String) extends Exec(Exec.BLACKBOX) {
+    def size = image sizeInBytes
+}
 
 protected[core] case class SequenceExec(code: String, components: Vector[String]) extends Exec(Exec.SEQUENCE) {
     val image = "whisk/nodejsaction"
+    def size = (code sizeInBytes) + components.map(_ sizeInBytes).reduce(_ + _)
 }
 
 protected[core] object Exec
@@ -87,15 +100,16 @@ protected[core] object Exec
     private lazy val b64decoder = Base64.getDecoder()
 
     // The possible values of the JSON 'kind' field.
-    protected[core] val NODEJS   = "nodejs"
-    protected[core] val NODEJS6  = "nodejs:6"
-    protected[core] val PYTHON   = "python"
-    protected[core] val SWIFT    = "swift"
-    protected[core] val SWIFT3   = "swift:3"
-    protected[core] val JAVA     = "java"
+    protected[core] val NODEJS = "nodejs"
+    protected[core] val NODEJS6 = "nodejs:6"
+    protected[core] val PYTHON = "python"
+    protected[core] val SWIFT = "swift"
+    protected[core] val SWIFT3 = "swift:3"
+    protected[core] val JAVA = "java"
     protected[core] val BLACKBOX = "blackbox"
     protected[core] val SEQUENCE = "sequence"
     protected[core] val runtimes = Set(NODEJS, NODEJS6, PYTHON, SWIFT, SWIFT3, JAVA, BLACKBOX, SEQUENCE)
+    val sizeLimit = 48 MB
 
     protected[core] def js(code: String, init: String = null): Exec = NodeJSExec(trim(code), Option(init).map(_.trim))
     protected[core] def js6(code: String, init: String = null): Exec = NodeJS6Exec(trim(code), Option(init).map(_.trim))

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -89,7 +89,7 @@ protected[core] case class BlackBoxExec(image: String) extends Exec(Exec.BLACKBO
 
 protected[core] case class SequenceExec(code: String, components: Vector[String]) extends Exec(Exec.SEQUENCE) {
     val image = "whisk/nodejsaction"
-    def size = (code sizeInBytes) + components.map(_ sizeInBytes).reduce(_ + _)
+    def size = components.map(_ sizeInBytes).reduce(_ + _)
 }
 
 protected[core] object Exec

--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+object SizeUnits extends Enumeration {
+
+    sealed abstract class Unit() {
+        def toBytes(n: Long): Long
+        def toKBytes(n: Long): Long
+        def toMBytes(n: Long): Long
+    }
+
+    case object BYTE extends Unit {
+        def toBytes(n: Long): Long = n
+        def toKBytes(n: Long): Long = n / 1024
+        def toMBytes(n: Long): Long = n / 1024 / 1024
+    }
+    case object KB extends Unit {
+        def toBytes(n: Long): Long = n * 1024
+        def toKBytes(n: Long): Long = n
+        def toMBytes(n: Long): Long = n / 1024
+    }
+    case object MB extends Unit {
+        def toBytes(n: Long): Long = n * 1024 * 1024
+        def toKBytes(n: Long): Long = n * 1024
+        def toMBytes(n: Long): Long = n
+    }
+}
+
+case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] {
+
+    require(size >= 0, "a negative size of an object is not allowed.")
+
+    def toBytes = unit.toBytes(size)
+    def toKB = unit.toKBytes(size)
+    def toMB = unit.toMBytes(size)
+
+    def +(other: ByteSize): ByteSize = {
+        val commonUnit = SizeUnits.BYTE
+        val commonSize = other.toBytes + toBytes
+        ByteSize(commonSize, commonUnit)
+    }
+
+    def compare(other: ByteSize) = toBytes compare other.toBytes
+}
+
+object ByteSize {
+    def fromString(sizeString: String): ByteSize = {
+        val unitprefix = sizeString.takeRight(1)
+        val size = sizeString.dropRight(1).toLong
+
+        val unit = unitprefix match {
+            case "B" => SizeUnits.BYTE
+            case "K" => SizeUnits.KB
+            case "M" => SizeUnits.MB
+            case _   => throw new IllegalArgumentException("""Size Unit not supported. Only "B", "K" and "M" are supported.""")
+        }
+
+        ByteSize(size, unit)
+    }
+}
+
+object size {
+    implicit class SizeInt(n: Int) extends SizeConversion {
+        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
+    }
+
+    implicit class SizeLong(n: Long) extends SizeConversion {
+        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n, unit)
+    }
+
+    implicit class SizeString(n: String) extends SizeConversion {
+        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n.length * 2, unit)
+    }
+}
+
+trait SizeConversion {
+    def B = sizeIn(SizeUnits.BYTE)
+    def KB = sizeIn(SizeUnits.KB)
+    def MB = sizeIn(SizeUnits.MB)
+
+    def sizeInBytes = sizeIn(SizeUnits.BYTE)
+
+    def sizeIn(unit: SizeUnits.Unit): ByteSize
+}

--- a/core/controller/src/main/resources/application.conf
+++ b/core/controller/src/main/resources/application.conf
@@ -5,4 +5,7 @@ include "logging"
 spray.can.server {
   request-timeout = infinite
   idle-timeout = infinite
+  parsing {
+    max-content-length = 50m
+  }
 }

--- a/core/controller/src/main/resources/whiskswagger.json
+++ b/core/controller/src/main/resources/whiskswagger.json
@@ -293,6 +293,9 @@
                     "409": {
                         "$ref": "#/responses/Conflict"
                     },
+                    "413": {
+                        "$ref": "#/responses/RequestEntityTooLarge"
+                    },
                     "500": {
                         "$ref": "#/responses/ServerError"
                     }
@@ -587,6 +590,9 @@
                     "409": {
                         "$ref": "#/responses/Conflict"
                     },
+                    "413": {
+                        "$ref": "#/responses/RequestEntityTooLarge"
+                    },
                     "500": {
                         "$ref": "#/responses/ServerError"
                     }
@@ -850,6 +856,9 @@
                     },
                     "409": {
                         "$ref": "#/responses/Conflict"
+                    },
+                    "413": {
+                        "$ref": "#/responses/RequestEntityTooLarge"
                     },
                     "500": {
                         "$ref": "#/responses/ServerError"
@@ -1119,6 +1128,9 @@
                     },
                     "409": {
                         "$ref": "#/responses/Conflict"
+                    },
+                    "413": {
+                        "$ref": "#/responses/RequestEntityTooLarge"
                     },
                     "500": {
                         "$ref": "#/responses/ServerError"
@@ -2096,10 +2108,16 @@
             "description": "Accepted activation request",
             "schema": {
                 "$ref": "#/definitions/ItemId"
-            }            
+            }
         },
         "AcceptedRuleStateChange": {
             "description": "Rule has been enabled or disabled"
+        },
+        "RequestEntityTooLarge": {
+            "description": "Request entity too large",
+            "schema": {
+                "$ref": "#/definitions/ErrorMessage"
+            }
         }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -87,8 +87,7 @@ object WhiskServices extends LoadbalancerRequest {
      * and returns the HTTP response from the load balancer as a future
      */
     def makeLoadBalancerComponent(config: WhiskConfig, timeout: Timeout = 10 seconds)(
-        implicit as: ActorSystem):
-        (LoadBalancerReq => Future[LoadBalancerResponse], () => JsObject, (ActivationId, TransactionId) => Future[WhiskActivation]) = {
+        implicit as: ActorSystem): (LoadBalancerReq => Future[LoadBalancerResponse], () => JsObject, (ActivationId, TransactionId) => Future[WhiskActivation]) = {
         val loadBalancer = new LoadBalancerService(config, Verbosity.Loud)
         val requestTaker = (lbr: LoadBalancerReq) => { loadBalancer.doPublish(lbr._1, lbr._2)(lbr._3) }
         (requestTaker, loadBalancer.getInvokerHealth, loadBalancer.queryActivationResponse)
@@ -100,6 +99,9 @@ object WhiskServices extends LoadbalancerRequest {
  * A trait which defines a few services which a whisk microservice may rely on.
  */
 trait WhiskServices {
+    /** Whisk configuration object. */
+    protected val whiskConfig: WhiskConfig
+
     /** An entitlement service to check access rights. */
     protected val entitlementService: EntitlementService
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -47,7 +47,6 @@ import whisk.core.entity.{ ActivationId, Subject, WhiskActivation, WhiskActivati
 import whisk.core.entity.types.{ ActivationStore, AuthStore, EntityStore }
 import whisk.core.controller.WhiskServices.LoadBalancerReq
 
-
 /**
  * Abstract class which provides basic Directives which are used to construct route structures
  * which are common to all versions of the Rest API.
@@ -208,6 +207,7 @@ protected[controller] class RestAPIVersion_v1(
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskActionsApi with WhiskServices {
+        override val whiskConfig = config
         setVerbosity(verbosity)
     }
 
@@ -224,6 +224,7 @@ protected[controller] class RestAPIVersion_v1(
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskTriggersApi with WhiskServices {
+        override val whiskConfig = config
         setVerbosity(verbosity)
     }
 
@@ -239,6 +240,7 @@ protected[controller] class RestAPIVersion_v1(
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskRulesApi with WhiskServices {
+        override val whiskConfig = config
         setVerbosity(verbosity)
     }
 
@@ -264,6 +266,7 @@ protected[controller] class RestAPIVersion_v1(
             override val consulServer: String,
             override val executionContext: ExecutionContext)
         extends WhiskPackagesApi with WhiskServices {
+        override val whiskConfig = config
         setVerbosity(verbosity)
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -96,8 +96,6 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
     /** Path to Triggers REST API */
     protected val triggersPath = "triggers"
 
-    val whiskConfig = new WhiskConfig(Map(WhiskConfig.servicePort -> "8080"))
-
     /**
      * Creates or updates trigger if it already exists. The PUT content is deserialized into a WhiskTriggerPut
      * which is a subset of WhiskTrigger (it eschews the namespace and entity name since the former is derived

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -54,6 +54,7 @@ public class TestUtils {
     public static final int NOT_FOUND = 148;     // 404 - 256 = 148
     public static final int NOTALLOWED = 149;    // 405 - 256 = 149
     public static final int CONFLICT = 153;      // 409 - 256 = 153
+    public static final int REQUEST_ENTITY_TOO_LARGE = 157;      // 413 - 256 = 157
     public static final int THROTTLED = 173;     // 429 (TOO_MANY_REQUESTS) - 256 = 173
     public static final int TIMEOUT = 246;       // 502 (GATEWAY_TIMEOUT)   - 256 = 246
     public static final int DONTCARE_EXIT = -1;  // any value is ok

--- a/tests/src/system/basic/ActionTests.scala
+++ b/tests/src/system/basic/ActionTests.scala
@@ -95,7 +95,7 @@ class ActionTests
      */
     it should "fail on creating an action with exec which is too big" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val name = "TestActionCausingParamsTooBig"
+            val name = "TestActionCausingExecTooBig"
 
             val actionCode = new File(s"$testActionsDir${File.separator}$name.js")
             actionCode.createNewFile()

--- a/tests/src/system/basic/ActionTests.scala
+++ b/tests/src/system/basic/ActionTests.scala
@@ -16,6 +16,8 @@
 
 package system.basic
 
+import java.io.File
+
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
@@ -23,13 +25,19 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import common.TestHelpers
+import common.TestUtils
+import common.TestUtils.REQUEST_ENTITY_TOO_LARGE
 import common.WhiskProperties
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
+import spray.json.DefaultJsonProtocol._
 import spray.json.pimpAny
-import spray.json.DefaultJsonProtocol.LongJsonFormat
-import common.TestUtils
+import whisk.core.WhiskConfig
+import whisk.core.entity.ByteSize
+import java.io.PrintWriter
+import java.nio.file.Files
+import whisk.core.entity.Exec
 
 @RunWith(classOf[JUnitRunner])
 class ActionTests
@@ -41,6 +49,9 @@ class ActionTests
 
     val defaultDosAction = TestUtils.getTestActionFilename("timeout.js")
     val allowedActionDuration = 10 seconds
+
+    val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")
+    val actionCodeLimit = Exec.sizeLimit
 
     behavior of "Actions CLI"
 
@@ -77,5 +88,26 @@ class ActionTests
                 _.fields("response").asJsObject.fields("result").toString should include(
                     """[OK] message terminated successfully""")
             }
+    }
+
+    /**
+     * Test an action that does not exceed the allowed execution timeout of an action.
+     */
+    it should "fail on creating an action with exec which is too big" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "TestActionCausingParamsTooBig"
+
+            val actionCode = new File(s"$testActionsDir${File.separator}$name.js")
+            actionCode.createNewFile()
+            val pw = new PrintWriter(actionCode)
+            pw.write("a" * ((actionCodeLimit.toBytes / 2) + 1).toInt)
+            pw.close
+
+            assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {
+                (action, _) =>
+                    action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = REQUEST_ENTITY_TOO_LARGE)
+            }
+
+            actionCode.delete
     }
 }

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -16,6 +16,8 @@
 
 package whisk.core.controller.test
 
+import scala.language.postfixOps
+
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.junit.runner.RunWith
@@ -28,6 +30,7 @@ import spray.http.StatusCodes.InternalServerError
 import spray.http.StatusCodes.MethodNotAllowed
 import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
+import spray.http.StatusCodes.RequestEntityTooLarge
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import spray.json.DefaultJsonProtocol.RootJsObjectFormat
@@ -50,6 +53,7 @@ import whisk.core.entity.MemoryLimit
 import whisk.core.entity.Namespace
 import whisk.core.entity.Parameters
 import whisk.core.entity.SemVer
+import whisk.core.entity.size.SizeInt
 import whisk.core.entity.Subject
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.WhiskAction
@@ -85,6 +89,9 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val collectionPath = s"/${Namespace.DEFAULT}/${collection.path}"
     def aname = MakeName.next("action_tests")
     setVerbosity(Verbosity.Loud)
+    val entityTooBigRejectionMessage = "request entity too large"
+    val actionLimit = Exec.sizeLimit
+    val parametersLimit = Parameters.sizeLimit
 
     //// GET /actions
     it should "list actions by default namespace" in {
@@ -234,6 +241,55 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/xxx", content) ~> sealRoute(routes(creds)) ~> check {
             val response = responseAs[String]
             status should be(BadRequest)
+        }
+    }
+
+    it should "reject create with exec which is too big" in {
+        implicit val tid = transid()
+        val code = "a" * (actionLimit.toBytes / 2L).toInt + 1
+        val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
+        Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(RequestEntityTooLarge)
+            response.entity.toString should include(entityTooBigRejectionMessage)
+        }
+    }
+
+    it should "reject update with exec which is too big" in {
+        implicit val tid = transid()
+        val oldCode = "function main()"
+        val code = "a" * (actionLimit.toBytes / 2L).toInt + 1
+        val action = WhiskAction(namespace, aname, Exec.js("??"))
+        val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
+        put(entityStore, action)
+        Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(RequestEntityTooLarge)
+            response.entity.toString should include(entityTooBigRejectionMessage)
+        }
+    }
+
+    it should "reject create with parameters which are too big" in {
+        implicit val tid = transid()
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val parameters = keys map { key =>
+            Parameters(key.toString, "a" * 10)
+        } reduce (_ ++ _)
+        val content = s"""{"exec":{"kind":"nodejs","code":"??"},"parameters":$parameters}""".stripMargin.parseJson.asJsObject
+        Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(RequestEntityTooLarge)
+            response.entity.toString should include(entityTooBigRejectionMessage)
+        }
+    }
+
+    it should "reject create with annotations which are too big" in {
+        implicit val tid = transid()
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val parameters = keys map { key =>
+            Parameters(key.toString, "a" * 10)
+        } reduce (_ ++ _)
+        val content = s"""{"exec":{"kind":"nodejs","code":"??"},"annotations":$parameters}""".stripMargin.parseJson.asJsObject
+        Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(RequestEntityTooLarge)
+            response.entity.toString should include(entityTooBigRejectionMessage)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -246,7 +246,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject create with exec which is too big" in {
         implicit val tid = transid()
-        val code = "a" * (actionLimit.toBytes / 2L).toInt + 1
+        val code = "a" * ((actionLimit.toBytes / 2L).toInt + 1)
         val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
         Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(RequestEntityTooLarge)
@@ -257,7 +257,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject update with exec which is too big" in {
         implicit val tid = transid()
         val oldCode = "function main()"
-        val code = "a" * (actionLimit.toBytes / 2L).toInt + 1
+        val code = "a" * ((actionLimit.toBytes / 2L).toInt + 1)
         val action = WhiskAction(namespace, aname, Exec.js("??"))
         val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
         put(entityStore, action)

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -75,13 +75,13 @@ protected trait ControllerTestCommon
     implicit val actorSystem = ActorSystem("controllertests")
     val executionContext = actorSystem.dispatcher
 
-    val config = new WhiskConfig(WhiskActionsApi.requiredProperties)
-    assert(config.isValid)
+    val whiskConfig = new WhiskConfig(WhiskActionsApi.requiredProperties)
+    assert(whiskConfig.isValid)
 
-    val entityStore = WhiskEntityStore.datastore(config)
-    val activationStore = WhiskActivationStore.datastore(config)
-    val authStore = WhiskAuthStore.datastore(config)
-    val entitlementService: EntitlementService = new LocalEntitlementService(config)
+    val entityStore = WhiskEntityStore.datastore(whiskConfig)
+    val activationStore = WhiskActivationStore.datastore(whiskConfig)
+    val authStore = WhiskAuthStore.datastore(whiskConfig)
+    val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig)
 
     val activationId = ActivationId() // need a static activation id to test activations api
     val performLoadBalancerRequest = (lbr: WhiskServices.LoadBalancerReq) => Future {

--- a/tests/src/whisk/core/entity/test/SizeTests.scala
+++ b/tests/src/whisk/core/entity/test/SizeTests.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity.test
+
+import scala.language.postfixOps
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+import whisk.core.entity.size.SizeInt
+import whisk.core.entity.ByteSize
+
+@RunWith(classOf[JUnitRunner])
+class SizeTests extends FlatSpec with Matchers {
+
+    behavior of "Size Entity"
+
+    // Comparing
+    it should "1 Byte smaller than 1 kB smaller than 1 mB" in {
+        val oneByte = 1 B
+        val oneKB = 1 KB
+        val oneMB = 1 MB
+
+        oneByte < oneKB should be(true)
+        oneKB < oneMB should be(true)
+    }
+
+    it should "3 Bytes smaller than 2 kB smaller than 1 mB" in {
+        val myBytes = 3 B
+        val myKBs = 2 KB
+        val myMBs = 1 MB
+
+        myBytes < myKBs should be(true)
+        myKBs < myMBs should be(true)
+    }
+
+    it should "1 mB greaten than 1 kB greater than 1 Byte" in {
+        val oneByte = 1 B
+        val oneKB = 1 KB
+        val oneMB = 1 MB
+
+        oneMB > oneKB should be(true)
+        oneKB > oneByte should be(true)
+    }
+
+    it should "1 mB == 1024 kB == 1048576 B" in {
+        val myBytes = 1048576 B
+        val myKBs = 1024 KB
+        val myMBs = 1 MB
+
+        myBytes equals (myKBs)
+        myKBs equals (myMBs)
+    }
+
+    // Addition
+    it should "1 Byte + 1 kB = 1025 Bytes" in {
+        (1 B) + (1 KB) should be(1025 B)
+    }
+
+    it should "1 mB + 1 mB = 2 mB" in {
+        ((1 MB) + (1 MB)).toBytes should be((2 MB).toBytes)
+    }
+
+    // Conversions
+    it should "1024 B to KB = 1" in {
+        (1024 B).toKB should be(1)
+    }
+
+    it should "1048576 B to MB = 1" in {
+        (1048576 B).toMB should be(1)
+    }
+
+    it should "1 kB to B = 1024" in {
+        (1 KB).toBytes should be(1024)
+    }
+
+    it should "1024 kB to mB = 1" in {
+        (1024 KB).toMB should be(1)
+    }
+
+    it should "1 mB to B = 1048576" in {
+        (1 MB).toBytes should be(1048576)
+    }
+
+    it should "1 mB to kB = 1024" in {
+        (1 MB).toKB should be(1024)
+    }
+
+    // Create ObjectSize from String
+    it should "create ObjectSize from String 3B" in {
+        val fromString = ByteSize.fromString("3B")
+        fromString equals (3 B)
+    }
+
+    it should "create ObjectSize from String 7K" in {
+        val fromString = ByteSize.fromString("7K")
+        fromString equals (7 KB)
+    }
+
+    it should "create ObjectSize from String 120M" in {
+        val fromString = ByteSize.fromString("120M")
+        fromString equals (120 MB)
+    }
+
+    it should "throw error on creating ObjectSize from String 120A" in {
+        the[IllegalArgumentException] thrownBy {
+            ByteSize.fromString("120A")
+        } should have message """Size Unit not supported. Only "B", "K" and "M" are supported."""
+    }
+
+    it should "throw error on creating ByteSize object with negative size" in {
+        the[IllegalArgumentException] thrownBy {
+            -130 MB
+        } should have message "requirement failed: a negative size of an object is not allowed."
+    }
+}


### PR DESCRIPTION
This PR includes protection against too big entities.
The limits are:
* Action
    * Exec: 50MB
    * Parameters: 1MB (includes key and value)
    * Annotations: 1MB (includes key and value)
* Package
    * Parameters: 1MB (includes key and value)
    * Annotations: 1MB (includes key and value)
* Rule
    * Annotations: 1MB (includes key and value)
* Trigger
    * Parameters: 1MB (includes key and value)
    * Annotations: 1MB (includes key and value)