### PR TITLE
Link redo to wskdev (issue #834)

### DIFF
--- a/bin/wskdev
+++ b/bin/wskdev
@@ -1,0 +1,1 @@
+../tools/build/redo

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -26,10 +26,7 @@ import subprocess
 # the default openwhisk location in openwhisk checkouts
 defaultOpenwhisk = os.path.dirname(os.path.realpath(__file__)) + '/../../'
 # the openwhisk env var overrides if it exists
-openwhiskHome = os.getenv('OPENWHISK_HOME', defaultOpenwhisk)
-cliDir = os.path.join(openwhiskHome, 'tools/cli')
-sys.path.insert(1, cliDir)
-import wskprop
+whiskHome = os.getenv('WHISK_HOME', defaultOpenwhisk)
 
 def main():
     args = getArgs()
@@ -96,11 +93,11 @@ def getArgs():
         exit(-1)
 
     if args.dir is None:
-        if openwhiskHome is None:
+        if whiskHome is None:
             print 'Must specify whisk home directory with "--dir".'
             exit(-1)
         else:
-            args.dir = openwhiskHome
+            args.dir = whiskHome
 
     if args.list:
         print "{:<27}{:<40}".format(bold('component'), bold('description'))

--- a/tools/build/scanCode.py
+++ b/tools/build/scanCode.py
@@ -39,6 +39,7 @@ def exceptional_paths():
     return [
         "bin/wsk",
         "bin/wskadmin",
+        "bin/wskdev",
         "bin/go-cli/wsk",
         "tests/src/com/google/code/tempusfugit/concurrency/ParallelRunner.java"
     ]


### PR DESCRIPTION
- links `redo` to `wskdev`.
- allows `redo` to operate from `WHISK_HOME` defined in the environment (must have gradelw and ansible playbooks)
- remove deadcode