### PR TITLE
[WIP] Add the script to install the catalog from openwhisk-catalog

### DIFF
--- a/catalog/installCatalog.sh
+++ b/catalog/installCatalog.sh
@@ -1,26 +1,32 @@
 #!/bin/bash
 #
-# use the command line interface to install standard actions deployed
-# automatically
+# Download the repository of openwhisk-catalog into the openwhisk home
+# directory and install all the packages.
 #
+
+# The system authentication file is specified by the first parameter, which is mandatory.
 WHISK_SYSTEM_AUTH_FILE=$1
 : ${WHISK_SYSTEM_AUTH_FILE:?"WHISK_SYSTEM_AUTH_FILE must be set and non-empty"}
 
-export WHISK_SYSTEM_AUTH=`cat $WHISK_SYSTEM_AUTH_FILE`
+# The openwhisk catalog can be specified by the second parameter. The default one
+# is the openwhisk-catalog repository in github.
+WHISK_CATALOG_REPO=${2:-"https://github.com/openwhisk/openwhisk-catalog.git"}
 
-SCRIPTDIR="$(cd $(dirname "$0")/ && pwd)"
-source "$SCRIPTDIR/util.sh"
+# The openwhisk home directory can be specified by the third parameter. If not,
+# we will look up the environment variable and then fetch the directory via the
+# current location when necessary.
+OPENWHISK_HOME=${3:-$OPENWHISK_HOME}
+: ${OPENWHISK_HOME:="$(dirname "$(pwd)")"}
 
-echo Installing open catalog
+export OPENWHISK_HOME
 
-runPackageInstallScript "$SCRIPTDIR" installSystem.sh
-runPackageInstallScript "$SCRIPTDIR" installGit.sh
-runPackageInstallScript "$SCRIPTDIR" installSlack.sh
-runPackageInstallScript "$SCRIPTDIR" installWatson.sh
-runPackageInstallScript "$SCRIPTDIR" installWeather.sh
-runPackageInstallScript "$SCRIPTDIR" installWebSocket.sh
-
-waitForAll
-
-echo open catalog ERRORS = $ERRORS
-exit $ERRORS
+# The openwhisk-catalog is saved in the openwhisk home directory.
+cd "$OPENWHISK_HOME"
+OPENWHISK_CATALOG="openwhisk-catalog"
+if [ ! -d "$OPENWHISK_CATALOG" ]; then
+    # git clone "$WHISK_CATALOG_REPO"
+    echo "Please install the catalog from openwhisk-catalog."
+    exit 1
+fi
+cd "$OPENWHISK_CATALOG/packages"
+bash "installCatalog.sh" "$WHISK_SYSTEM_AUTH_FILE" "$OPENWHISK_HOME"


### PR DESCRIPTION
Since all the packages have been relocated to openwhisk-catalog,
this patch adds a script under openwhisk to pull all the packages
from openwhisk-catalog and install them.

Closes-Bug: #719