### PR TITLE
Set CLI build version at build-time using gradle

### DIFF
--- a/docker.gradle
+++ b/docker.gradle
@@ -12,6 +12,7 @@
  * - dockerTimeout (optional, default 840): Timeout for docker operations in seconds
  * - dockerRetries (optional, default 3): How many times to retry docker operations
  * - dockerBinary (optional, default 'docker'): The binary to execute docker commands
+ * - dockerBuildArgs (options, default ''): Project specific custom docker build arguments
  * - dockerHost (optional): The docker host to run commands on, default behaviour is
  *       docker's own DOCKER_HOST environment variable
  */
@@ -22,14 +23,20 @@ ext {
     dockerTimeout = project.hasProperty('dockerTimeout') ? dockerTimeout.toInteger() : 840
     dockerRetries = project.hasProperty('dockerRetries') ? dockerRetries.toInteger() : 3
     dockerBinary = project.hasProperty('dockerBinary') ? [dockerBinary] : ['docker']
+    dockerBuildArg = ['build']
 }
 
 if(project.hasProperty('dockerHost')) {
     dockerBinary += ['--host', project.dockerHost]
 }
 
+if(project.hasProperty('dockerBuildArgs')) {
+    dockerBuildArg += ['--build-arg', project.dockerBuildArgs]
+}
+
 task distDocker << {
-    def cmd = dockerBinary + ['build', '-t', dockerImageName, project.buildscript.sourceFile.getParentFile().getAbsolutePath()]
+    def cmd
+    cmd = dockerBinary + dockerBuildArg + ['-t', dockerImageName, project.buildscript.sourceFile.getParentFile().getAbsolutePath()]
     retry(cmd, dockerRetries, dockerTimeout)
 }
 task tagImage << {

--- a/tools/go-cli/Dockerfile
+++ b/tools/go-cli/Dockerfile
@@ -29,7 +29,7 @@ ENV EXEC=wsk.exe
 ENV ARCHS="386 amd64"
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
       zip $GOOS/$GOARCH/openwhisk-win-$GOARCH.zip $GOOS/$GOARCH/$EXEC; \
     done
 
@@ -38,7 +38,7 @@ ENV ARCHS="386 amd64 arm arm64"
 ENV EXEC=wsk
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o mac/$GOARCH/$EXEC main.go && \
       tar -cf mac/$GOARCH/openwhisk-mac-$GOARCH.tar mac/$GOARCH/$EXEC && \
       gzip < mac/$GOARCH/openwhisk-mac-$GOARCH.tar > mac/$GOARCH/openwhisk-mac-$GOARCH.tar.gz && \
       rm -f mac/$GOARCH/openwhisk-mac-$GOARCH.tar; \
@@ -49,7 +49,7 @@ ENV ARCHS="386 amd64 arm arm64 ppc64 ppc64le mips64 mips64le"
 ENV EXEC=wsk
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X commands.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o $GOOS/$GOARCH/$EXEC main.go && \
       tar -cf $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar $GOOS/$GOARCH/$EXEC && \
       gzip < $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar > $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar.gz && \
       rm -f $GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar; \

--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -1,5 +1,6 @@
 ext.dockerImageName = "whisk/go-cli"
 ext.dockerContainerName = "go-cli"
+ext.dockerBuildArgs = getDockerBuildArgs()
 apply from: "../../docker.gradle"
 
 // Detects if the local OS is Unix. If so, ant.properties.family is set to linux.
@@ -35,6 +36,13 @@ ant.condition(property: "arch", value: "386") {
 // Detects if the local CPU architecture is x86_32. If so, ant.properties.arch is set to 386.
 ant.condition(property: "arch", value: "386") {
     os(arch: "x86_32")
+}
+
+// Returns the Go CLI docker build args
+def getDockerBuildArgs() {
+    java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+    String dateStr = sdf.format(new Date())
+    return "BUILDTIME="+dateStr
 }
 
 task removeBinary(type: Delete) {

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -23,15 +23,12 @@ import (
     "os"
     "strings"
     "net/url"
-    "time"
 
     "github.com/mitchellh/go-homedir"
     "github.com/spf13/cobra"
 
     "../../go-whisk/whisk"
 )
-
-var CLI_BUILD_TIME string = time.Now().Format("2006-01-02T15:04:05-07:00")
 
 var Properties struct {
     Auth       string
@@ -302,8 +299,8 @@ func setDefaultProperties() {
     Properties.APIBuild = DefaultAPIBuild
     Properties.APIBuildNo = DefaultAPIBuildNo
     Properties.APIVersion = DefaultAPIVersion
-    Properties.CLIVersion = CLI_BUILD_TIME
     Properties.PropsFile = DefaultPropsFile
+    // Properties.CLIVersion value is set from main's init()
 }
 
 func getPropertiesFilePath() (propsFilePath string, werr error) {

--- a/tools/go-cli/go-whisk-cli/main.go
+++ b/tools/go-cli/go-whisk-cli/main.go
@@ -25,12 +25,20 @@ import (
     "../go-whisk-cli/commands"
 )
 
+// CLI_BUILD_TIME holds the time of the CLI build.  During gradle builds,
+// this value will be overwritten via the command:
+//     go build -ldflags "-X main.CLI_BUILD_TIME=nnnnn"   // nnnnn is the new timestamp
+var CLI_BUILD_TIME string = "not set"
+
 var cliDebug = os.Getenv("WSK_CLI_DEBUG")  // Useful for tracing init() code
 
 func init() {
     if len(cliDebug) > 0 {
         whisk.SetDebug(true)
     }
+
+    // Rest of CLI uses the Properties struct, so set the build time there
+    commands.Properties.CLIVersion = CLI_BUILD_TIME
 }
 
 func main() {


### PR DESCRIPTION
Set CLI build version using gradle + ansible generated properties file
Go CLI build version now comes from same default.properties as the python CLI
Also fix CLI build version logic cuz Go code was not getting build version from docker