### PR TITLE
Dumbing down the terminal to keep Gradle quiet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ scala:
 services:
   - docker
 
+env:
+  global:
+    - TERM=dumb
+
 notifications:
   email: false
   slack:


### PR DESCRIPTION
Affects TravisCI only. Pretends the terminal is crippled; disables the `> Loading` CR-animations that make the log hard to read. 

~~@domdom82 you had the last change in the file :)~~