### PR TITLE
Bump kafka to 0.9.0.1 to fix high cpu utilization

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -27,6 +27,6 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-logging:commons-logging:1.2'
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
-    compile 'org.apache.kafka:kafka-clients:0.9.0.0'
+    compile 'org.apache.kafka:kafka-clients:0.9.0.1'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'
 }

--- a/services/kafka/Dockerfile
+++ b/services/kafka/Dockerfile
@@ -19,7 +19,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 
 # Install Kafka Stuff
 RUN mkdir /kafka /data
-ENV KAFKA_RELEASE_ARCHIVE kafka_2.11-0.9.0.0.tgz
+
+ENV KAFKA_RELEASE 0.9.0.1
+ENV KAFKA_SCALA_VERSION 2.11
+ENV KAFKA_RELEASE_ARCHIVE kafka_${KAFKA_SCALA_VERSION}-${KAFKA_RELEASE}.tgz
 
 # Download Kafka binary distribution
 #
@@ -28,8 +31,8 @@ ENV KAFKA_RELEASE_ARCHIVE kafka_2.11-0.9.0.0.tgz
 # Install Kafka to /kafka
 
 WORKDIR /tmp
-RUN wget --no-verbose http://www.us.apache.org/dist/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE} && \
-    wget --no-verbose https://dist.apache.org/repos/dist/release/kafka/0.9.0.0/${KAFKA_RELEASE_ARCHIVE}.md5  && \
+RUN wget --no-verbose http://www.us.apache.org/dist/kafka/${KAFKA_RELEASE}/${KAFKA_RELEASE_ARCHIVE} && \
+    wget --no-verbose https://dist.apache.org/repos/dist/release/kafka/${KAFKA_RELEASE}/${KAFKA_RELEASE_ARCHIVE}.md5  && \
     npm install -g express@4.8.0 nano@5.10.0 process@0.10.1 websocket@1.0.17 && \
   echo VERIFY CHECKSUM: && \
   gpg --print-md MD5 ${KAFKA_RELEASE_ARCHIVE} 2>/dev/null && \


### PR DESCRIPTION
This PR resolves #701 by bumping kafka to the next minor version because investigation showed that a fix provided by this version resolves this issue.

> [KAFKA-3159] - Kafka consumer 0.9.0.0 client poll is very CPU intensive under certain conditions
