### PR TITLE
Wait for Kafka and Zookeeper using the designated method

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -16,11 +16,11 @@
       - "{{ zookeeper.port }}:2181"
 
 - name: wait until the Zookeeper in this host is up and running
-  wait_for:
-    delay: 2
-    host: "{{ inventory_hostname }}"
-    port: "{{ zookeeper.port }}"
-    timeout: 60
+  action: shell echo ruok | nc -w 3 {{ inventory_hostname }} {{ zookeeper.port }}
+  register: result
+  until: result.stdout.find("imok") != -1
+  retries: 12
+  delay: 5
 
 - name: "pull the {{ docker_image_tag }} image of kafka"
   shell: "docker pull {{ docker_registry }}whisk/kafka:{{ docker_image_tag }}"
@@ -42,8 +42,9 @@
       - "{{ kafka.ras.port }}:8080"
 
 - name: wait until the Kafka in this host is up and running
-  wait_for:
-    delay: 2
-    host: "{{ inventory_hostname }}"
-    port: "{{ kafka.port }}"
-    timeout: 60
+  uri:
+    url: "http://{{ inventory_hostname }}:{{ kafka.ras.port }}/ready"
+  register: result
+  until: result.status == 200
+  retries: 12
+  delay: 5


### PR DESCRIPTION
This ports some of the functionality of isAlive to the Ansible deployment scripts. Before the change, Ansible only waits for the port to be bound, which does not guarantee that the services are actually available.

~~Appears to fix #713.~~

FYI @rabbah @perryibm 