### PR TITLE
'wsk property get' now displays all properties and their values.  Also updated .gitattributes for .py files'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@
 *.java          text
 *.js            text
 *.md            text
-*.py            text
+*.py            text eol=lf
 *.scala         text
 *.sh            text eol=lf
 *.gradle        text
@@ -18,3 +18,10 @@
 
 *.jar           binary
 *.png           binary
+
+# python files not having the .py extension
+tools/cli/wsk      text eol=lf
+tools/cli/wskadmin text eol=lf
+
+# bash files not having the .sh extension
+tools/vagrant/simple/wsk  text eol=lf

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -213,6 +213,14 @@ var propertyGetCmd = &cobra.Command{
     SilenceErrors:  true,
     RunE: func(cmd *cobra.Command, args []string) error {
 
+        // If no property is explicitly specified, default to all properties
+        if !(flags.property.all || flags.property.auth ||
+             flags.property.apiversion || flags.property.cliversion ||
+             flags.property.namespace || flags.property.apibuild ||
+             flags.property.apibuildno) {
+            flags.property.all = true
+        }
+
         if flags.property.all || flags.property.auth {
             fmt.Println("whisk auth\t\t", Properties.Auth)
         }
@@ -225,12 +233,12 @@ var propertyGetCmd = &cobra.Command{
             fmt.Println("whisk API version\t", Properties.APIVersion)
         }
 
-        if flags.property.all|| flags.property.cliversion {
-            fmt.Println("whisk CLI version\t", Properties.CLIVersion)
-        }
-
         if flags.property.all || flags.property.namespace {
             fmt.Println("whisk namespace\t\t", Properties.Namespace)
+        }
+
+        if flags.property.all || flags.property.cliversion {
+            fmt.Println("whisk CLI version\t", Properties.CLIVersion)
         }
 
         if flags.property.all || flags.property.apibuild || flags.property.apibuildno {


### PR DESCRIPTION
'wsk property get' now displays all properties and their values
Also updated .gitattributes for .py files and wsk bash/python files without .py/.sh extensions
  - These must retain LF EOL because the python CLI is built on vagrant/linux on Windows