### PR TITLE
CLI to failure when no authorization key configured/provided (prior to sending HTTP request)

### DIFF
--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -78,12 +78,12 @@ case class WskProps(
 }
 
 class Wsk(override val usePythonCLI: Boolean = true) extends RunWskCmd {
-    implicit val action = new WskAction()
-    implicit val trigger = new WskTrigger()
-    implicit val rule = new WskRule()
-    implicit val activation = new WskActivation()
-    implicit val pkg = new WskPackage()
-    implicit val namespace = new WskNamespace()
+    implicit val action = new WskAction(usePythonCLI)
+    implicit val trigger = new WskTrigger(usePythonCLI)
+    implicit val rule = new WskRule(usePythonCLI)
+    implicit val activation = new WskActivation(usePythonCLI)
+    implicit val pkg = new WskPackage(usePythonCLI)
+    implicit val namespace = new WskNamespace(usePythonCLI)
 }
 
 trait FullyQualifiedNames {
@@ -202,13 +202,14 @@ trait HasActivation {
     }
 }
 
-class WskAction()
+class WskAction(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with ListOrGetFromCollection
     with DeleteFromCollection
     with HasActivation {
 
     override protected val noun = "action"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Creates action. Parameters mirror those available in the CLI.
@@ -267,13 +268,14 @@ class WskAction()
     }
 }
 
-class WskTrigger()
+class WskTrigger(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with ListOrGetFromCollection
     with DeleteFromCollection
     with HasActivation {
 
     override protected val noun = "trigger"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Creates trigger. Parameters mirror those available in the CLI.
@@ -317,13 +319,14 @@ class WskTrigger()
     }
 }
 
-class WskRule()
+class WskRule(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with ListOrGetFromCollection
     with DeleteFromCollection
     with WaitFor {
 
     override protected val noun = "rule"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Creates rule. Parameters mirror those available in the CLI.
@@ -432,12 +435,13 @@ class WskRule()
     }
 }
 
-class WskActivation()
+class WskActivation(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with HasActivation
     with WaitFor {
 
     protected val noun = "activation"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Activation polling console.
@@ -608,11 +612,12 @@ class WskActivation()
     private case class PartialResult(ids: Seq[String]) extends Throwable
 }
 
-class WskNamespace()
+class WskNamespace(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with FullyQualifiedNames {
 
     protected val noun = "namespace"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Lists available namespaces for whisk properties.
@@ -641,11 +646,12 @@ class WskNamespace()
     }
 }
 
-class WskPackage()
+class WskPackage(override val usePythonCLI: Boolean = true)
     extends RunWskCmd
     with ListOrGetFromCollection
     with DeleteFromCollection {
     override protected val noun = "package"
+    override def baseCommand = Wsk.baseCommand(usePythonCLI)
 
     /**
      * Creates package. Parameters mirror those available in the CLI.

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -188,14 +188,9 @@ class WskBasicTests
         // override wsk props file in case it exists
         val wskprops = File.createTempFile("wskprops", ".tmp")
         val env = Map("WSK_CONFIG_FILE" -> wskprops.getAbsolutePath())
-
-        if (usePythonCLI) {
-            val stderr = wsk.cli(Seq("list"), env = env, expectedExitCode = MISUSE_EXIT).stderr
-            stderr should include("usage:")
-            stderr should include("--auth is required")
-        } else {
-            val result = wsk.cli(Seq("list"), env = env, expectedExitCode = UNAUTHORIZED)
-        }
+        val stderr = wsk.cli(Seq("list"), env = env, expectedExitCode = MISUSE_EXIT).stderr
+        stderr should include regex (s"usage[:.]")  // Python CLI: "usage:", Go CLI: "usage."
+        stderr should include("--auth is required")
     }
 
     behavior of "Wsk Package CLI"

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -279,7 +279,7 @@ func init() {
     propertyGetCmd.Flags().BoolVar(&flags.property.apibuild, "apibuild", false, "whisk API build version")
     propertyGetCmd.Flags().BoolVar(&flags.property.apibuildno, "apibuildno", false, "whisk API build number")
     propertyGetCmd.Flags().BoolVar(&flags.property.cliversion, "cliversion", false, "whisk CLI version")
-    propertyGetCmd.Flags().BoolVar(&flags.property.namespace, "namespace", false, "authorization key")
+    propertyGetCmd.Flags().BoolVar(&flags.property.namespace, "namespace", false, "whisk namespace")
     propertyGetCmd.Flags().BoolVar(&flags.property.all, "all", false, "all properties")
 
     propertySetCmd.Flags().StringVarP(&flags.global.auth, "auth", "u", "", "authorization key")

--- a/tools/go-cli/go-whisk/whisk/sdk.go
+++ b/tools/go-cli/go-whisk/whisk/sdk.go
@@ -48,7 +48,18 @@ func (s *SdkService) Install(relFileUrl string) (*http.Response, error) {
         return nil, werr
     }
 
-    s.client.addAuthHeader(req)
+    if IsVerbose() {
+        fmt.Println("REQUEST:")
+        fmt.Printf("[%s]\t%s\n", req.Method, req.URL)
+        if len(req.Header) > 0 {
+            fmt.Println("Req Headers")
+            printJSON(req.Header)
+        }
+        if req.Body != nil {
+            fmt.Println("Req Body")
+            fmt.Println(req.Body)
+        }
+    }
 
     // Directly use the HTTP client, not the Whisk CLI client, so that the response body is left alone
     resp, err := s.client.client.Do(req)

--- a/tools/go-cli/go-whisk/whisk/trace.go
+++ b/tools/go-cli/go-whisk/whisk/trace.go
@@ -20,6 +20,7 @@ import (
     "fmt"
     "runtime"
     "strings"
+    "os"
 )
 
 type DebugLevel string
@@ -34,6 +35,12 @@ const MaxNameLen int = 25
 
 var isVerbose bool
 var isDebug bool
+
+func init() {
+    if len(os.Getenv("WSK_CLI_DEBUG")) > 0 {    // Useful for tracing init() code, before parms are parsed
+        SetDebug(true)
+    }
+}
 
 func SetDebug(b bool) {
     isDebug = b


### PR DESCRIPTION
Check that the auth key is set prior to sending the HTTP request
Fail the CLI if the require auth key is not set
Remove auth key from `sdk install` as it is not needed
Refactor the namespace code to use the common HTTP client code
Fix incorrect argument help text
Fixes #778