### PR TITLE
Add --insecure|-i flag to the python CLI for CLI syntax parity with the Go CLI

### DIFF
--- a/tools/cli/wsk
+++ b/tools/cli/wsk
@@ -100,6 +100,7 @@ def parseArgs(props):
 
     parser.add_argument('--apihost', help='whisk API host', dest='apihostOverride', metavar='hostname')
     parser.add_argument('--apiversion', help='whisk API version', dest='apiversionOverride', metavar='version')
+    parser.add_argument('-i', '--insecure', help='reserved command option', action='store_true')
 
     Action().getCommands(subparsers, props)
     Activation().getCommands(subparsers, props)


### PR DESCRIPTION
Add --insecure|-i flag to the python CLI for CLI syntax parity with the Go CLI.
This flag is simply ignored by the python CLI; previously it caused a failure.
See https://github.com/openwhisk/openwhisk/pull/614/files#r68393928