### PR TITLE
[Ready] Fix issue #816. 

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/DefaultRuntimeVersions.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DefaultRuntimeVersions.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package main.scala.whisk.core.entity
+package whisk.core.entity
 
 trait DefaultRuntimeVersions {
     def resolveDefaultRuntime(kind: String): String = {

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -16,17 +16,16 @@
 
 package whisk.core.entity
 
-import scala.collection.JavaConversions.asScalaSet
-import spray.json.DefaultJsonProtocol
-import spray.json.RootJsonFormat
-import spray.json.{ JsValue, JsObject, JsString, JsArray }
-import spray.json.DeserializationException
-import whisk.core.entity.ArgNormalizer.trim
-import spray.json.pimpString
-import scala.util.Try
-import spray.json.DeserializationException
 import java.util.Base64
-import main.scala.whisk.core.entity.DefaultRuntimeVersions
+
+import spray.json.DefaultJsonProtocol
+import spray.json.DeserializationException
+import spray.json.JsArray
+import spray.json.JsObject
+import spray.json.JsString
+import spray.json.JsValue
+import spray.json.RootJsonFormat
+import whisk.core.entity.ArgNormalizer.trim
 
 /**
  * Exec encodes the executable details of an action. For black

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -386,9 +386,14 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         } getOrElse action.limits
 
         // This is temporary while we are making sequencing directly supported in the controller.
-        // The parameter override allows this to work with Pipecode.code. Any parameters other
-        // than the action sequence itself are discarded and have no effect unless a non-sequence
-        // exec is given.
+        // Actions that are updated with a sequence will have their parameter property overriden.
+        // Actions that are updated with non-sequence actions will either set the parameter property according to
+        // the content provided, or if that is not defined, and iff the previous version of the action was not a
+        // sequence, inherit previous parameters. This is because sequence parameters are special and should not
+        // leak to non-sequence actions.
+        // If updating an action but not specifying a new exec type, then preserve the previous parameters if the
+        // existing type of the action is a sequence (regardless of what parameters may be defined in the content)
+        // otherwise, parameters are inferred from the content or previous values.
         val parameters = content.exec map {
             case seq: SequenceExec => Parameters("_actions", JsArray(seq.components map { JsString(_) }))
             case _ => content.parameters getOrElse {

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -261,11 +261,13 @@ class WskBasicTests
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) =>
                     action.create(name, file, parameters = params, shared = Some(true))
-                    action.create(name, None, update = true)
+                    action.create(name, None, parameters = Map("b" -> "B".toJson), update = true)
             }
             val stdout = wsk.action.get(name).stdout
-            stdout should include regex (""""key": "a"""")
-            stdout should include regex (""""value": "A"""")
+            stdout should not include regex (""""key": "a"""")
+            stdout should not include regex (""""value": "A"""")
+            stdout should include regex (""""key": "b""")
+            stdout should include regex (""""value": "B"""")
             stdout should include regex (""""publish": true""")
             stdout should include regex (""""version": "0.0.2"""")
             wsk.action.list().stdout should include(name)


### PR DESCRIPTION
When updating an action that is already a sequence or when updating an action with a sequence, set parameters explicitly. If new action is not a sequence or if the type of the existing action is not a sequence, preserve new parameters or use pre-existing parameters.

This logic will be removed when sequences are fully converted to a first class entity type. In the previous incremental commit toward this goal, I didn't quite get the logic correct on the update operation. I added more tests to cover the different use cases, including a test we did not have for using the CLI to do an action update defining only new parameters.

@perryibm @markusthoemmes @ChrBi for your reviewing pleasure.
FYI @dubeejw @mdeuser note new test (passed go cli).

PPG 736 approved.