### PR TITLE
Adding registry to the identifier for the Go CLI

### DIFF
--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -18,7 +18,7 @@ task removeBinary(type: Delete) {
 task distBinary(dependsOn: [removeBinary, distDocker]) << {
     run(dockerBinary + ["rm", "-f", dockerContainerName], true)
     run(["mkdir", "${projectDir}/../../bin/go-cli/"])
-    run(dockerBinary + ["run", "--name", dockerContainerName, dockerImageName + ":" + dockerImageTag])
+    run(dockerBinary + ["run", "--name", dockerContainerName, dockerRegistry + dockerImageName + ":" + dockerImageTag])
 
     // Copy all Go binaries from Docker into openwhisk/bin/go-cli folder
     run(dockerBinary + ["cp", dockerContainerName +


### PR DESCRIPTION
As per title. Needed in environments with a deployed registry