### PR TITLE
No longer obtain Go CLI build timestamp from gradle

### DIFF
--- a/tools/go-cli/Dockerfile
+++ b/tools/go-cli/Dockerfile
@@ -24,7 +24,8 @@ RUN cd /src/github.com/go-whisk-cli && echo "Dependencies list requires restruct
 RUN mkdir /src/github.com/go-whisk-cli/build
 
 # The BUILDTIME argument is used as the CLI build time property (wsk property get --all)
-ARG BUILDTIME
+# Disabled for now to speed build times
+#ARG BUILDTIME
 
 # Build the Go wsk CLI binaries
 ENV GOOS=windows
@@ -32,7 +33,7 @@ ENV EXEC=wsk.exe
 ENV ARCHS="386 amd64"
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o build/$GOOS/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -v -o build/$GOOS/$GOARCH/$EXEC main.go && \
       zip build/$GOOS/$GOARCH/openwhisk-win-$GOARCH.zip build/$GOOS/$GOARCH/$EXEC; \
     done
 
@@ -41,7 +42,7 @@ ENV ARCHS="386 amd64 arm arm64"
 ENV EXEC=wsk
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o build/mac/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -v -o build/mac/$GOARCH/$EXEC main.go && \
       tar -cf build/mac/$GOARCH/openwhisk-mac-$GOARCH.tar build/mac/$GOARCH/$EXEC && \
       gzip < build/mac/$GOARCH/openwhisk-mac-$GOARCH.tar > build/mac/$GOARCH/openwhisk-mac-$GOARCH.tar.gz && \
       rm -f build/mac/$GOARCH/openwhisk-mac-$GOARCH.tar; \
@@ -52,7 +53,7 @@ ENV ARCHS="386 amd64 arm arm64 ppc64 ppc64le mips64 mips64le"
 ENV EXEC=wsk
 RUN for GOARCH in $ARCHS; do \
       cd /src/github.com/go-whisk-cli && \
-      go build -ldflags "-X main.CLI_BUILD_TIME=$BUILDTIME" -v -o build/$GOOS/$GOARCH/$EXEC main.go && \
+      go build -ldflags "-X main.CLI_BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%S%:z'`" -v -o build/$GOOS/$GOARCH/$EXEC main.go && \
       tar -cf build/$GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar build/$GOOS/$GOARCH/$EXEC && \
       gzip < build/$GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar > build/$GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar.gz && \
       rm -f build/$GOOS/$GOARCH/openwhisk-$GOOS-$GOARCH.tar; \

--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -1,6 +1,6 @@
 ext.dockerImageName = "whisk/go-cli"
 ext.dockerContainerName = "go-cli"
-ext.dockerBuildArgs = getDockerBuildArgs()
+//ext.dockerBuildArgs = getDockerBuildArgs()
 apply from: "../../docker.gradle"
 
 // Returns the Go CLI docker build args


### PR DESCRIPTION
Remove gradle supplied build timestamp that's passed to Go CLI dockerfile via ARG
Fixes #759