### PR TITLE
[Ready] Tweaked entitlement checks to bypass entitlement service entirely for default namespace

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -193,5 +193,9 @@ object WhiskConfig {
     val messagehubtriggerHost = Map(messagehubtriggerHostName -> null, messagehubtriggerHostPort -> null)
     val monitorHost = Map(monitorHostName -> null, monitorHostPort -> null)
     val zookeeperHost = Map(zookeeperHostName -> null, zookeeperHostPort -> null)
+
+    // use empty string as default for entitlement host as this is an optional service
+    // and the way to prevent the configuration checker from failing is to provide a value;
+    // an empty string is permitted but null is not
     val entitlementHost = Map(entitlementHostName -> "", entitlementHostPort -> "")
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -69,11 +69,12 @@ object WhiskServices extends LoadbalancerRequest {
      */
     def entitlementService(config: WhiskConfig, timeout: FiniteDuration = 5 seconds)(
         implicit as: ActorSystem, ec: ExecutionContext) = {
-        config.entitlementHost match {
-            case EntitlementService.LOCAL_ENTITLEMENT_HOST =>
-                new LocalEntitlementService(config)
-            case _ =>
-                new RemoteEntitlementService(config, timeout, as, ec)
+        // remote entitlement service requires a host:port definition. If not given,
+        // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
+        if (config.entitlementHost.startsWith(":")) {
+            new LocalEntitlementService(config)
+        } else {
+            new RemoteEntitlementService(config, timeout, as, ec)
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -79,7 +79,7 @@ protected[core] case class Collection protected (
      * to any resource in in any of their namespaces as long as the right (the implied operation)
      * is permitted on the resource.
      */
-    protected[core] def implicitRights(namespaces: List[String], right: Privilege, resource: Resource)(
+    protected[core] def implicitRights(namespaces: Set[String], right: Privilege, resource: Resource)(
         implicit ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
         // if the resource root namespace is in any of the allowed namespaces
         // then this is an owner of the resource

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -31,20 +31,13 @@ private object LocalEntitlementService {
 }
 
 protected[core] class LocalEntitlementService(
-    private val config : WhiskConfig)
-    (implicit actorSystem: ActorSystem)
+    private val config: WhiskConfig)(
+        implicit actorSystem: ActorSystem)
     extends EntitlementService(config) {
 
     private implicit val executionContext = actorSystem.dispatcher
 
     private val matrix = LocalEntitlementService.matrix
-
-    /**
-     * The default namespace is the subject name. This is the only namespace.
-     */
-    protected[core] override def namespaces(subject: Subject)(implicit transid: TransactionId): Future[List[String]] = Future.successful {
-        List(subject())
-    }
 
     /** Grants subject right to resource by adding them to the entitlement matrix. */
     protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future {

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -51,7 +51,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
      * A published package makes all its assets public regardless of their shared bit.
      * All assets that are not in an explicit package are private because the default package is private.
      */
-    protected[core] override def implicitRights(namespaces: List[String], right: Privilege, resource: Resource)(
+    protected[core] override def implicitRights(namespaces: Set[String], right: Privilege, resource: Resource)(
         implicit ec: ExecutionContext, transid: TransactionId) = {
         resource.entity map {
             pkgname =>
@@ -83,7 +83,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
      */
     private def checkPackageReadPermission(
         promise: Promise[Boolean],
-        namespaces: List[String],
+        namespaces: Set[String],
         isOwner: Boolean,
         doc: DocId)(
             implicit ec: ExecutionContext, transid: TransactionId): Unit = {

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -45,7 +45,7 @@ import whisk.core.entity.Subject
 import whisk.core.WhiskConfig
 
 protected[core] class RemoteEntitlementService(
-    private val config : WhiskConfig,
+    private val config: WhiskConfig,
     private val timeout: FiniteDuration = 5 seconds,
     private implicit val actorSystem: ActorSystem,
     private implicit val ec: ExecutionContext)
@@ -54,7 +54,7 @@ protected[core] class RemoteEntitlementService(
     private val apiLocation = config.entitlementHost
     private val matrix = TrieMap[(Subject, String), Set[Privilege]]()
 
-    protected[core] override def namespaces(subject: Subject)(implicit transid: TransactionId): Future[List[String]] = {
+    protected[core] override def namespaces(subject: Subject)(implicit transid: TransactionId): Future[Set[String]] = {
         info(this, s"getting namespaces from ${apiLocation}")
 
         val url = Uri("http://" + apiLocation + "/namespaces").withQuery(
@@ -64,7 +64,7 @@ protected[core] class RemoteEntitlementService(
             addHeader("X-Transaction-Id", transid.toString())
             ~> sendReceive
             ~> unmarshal[List[String]])
-        pipeline(Get(url))
+        pipeline(Get(url)) map { _.toSet }
     }
 
     protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean] = {

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -38,11 +38,10 @@ import spray.http.HttpResponse
 import spray.http.StatusCodes.OK
 import spray.http.Uri
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.DefaultJsonProtocol.listFormat
+import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
-import whisk.core.entity.Subject
 import whisk.core.WhiskConfig
+import whisk.core.entity.Subject
 
 protected[core] class RemoteEntitlementService(
     private val config: WhiskConfig,
@@ -60,11 +59,11 @@ protected[core] class RemoteEntitlementService(
         val url = Uri("http://" + apiLocation + "/namespaces").withQuery(
             "subject" -> subject())
 
-        val pipeline: HttpRequest => Future[List[String]] = (
+        val pipeline: HttpRequest => Future[Set[String]] = (
             addHeader("X-Transaction-Id", transid.toString())
             ~> sendReceive
-            ~> unmarshal[List[String]])
-        pipeline(Get(url)) map { _.toSet }
+            ~> unmarshal[Set[String]])
+        pipeline(Get(url))
     }
 
     protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId): Future[Boolean] = {


### PR DESCRIPTION
Tweaked entitlement checks so that the default namespace is always checked and does not require a query from an entitlement service even if such service exists. Only if the implicit entitlement fails is the service queried for additional namespaces to check.