### PR TITLE
Add twilio node sdk

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -51,6 +51,7 @@ socket.io-client@1.4.6 \
 superagent@1.8.3 \
 swagger-tools@0.10.1 \
 tmp@0.0.28 \
+twilio@2.9.1 \
 watson-developer-cloud@1.8.0 \
 when@3.7.7 \
 ws@1.1.0 \

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -45,6 +45,7 @@ pug@">2.0.0-alpha <2.0.1" \
 request@2.72.0 \
 rimraf@2.5.2 \
 semver@5.1.0 \
+sendgrid@3.0.5 \
 serve-favicon@2.3.0 \
 socket.io@1.4.6 \
 socket.io-client@1.4.6 \

--- a/core/nodejsAction/Dockerfile
+++ b/core/nodejsAction/Dockerfile
@@ -38,6 +38,7 @@ process@0.11.0 \
 request@2.60.0 \
 rimraf@2.5.1 \
 semver@4.3.6 \
+sendgrid@3.0.5 \
 serve-favicon@2.2.0 \
 socket.io@1.3.5 \
 socket.io-client@1.3.5 \

--- a/core/nodejsAction/Dockerfile
+++ b/core/nodejsAction/Dockerfile
@@ -44,6 +44,7 @@ socket.io-client@1.3.5 \
 superagent@1.3.0 \
 swagger-tools@0.8.7 \
 tmp@0.0.28 \
+twilio@2.9.1 \
 watson-developer-cloud@1.4.1 \
 when@3.7.3 \
 ws@1.1.0 \


### PR DESCRIPTION
For enabling twilio service for openwhisk, the sdk is required.