### PR TITLE
[WIP] Do Not Take Arguments for --shared Flag (Go CLI)

### DIFF
--- a/tests/src/common/WskCli.java
+++ b/tests/src/common/WskCli.java
@@ -367,7 +367,7 @@ public class WskCli {
         }
 
         if (shared) {
-            cmd = Util.concat(cmd, new String[] { "--shared", "yes"});
+            cmd = Util.concat(cmd, new String[] { "--shared" });
         }
 
         RunResult result = cli(expectedCode, cmd);

--- a/tools/go-cli/go-whisk-cli/commands/flags.go
+++ b/tools/go-cli/go-whisk-cli/commands/flags.go
@@ -41,7 +41,7 @@ var flags struct {
         blocking    bool
         annotation  []string
         param       []string
-        shared      string // AKA "public" or "publish"
+        shared      bool // AKA "public" or "publish"
         skip        int  // skip first N records
         limit       int  // return max N records
         full        bool // return full records (docs=true for client request)
@@ -68,7 +68,6 @@ var flags struct {
         docker      bool
         copy        bool
         pipe        bool
-        shared      string
         sequence    bool
         lib         string
         timeout     int

--- a/tools/go-cli/go-whisk-cli/commands/rule.go
+++ b/tools/go-cli/go-whisk-cli/commands/rule.go
@@ -177,19 +177,12 @@ var ruleCreateCmd = &cobra.Command{
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
-        var shared bool
 
         if len(args) != 3 {
             whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
             errStr := fmt.Sprintf("Invalid number of arguments (%d) provided; exactly three arguments are expected", len(args))
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
-        }
-
-        if (flags.common.shared == "yes") {
-            shared = true
-        } else {
-            shared = false
         }
 
         qName, err := parseQualifiedName(args[0])
@@ -215,7 +208,7 @@ var ruleCreateCmd = &cobra.Command{
             Name:    ruleName,
             Trigger: triggerName,
             Action:  actionName,
-            Publish: shared,
+            Publish: flags.common.shared,
         }
 
         whisk.Debug(whisk.DbgInfo, "Inserting rule:\n%+v\n", rule)
@@ -254,7 +247,6 @@ var ruleUpdateCmd = &cobra.Command{
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
-        var shared bool
 
         if len(args) != 3 {
             whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
@@ -282,17 +274,11 @@ var ruleUpdateCmd = &cobra.Command{
         triggerName := args[1]  //MWD qualified name?
         actionName := args[2]   //MWD qualified name?
 
-        if (flags.common.shared == "yes") {
-            shared = true
-        } else {
-            shared = false
-        }
-
         rule := &whisk.Rule{
             Name:    ruleName,
             Trigger: triggerName,
             Action:  actionName,
-            Publish: shared,
+            Publish: flags.common.shared,
         }
 
         rule, _, err = client.Rules.Insert(rule, true)
@@ -461,12 +447,12 @@ var ruleListCmd = &cobra.Command{
 
 func init() {
 
-    ruleCreateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "shared action (yes = shared, no[default] = private)")
-    ruleCreateCmd.Flags().BoolVar(&flags.rule.enable, "enable", false, "autmatically enable rule after creating it")
+    ruleCreateCmd.Flags().BoolVar(&flags.common.shared, "shared", false, "make a rule publically accessible")
+    ruleCreateCmd.Flags().BoolVar(&flags.rule.enable, "enable", false, "automatically enable rule after creating it")
 
-    ruleUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "shared action (yes = shared, no[default] = private)")
+    ruleUpdateCmd.Flags().BoolVar(&flags.common.shared, "shared", false, "make a rule publically accessible)")
 
-    ruleDeleteCmd.Flags().BoolVar(&flags.rule.disable, "disable", false, "autmatically disable rule before deleting it")
+    ruleDeleteCmd.Flags().BoolVar(&flags.rule.disable, "disable", false, "automatically disable rule before deleting it")
 
     ruleListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "skip this many entities from the head of the collection")
     ruleListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return this many entities from the collection")

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -214,24 +214,11 @@ var triggerCreateCmd = &cobra.Command{
             whisk.Debug(whisk.DbgInfo, "Trigger feed annotations: %#v\n", annotations)
         }
 
-        whisk.Debug(whisk.DbgInfo, "Trigger shared: %s\n", flags.common.shared)
-        shared := strings.ToLower(flags.common.shared)
-        if shared != "yes" && shared != "no" && shared != "" {  // "" means argument was not specified
-            whisk.Debug(whisk.DbgError, "Shared argument value '%s' is invalid\n", flags.common.shared)
-            errStr := fmt.Sprintf("Invalid --shared argument value '%s'; valid values are 'yes' or 'no'", flags.common.shared)
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), nil, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        publish := false
-        if shared == "yes" {
-            publish = true
-        }
-
         trigger := &whisk.Trigger{
             Name:        qName.entityName,
             Parameters:  parameters,
             Annotations: annotations,
-            Publish:     publish,
+            Publish:     flags.common.shared,
         }
 
         retTrigger, _, err := client.Triggers.Insert(trigger, false)
@@ -323,32 +310,11 @@ var triggerUpdateCmd = &cobra.Command{
             return werr
         }
 
-        whisk.Debug(whisk.DbgInfo, "Trigger shared: %s\n", flags.common.shared)
-        shared := strings.ToLower(flags.common.shared)
-
-        if shared != "yes" && shared != "no" && shared != "" {  // "" means argument was not specified
-            whisk.Debug(whisk.DbgError, "Shared argument value '%s' is invalid\n", flags.common.shared)
-            errStr := fmt.Sprintf("Invalid --shared argument value '%s'; valid values are 'yes' or 'no'", flags.common.shared)
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), nil, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        publishSet := false
-        publish := false
-        if shared == "yes" {
-            publishSet = true
-            publish = true
-        } else if shared == "no" {
-            publishSet = true
-            publish = false
-        }
-
         trigger := &whisk.Trigger{
             Name:        qName.entityName,
             Parameters:  parameters,
             Annotations: annotations,
-        }
-        if publishSet {
-            trigger.Publish = publish
+            Publish: flags.common.shared,
         }
 
         retTrigger, _, err := client.Triggers.Insert(trigger, true)
@@ -603,12 +569,12 @@ func init() {
 
     triggerCreateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")
     triggerCreateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
-    triggerCreateCmd.Flags().StringVar(&flags.common.shared, "shared", "no", "shared action [yes|no]")
+    triggerCreateCmd.Flags().BoolVar(&flags.common.shared, "shared", false, "make a trigger publically accessible")
     triggerCreateCmd.Flags().StringVarP(&flags.common.feed, "feed", "f", "", "trigger feed")
 
     triggerUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")
     triggerUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
-    triggerUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "shared action (yes = shared, no[default] = private)")
+    triggerUpdateCmd.Flags().BoolVar(&flags.common.shared, "shared", false, "make a trigger publically accessible")
 
     triggerFireCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
 

--- a/tools/go-cli/go-whisk/whisk/package.go
+++ b/tools/go-cli/go-whisk/whisk/package.go
@@ -35,7 +35,7 @@ type PackageInterface interface {
 }
 
 // Use this struct to create/update a package/binding with the Publish setting
-type SentPackagePublish struct {
+type SentPackage struct {
     Namespace string `json:"-"`
     Name      string `json:"-"`
     Version   string `json:"version,omitempty"`
@@ -43,20 +43,7 @@ type SentPackagePublish struct {
     Annotations 	 `json:"annotations,omitempty"`
     Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
 }
-func (p *SentPackagePublish) GetName() string {
-    return p.Name
-}
-
-// Use this struct to update a package/binding with no change to the Publish setting
-type SentPackageNoPublish struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
-}
-func (p *SentPackageNoPublish) GetName() string {
+func (p *SentPackage) GetName() string {
     return p.Name
 }
 

--- a/tools/go-cli/go-whisk/whisk/rule.go
+++ b/tools/go-cli/go-whisk/whisk/rule.go
@@ -32,7 +32,7 @@ type Rule struct {
     Namespace string `json:"namespace,omitempty"`
     Name      string `json:"name,omitempty"`
     Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
+    Publish   bool   `json:"publish"`
 
     Status  string `json:"status"`
     Trigger string `json:"trigger"`


### PR DESCRIPTION
- Remove logic for --shared flag to take arguments
- If --shared is present in a command, the entity will be public.
  Otherwise, the entity will not be publically shared