### PR TITLE
Add address of edge host to WhiskConfig

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -53,6 +53,8 @@ class WhiskConfig(
     val loadbalancerHost = this(WhiskConfig.loadbalancerHostName) + ":" + this(WhiskConfig.loadbalancerHostPort)
     val messagehubtriggerHost = this(WhiskConfig.messagehubtriggerHostName) + ":" + this(WhiskConfig.messagehubtriggerHostPort)
 
+    val edgeHostName = this(WhiskConfig.edgeHostName)
+
     val monitorHost = this(WhiskConfig.monitorHostName) + ":" + this(WhiskConfig.monitorHostPort)
     val zookeeperHost = this(WhiskConfig.zookeeperHostName) + ":" + this(WhiskConfig.zookeeperHostPort)
     val consulServer = this(WhiskConfig.consulServerHost) + ":" + this(WhiskConfig.consulPort)


### PR DESCRIPTION
This PR adds the address of the edge host to WhiskConfig.
Before this change, it was only possible to get the edge host including a port, but not the address itself.