### PR TITLE
Use Groovy instead of ant to detect platform/arch

### DIFF
--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -3,41 +3,6 @@ ext.dockerContainerName = "go-cli"
 ext.dockerBuildArgs = getDockerBuildArgs()
 apply from: "../../docker.gradle"
 
-// Detects if the local OS is Unix. If so, ant.properties.family is set to linux.
-ant.condition(property: "family", value: "linux") {
-    os(family: "unix")
-}
-
-// Detects if the local OS is Mac. If so, ant.properties.family is set to mac.
-ant.condition(property: "family", value: "mac") {
-    os(family: "mac")
-}
-
-// Detects if the local CPU architecture is amd64. If so, ant.properties.arch is set to amd64.
-ant.condition(property: "arch", value: "amd64") {
-    os(arch: "amd64")
-}
-
-// Detects if the local CPU architecture is x86_64. If so, ant.properties.arch is set to amd64.
-ant.condition(property: "arch", value: "amd64") {
-    os(arch: "x86_64")
-}
-
-// Detects if the local CPU architecture is 386. If so, ant.properties.arch is set to 386.
-ant.condition(property: "arch", value: "386") {
-    os(arch: "386")
-}
-
-// Detects if the local CPU architecture is i386. If so, ant.properties.arch is set to 386.
-ant.condition(property: "arch", value: "386") {
-    os(arch: "i386")
-}
-
-// Detects if the local CPU architecture is x86_32. If so, ant.properties.arch is set to 386.
-ant.condition(property: "arch", value: "386") {
-    os(arch: "x86_32")
-}
-
 // Returns the Go CLI docker build args
 def getDockerBuildArgs() {
     java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
@@ -54,15 +19,18 @@ task distBinary(dependsOn: [removeBinary, distDocker]) << {
     run(["mkdir", "${projectDir}/../../bin/go-cli/"])
     run(dockerBinary + ["run", "--name", dockerContainerName, dockerImageName + ":" + dockerImageTag])
 
-    // Copy all Go binaries outside of Docker into openwhisk go-cli/bin/ folder
+    // Copy all Go binaries from Docker into openwhisk/bin/go-cli folder
     run(dockerBinary + ["cp", dockerContainerName +
             ":/src/github.com/go-whisk-cli/build/.", "${projectDir}/../../bin/go-cli"])
 
-    if (ant.properties.family in ["linux", "mac"] && ant.properties.arch in ["amd64", "386"]) {
-        exec {
-            executable "ln"
-            args "${projectDir}/../../bin/go-cli/${ant.properties.family}/${ant.properties.arch}/wsk", "${projectDir}/../../bin/go-cli/wsk", "-s"
-        }
+    // Create a shorthand sym link to current platform appropriate Go CLI binary
+    String go_osname = mapOsNameToGoName(getOsName())
+    String go_osarch = mapOsArchToGoArch(getOsArch())
+    String link_to_path = new File("${projectDir}/../../bin/go-cli/wsk").getCanonicalPath()
+    String link_from_path = new File("${projectDir}/../../bin/go-cli/${go_osname}/${go_osarch}/wsk").getCanonicalPath()
+    exec {
+        executable "ln"
+        args "-s", "${link_from_path}", "${link_to_path}"
     }
 
     run(dockerBinary + ["rm", "-f", dockerContainerName])
@@ -77,4 +45,34 @@ def run(cmd, ignoreError = false) {
     if(!ignoreError && proc.exitValue() != 0) {
         println("Command '${cmd.join(" ")}' failed with exitCode ${proc.exitValue()}")
     }
+}
+
+task dump_os() << {
+    println "os.name = "+getOsName()
+    println "os.arch = "+getOsArch()
+    println "go.name = "+mapOsNameToGoName(getOsName())
+    println "go.arch = "+mapOsArchToGoArch(getOsArch())
+}
+
+def getOsName() {
+    return System.properties['os.name']
+}
+
+def getOsArch() {
+    return System.properties['os.arch']
+}
+
+def mapOsNameToGoName(String osname) {
+    String osname_l = osname.toLowerCase()
+    if (osname_l.contains("nux") || osname.contains("nix")) return "linux"
+    if (osname_l.contains("mac")) return "mac"
+    if (osname_l.contains("windows")) return "windows"
+    return osname_l
+}
+
+def mapOsArchToGoArch(String osarch) {
+    String osarch_l = osarch.toLowerCase()
+    if (osarch_l.contains("x86_64") || osarch_l == "amd64") return "amd64"
+    if (osarch_l.contains("i386") || osarch_l.contains("x86_32")) return "386"
+    return osarch_l
 }


### PR DESCRIPTION
Use Groovy instead of ant to detect platform/arch
Fixes #761