### PR TITLE
[Ready] Fewer `ActorSystem`s

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     compile 'io.spray:spray-io_2.11:1.3.3'
     compile 'io.spray:spray-routing_2.11:1.3.3'
 
-    compile 'com.typesafe.akka:akka-actor_2.11:2.3.9'
-    compile 'com.typesafe.akka:akka-slf4j_2.11:2.3.9'
+    compile 'com.typesafe.akka:akka-actor_2.11:2.4.7'
+    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.7'
 
     compile 'log4j:log4j:1.2.16'
     compile 'commons-codec:commons-codec:1.9'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 
     compile 'com.typesafe.akka:akka-actor_2.11:2.4.7'
     compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.7'
+    compile 'com.typesafe.akka:akka-http-core_2.11:2.4.7'
+    compile 'com.typesafe.akka:akka-http-spray-json-experimental_2.11:2.4.7'
 
     compile 'log4j:log4j:1.2.16'
     compile 'commons-codec:commons-codec:1.9'

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -1,2 +1,12 @@
 # default application configuration file for spray/akka
 include "logging"
+
+akka.http {
+    client {
+        parsing.illegal-header-warnings = off
+    }
+
+    host-connection-pool {
+        max-connections = 16
+    }
+}

--- a/common/scala/src/main/scala/whisk/common/ConsulKVReporter.scala
+++ b/common/scala/src/main/scala/whisk/common/ConsulKVReporter.scala
@@ -48,8 +48,9 @@ class ConsulKVReporter(
     startKey: String,
     statusKey: String,
     updater: () => Map[String, JsValue])(
-        implicit val system: ActorSystem,
-        val ec: ExecutionContext) {
+        implicit val system: ActorSystem) {
+
+    implicit val executionContext = system.dispatcher
 
     system.scheduler.scheduleOnce(initialDelay) {
         val (selfHostname, stderr, exitCode) = SimpleExec.syncRunCmd(Array("hostname", "-f"))(TransactionId.unknown)

--- a/common/scala/src/main/scala/whisk/core/connector/LoadbalancerRequest.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/LoadbalancerRequest.scala
@@ -50,7 +50,9 @@ trait LoadbalancerRequest extends HttpClient {
      * and returns the HTTP response from the load balancer as a future
      */
     protected def request(loadbalancerHost: String, timeout: Timeout = 5 seconds)(
-        implicit as: ActorSystem, ec: ExecutionContext): HttpRequest => Future[LoadBalancerResponse] = {
+        implicit as: ActorSystem): HttpRequest => Future[LoadBalancerResponse] = {
+
+        implicit val executionContext = as.dispatcher
         val loadbalancer = loadbalancerHost.split(":")
         (req: HttpRequest) => {
             httpRequest(loadbalancer(0), loadbalancer(1).toInt, timeout) flatMap {

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -21,8 +21,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Try, Success, Failure }
 import spray.json.JsObject
-import spray.http.StatusCode
-import spray.http.StatusCodes
+import akka.http.scaladsl.model.{ StatusCode, StatusCodes }
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.entity.WhiskDocument

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -107,8 +107,7 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
 }
 
 object BasicHttpService extends Directives {
-    def startService[T <: Actor](name: String, interface: String, port: Integer, service: Creator[T]) = {
-        val system = ActorSystem(name)
+    def startService[T <: Actor](system: ActorSystem, name: String, interface: String, port: Integer, service: Creator[T]) = {
         val actor = system.actorOf(Props.create(service), s"$name-service")
 
         implicit val timeout = Timeout(5 seconds)

--- a/common/scala/src/main/scala/whisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicRasService.scala
@@ -17,6 +17,7 @@
 package whisk.http
 
 import akka.actor.Actor
+import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.japi.Creator
 import spray.http.MediaTypes.`application/json`
@@ -50,8 +51,8 @@ trait BasicRasService extends BasicHttpService {
  */
 object BasicRasService {
 
-    def startService(name: String, interface: String, port: Integer) = {
-        BasicHttpService.startService(name, interface, port, new ServiceBuilder)
+    def startService(system: ActorSystem, name: String, interface: String, port: Integer) = {
+        BasicHttpService.startService(system, name, interface, port, new ServiceBuilder)
     }
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -68,13 +68,13 @@ object WhiskServices extends LoadbalancerRequest {
      * Creates instance of an entitlement service.
      */
     def entitlementService(config: WhiskConfig, timeout: FiniteDuration = 5 seconds)(
-        implicit as: ActorSystem, ec: ExecutionContext) = {
+        implicit as: ActorSystem) = {
         // remote entitlement service requires a host:port definition. If not given,
         // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
         if (config.entitlementHost.startsWith(":")) {
             new LocalEntitlementService(config)
         } else {
-            new RemoteEntitlementService(config, timeout, as, ec)
+            new RemoteEntitlementService(config, timeout)
         }
     }
 
@@ -87,7 +87,7 @@ object WhiskServices extends LoadbalancerRequest {
      * and returns the HTTP response from the load balancer as a future
      */
     def makeLoadBalancerComponent(config: WhiskConfig, timeout: Timeout = 10 seconds)(
-        implicit as: ActorSystem, ec: ExecutionContext):
+        implicit as: ActorSystem):
         (LoadBalancerReq => Future[LoadBalancerResponse], () => JsObject, (ActivationId, TransactionId) => Future[WhiskActivation]) = {
         val loadBalancer = new LoadBalancerService(config, Verbosity.Loud)
         val requestTaker = (lbr: LoadBalancerReq) => { loadBalancer.doPublish(lbr._1, lbr._2)(lbr._3) }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -118,12 +118,13 @@ protected[controller] trait RespondWithHeaders extends Directives {
 protected[controller] class RestAPIVersion_v1(
     config: WhiskConfig,
     verbosity: Verbosity.Level,
-    implicit val actorSystem: ActorSystem,
-    implicit val executionContext: ExecutionContext)
+    implicit val actorSystem: ActorSystem)
     extends RestAPIVersion("v1", config(whiskVersionDate), config(whiskVersionBuildno))
     with Authenticate
     with AuthenticatedRoute
     with RespondWithHeaders {
+
+    implicit val executionContext = actorSystem.dispatcher
 
     /**
      * Here is the key method: it defines the Route (route tree) which implement v1 of the REST API.

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -17,7 +17,6 @@
 package whisk.core.entitlement
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.DurationInt
@@ -45,10 +44,11 @@ import whisk.core.entity.Subject
 
 protected[core] class RemoteEntitlementService(
     private val config: WhiskConfig,
-    private val timeout: FiniteDuration = 5 seconds,
-    private implicit val actorSystem: ActorSystem,
-    private implicit val ec: ExecutionContext)
+    private val timeout: FiniteDuration = 5 seconds)(
+    private implicit val actorSystem: ActorSystem)
     extends EntitlementService(config) {
+
+    private implicit val executionContext = actorSystem.dispatcher
 
     private val apiLocation = config.entitlementHost
     private val matrix = TrieMap[(Subject, String), Set[Privilege]]()

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
@@ -56,8 +55,9 @@ class InvokerHealth(
     config: WhiskConfig,
     instanceChange: Array[Int] => Unit,
     getKafkaPostCount: () => Int)(
-        implicit val system: ActorSystem,
-        val ec: ExecutionContext) extends Logging {
+        implicit val system: ActorSystem) extends Logging {
+
+    private implicit val executionContext = system.dispatcher
 
     setComponentName("LoadBalancer");
     setVerbosity(Verbosity.Loud);

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -49,10 +49,11 @@ import whisk.core.entity.WhiskActivation
 import whisk.utils.ExecutionContextFactory.PromiseExtensions
 
 class LoadBalancerService(config: WhiskConfig, verbosity: Verbosity.Level)(
-    implicit val actorSystem: ActorSystem,
-    val executionContext: ExecutionContext)
+    implicit val actorSystem: ActorSystem)
     extends LoadBalancerToKafka
     with Logging {
+
+    implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
     /**
      * The two public methods are getInvokerHealth and the inherited doPublish methods.

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -40,7 +40,7 @@ import scala.language.postfixOps
 @RunWith(classOf[JUnitRunner])
 class KafkaConnectorTests extends FlatSpec with Matchers with BeforeAndAfter {
     implicit val transid = TransactionId.testing
-    implicit val ec = ExecutionContextFactory.makeCustomThreadPoolExecutionContext(poolSize = 4)
+    implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
 
     behavior of "Kafka connector"
 

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -82,6 +82,8 @@ class ContainerPoolTests extends FlatSpec
     override def afterAll() {
         println("Shutting down store connections")
         datastore.shutdown()
+        println("Shutting down HTTP connections")
+        Await.result(akka.http.scaladsl.Http().shutdownAllConnectionPools(), Duration.Inf)
         println("Shutting down actor system")
         actorSystem.terminate()
         Await.result(actorSystem.whenTerminated, Duration.Inf)

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -17,6 +17,8 @@
 package whisk.core.container.test
 
 import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 import akka.actor.ActorSystem
 
@@ -81,7 +83,8 @@ class ContainerPoolTests extends FlatSpec
         println("Shutting down store connections")
         datastore.shutdown()
         println("Shutting down actor system")
-        actorSystem.shutdown()
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     /**

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -73,6 +73,7 @@ protected trait ControllerTestCommon
     implicit val routeTestTimeout = RouteTestTimeout(90 seconds)
 
     implicit val actorSystem = ActorSystem("controllertests")
+    val executionContext = actorSystem.dispatcher
 
     val config = new WhiskConfig(WhiskActionsApi.requiredProperties)
     assert(config.isValid)

--- a/tests/src/whisk/core/database/test/DbPing.scala
+++ b/tests/src/whisk/core/database/test/DbPing.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.{ Try, Success, Failure }
+
+import akka.actor.ActorSystem
+
+import akka.stream.ActorMaterializer
+import akka.stream.OverflowStrategy
+import akka.stream.QueueOfferResult
+import akka.stream.scaladsl._
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.unmarshalling._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+import org.junit.runner.RunWith
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+
+import whisk.core.WhiskConfig
+import whisk.core.WhiskConfig._
+
+@RunWith(classOf[JUnitRunner])
+class DbPing extends FlatSpec
+    with BeforeAndAfter
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Matchers {
+
+    override implicit val patienceConfig = PatienceConfig(timeout = 10.seconds, interval = 0.5.seconds)
+
+    implicit val actorSystem      = ActorSystem()
+    implicit val executionContext = actorSystem.dispatcher
+    implicit val materializer     = ActorMaterializer()
+
+    override def afterAll() {
+        println("Shutting down materializer")
+        materializer.shutdown()
+        println("Shutting down HTTP connections")
+        Await.result(akka.http.scaladsl.Http().shutdownAllConnectionPools(), Duration.Inf)
+        println("Shutting down actor system")
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
+    }
+
+    lazy val config = new WhiskConfig(Map(
+        dbProvider -> null,
+        dbProtocol -> null,
+        dbUsername -> null,
+        dbPassword -> null,
+        dbHost -> null,
+        dbPort -> null))
+
+    lazy val dbRootUri = Uri(
+        scheme = config.dbProtocol,
+        authority = Uri.Authority(
+            host = Uri.Host(config.dbHost),
+            port = config.dbPort.toInt),
+        path = Uri.Path("/")
+    )
+
+    lazy val dbRootRequest = HttpRequest(
+        headers = List(
+            Authorization(BasicHttpCredentials(config.dbUsername, config.dbPassword)),
+            Accept(MediaTypes.`application/json`)),
+        uri = dbRootUri
+    )
+
+    behavior of "Database ping"
+
+    it should "retrieve CouchDB/Cloudant DB info" in {
+        assume(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB")
+
+        val f: Future[JsObject] = Http().singleRequest(dbRootRequest).flatMap { response =>
+            Unmarshal(response.entity).to[JsObject]
+        }
+
+        whenReady(f) { js =>
+            js.fields.get("couchdb") shouldBe defined
+            js.fields("couchdb").convertTo[String] should equal("Welcome")
+        }
+    }
+}

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -19,6 +19,8 @@ package whisk.core.dispatcher.test
 import java.util.Calendar
 
 import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 import akka.actor.ActorSystem
 
@@ -55,10 +57,12 @@ class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with Be
 
     val dispatcher = new TestDispatcher("whisk")
 
-    implicit val actorSystem = ActorSystem()
+    implicit val actorSystem = ActorSystem("dispatchertests")
 
     override def afterAll() {
-        actorSystem.shutdown()
+        println("Shutting down actor system")
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     behavior of "Dispatcher"

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -53,11 +53,11 @@ import whisk.core.entity.WhiskTrigger
 @RunWith(classOf[JUnitRunner])
 class DispatcherTests extends FlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
     implicit val transid = TransactionId.testing
-    implicit val ec = Dispatcher.executionContext
-
-    val dispatcher = new TestDispatcher("whisk")
 
     implicit val actorSystem = ActorSystem("dispatchertests")
+    implicit val ec = actorSystem.dispatcher
+
+    val dispatcher = new TestDispatcher("whisk")
 
     override def afterAll() {
         println("Shutting down actor system")

--- a/tests/src/whisk/core/dispatcher/test/TestConnector.scala
+++ b/tests/src/whisk/core/dispatcher/test/TestConnector.scala
@@ -19,6 +19,7 @@ package whisk.core.dispatcher.test
 import java.util.concurrent.LinkedBlockingQueue
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
@@ -29,7 +30,7 @@ import whisk.core.connector.MessageConsumer
 import whisk.core.connector.MessageProducer
 import whisk.core.dispatcher.MessageDispatcher
 
-class TestDispatcher(topic: String)
+class TestDispatcher(topic: String)(implicit val executionContext: ExecutionContext)
     extends MessageDispatcher
     with MessageConsumer {
 

--- a/tests/src/whisk/core/entity/test/ConformanceTests.scala
+++ b/tests/src/whisk/core/entity/test/ConformanceTests.scala
@@ -17,7 +17,11 @@
 package whisk.core.entity.test
 
 import akka.actor.ActorSystem
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 import scala.util.Try
+
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
@@ -50,7 +54,6 @@ class ConformanceTests extends FlatSpec
     implicit val defaultPatience =
         PatienceConfig(timeout = Span(1, Minutes), interval = Span(1, Seconds))
 
-
     // Properties for WhiskAuthStore and WhiskEntityStore.
     val config = new WhiskConfig(Map(
         dbProvider -> null,
@@ -74,7 +77,8 @@ class ConformanceTests extends FlatSpec
         datastore.shutdown()
         authstore.shutdown()
         println("Shutting down actor system")
-        actorSystem.shutdown()
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     /**

--- a/tests/src/whisk/core/entity/test/ConformanceTests.scala
+++ b/tests/src/whisk/core/entity/test/ConformanceTests.scala
@@ -111,7 +111,7 @@ class ConformanceTests extends FlatSpec
         }
     }
 
-    /* "Auth Database" */ ignore should "conform to expected schema" in {
+    "Auth Database" should "conform to expected schema" in {
         checkDatabaseFields(authstore, "subjects/uuids", _ => true, Set("subject", "uuid", "key", "_id", "_rev"))
     }
 

--- a/tests/src/whisk/core/entity/test/ConformanceTests.scala
+++ b/tests/src/whisk/core/entity/test/ConformanceTests.scala
@@ -76,6 +76,8 @@ class ConformanceTests extends FlatSpec
         println("Shutting down store connections")
         datastore.shutdown()
         authstore.shutdown()
+        println("Shutting down HTTP connections")
+        Await.result(akka.http.scaladsl.Http().shutdownAllConnectionPools(), Duration.Inf)
         println("Shutting down actor system")
         actorSystem.terminate()
         Await.result(actorSystem.whenTerminated, Duration.Inf)

--- a/tests/src/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/whisk/core/entity/test/DatastoreTests.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 
 import scala.Vector
 import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 import akka.actor.ActorSystem
 
@@ -76,7 +77,8 @@ class DatastoreTests extends FlatSpec
         datastore.shutdown()
         authstore.shutdown()
         println("Shutting down actor system")
-        actorSystem.shutdown()
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     @volatile var counter = 0

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -19,6 +19,7 @@ package whisk.core.entity.test
 import java.time.Clock
 import java.time.Instant
 import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.util.Try
 import akka.actor.ActorSystem
 import org.junit.runner.RunWith
@@ -96,7 +97,8 @@ class ViewTests extends FlatSpec
         println("Shutting down store connections")
         datastore.shutdown()
         println("Shutting down actor system")
-        actorSystem.shutdown()
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     behavior of "Datastore View"

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -67,7 +67,8 @@ class ViewTests extends FlatSpec
     with Matchers
     with DbUtils {
 
-    implicit val actorSystem = ActorSystem()
+    implicit val actorSystem      = ActorSystem()
+    implicit val executionContext = actorSystem.dispatcher
 
     def aname = MakeName.next("viewtests")
 
@@ -96,6 +97,8 @@ class ViewTests extends FlatSpec
     override def afterAll() {
         println("Shutting down store connections")
         datastore.shutdown()
+        println("Shutting down HTTP connections")
+        Await.result(akka.http.scaladsl.Http().shutdownAllConnectionPools(), Duration.Inf)
         println("Shutting down actor system")
         actorSystem.terminate()
         Await.result(actorSystem.whenTerminated, Duration.Inf)

--- a/tests/src/whisk/core/invoker/test/InvokerTests.scala
+++ b/tests/src/whisk/core/invoker/test/InvokerTests.scala
@@ -19,7 +19,7 @@ package whisk.core.invoker.test
 import java.util.Calendar
 
 import scala.concurrent.Await
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 
@@ -82,7 +82,8 @@ class InvokerTests extends FlatSpec
         authstore.shutdown()
         activationstore.shutdown()
         println("Shutting down actor system")
-        actorSystem.shutdown()
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, Duration.Inf)
     }
 
     behavior of "Invoker"

--- a/tests/src/whisk/core/invoker/test/InvokerTests.scala
+++ b/tests/src/whisk/core/invoker/test/InvokerTests.scala
@@ -81,6 +81,8 @@ class InvokerTests extends FlatSpec
         datastore.shutdown()
         authstore.shutdown()
         activationstore.shutdown()
+        println("Shutting down HTTP connections")
+        Await.result(akka.http.scaladsl.Http().shutdownAllConnectionPools(), Duration.Inf)
         println("Shutting down actor system")
         actorSystem.terminate()
         Await.result(actorSystem.whenTerminated, Duration.Inf)


### PR DESCRIPTION
This PR is built on top of #765 because it assumes Akka 2.4.7 (and therefore shouldn't be merged before it). Only the last two commits are specific to this PR.

Makes it more explicit where `ActorSystem`s are created. Eliminates the creation of one spurious system in the invoker. Generalizes the practice of retrieving `ExecutionContext`s from `ActorSystem`s when available.

Taking the actor system out of `BasicHttpService` is also a required step towards having cohabiting Spray and Akka HTTP API endpoints.

