### PR TITLE
Go CLI Does Not Produce Proper Error Message When Creating an Action …

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -591,7 +591,7 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
         stat, err := os.Stat(artifact)
         if err != nil {
             whisk.Debug(whisk.DbgError, "os.Stat(%s) error: %s\n", artifact, err)
-            errMsg := fmt.Sprintf("File '%s' does not exist: %s", artifact, err)
+            errMsg := fmt.Sprintf("The artifact \"%s\" is not a valid file. If this is a docker image, use --docker.: %s", artifact, err)
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_USAGE,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return nil, sharedSet, whiskErr


### PR DESCRIPTION
…with a Missing File

- Update the error message that is displayed when action create is invoke with a missing file
- Fixes "reject create with missing file" test failure in WskBasicTests