### PR TITLE
[Review] Go CLI Does Not Create Action with Empty File

### DIFF
--- a/tests/src/system/basic/CLIActionTests.java
+++ b/tests/src/system/basic/CLIActionTests.java
@@ -329,6 +329,35 @@ public class CLIActionTests {
     }
 
     @Test(timeout=120*1000)
+    public void createActionWithEmptyFile() throws Exception {
+        String action = "createActionWithEmptyFile";
+        String expectedCode = "\"code\": \"\"";
+        try {
+            wsk.sanitize(Action, action);
+            wsk.createAction(action, TestUtils.getTestActionFilename("empty.js"), false, false);
+            String item = wsk.get(Action, action);
+            assertTrue("Expect code to be an empty string", item.contains(expectedCode));
+        } finally {
+            wsk.delete(Action, action);
+        }
+    }
+
+    @Test(timeout=120*1000)
+    public void invokeActionWithNoCode() throws Exception {
+        String name = "invokeActionWithNoCode";
+        try {
+            wsk.sanitize(Action, name);
+            wsk.createAction(name, TestUtils.getTestActionFilename("empty.js"));
+            String activationId = wsk.invoke(name, null);
+            String expected = "Missing main/no code to execute.";
+            boolean present = wsk.checkResultFor(activationId, expected, 45);
+            assertTrue("Expected '" + expected + "' which is missing in log for activation " + activationId, present);
+        } finally {
+            wsk.delete(Action, name);
+        }
+    }
+
+    @Test(timeout=120*1000)
     public void invokeActionWithSpace() throws Exception {
         String name = "WORD COUNT";
         try {

--- a/tools/go-cli/go-whisk/whisk/action.go
+++ b/tools/go-cli/go-whisk/whisk/action.go
@@ -94,7 +94,7 @@ type SentActionNoPublish struct {
 
 type Exec struct {
     Kind  string `json:"kind,omitempty"`
-    Code  string `json:"code,omitempty"`
+    Code  string `json:"code"`
     Image string `json:"image,omitempty"`
     Init  string `json:"init,omitempty"`
     Jar   string `json:"jar,omitempty"`


### PR DESCRIPTION
- Ensure code property always exists even if it is an empty string
- Add test case to ensure actions can be create with empty files
- Add test case to invoke an empty action