### PR TITLE
Improve use of docker cache in Go CLI build

### DIFF
--- a/tools/go-cli/Dockerfile
+++ b/tools/go-cli/Dockerfile
@@ -1,10 +1,5 @@
 FROM golang:1.6
 
-ADD . /src/github.com/
-
-# The BUILDTIME argument is used as the CLI build time property (wsk property get --all)
-ARG BUILDTIME
-
 # Install zip
 RUN apt-get -y update && \
     apt-get -y install zip
@@ -13,6 +8,8 @@ RUN apt-get -y update && \
 RUN echo "Installing the godep tool"
 ENV GOPATH=/
 RUN go get github.com/tools/godep
+
+ADD . /src/github.com/
 
 # Load all of the dependencies from the previously generated/saved godep generated godeps.json file
 RUN echo "Restoring Go dependencies"
@@ -25,6 +22,9 @@ RUN cd /src/github.com/go-whisk-cli && echo "Dependencies list requires restruct
 
 # All of the Go CLI binaries will be placed under a build folder
 RUN mkdir /src/github.com/go-whisk-cli/build
+
+# The BUILDTIME argument is used as the CLI build time property (wsk property get --all)
+ARG BUILDTIME
 
 # Build the Go wsk CLI binaries
 ENV GOOS=windows

--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -41,7 +41,8 @@ ant.condition(property: "arch", value: "386") {
 // Returns the Go CLI docker build args
 def getDockerBuildArgs() {
     java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-    String dateStr = sdf.format(new Date())
+    String envDateStr = "$System.env.WHISK_BUILD_TIMESTAMP"
+    String dateStr = ((envDateStr != "null") ? envDateStr : sdf.format(new Date()))
     return "BUILDTIME="+dateStr
 }
 


### PR DESCRIPTION
Improve use of docker cache in Go CLI build

Whisk developers can now set WHISK_BUILD_TIMESTAMP env variable to cause Go CLI build use
the docker cache during Go CLI compilation (will take affect after initial build)

Fixes #759 