### PR TITLE
Reverting the switch for CLIActionTests suite

### DIFF
--- a/tests/src/system/basic/CLIActionTests.java
+++ b/tests/src/system/basic/CLIActionTests.java
@@ -44,7 +44,7 @@ import common.WskCli;
  */
 @RunWith(ParallelRunner.class)
 public class CLIActionTests {
-    private static final Boolean usePythonCLI = false;
+    private static final Boolean usePythonCLI = true;
     private static final WskCli wsk = new WskCli(usePythonCLI);
 
     public static final String[] sampleTestWords = new String[] { "SHERLOCK", "WATSON", "LESTRADE" };


### PR DESCRIPTION
These tests have proven non-stable for the moment. Temporarily reverting the switch to use python based CLI again.