### PR TITLE
Add Ability to Test a Downloaded Go CLI

### DIFF
--- a/tests/src/common/WhiskProperties.java
+++ b/tests/src/common/WhiskProperties.java
@@ -181,7 +181,7 @@ public class WhiskProperties {
         return whiskProperties.getProperty("kafka.docker.endpoint");
     }
 
-    public static boolean useCliDownload() {
+    public static boolean useCLIDownload() {
         return whiskProperties.getProperty("use.cli.download").equals("true");
     }
 

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -730,59 +730,34 @@ object Wsk {
     private val binaryName = "wsk"
 
     /** What is the path to a downloaded CLI? **/
-    private def getDownloadedCliPath = {
+    private def getDownloadedPythonCLIPath = {
         s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}${binaryName}"
     }
 
+    /** What is the path to a downloaded CLI? **/
+    private def getDownloadedGoCLIPath = {
+        s"${System.getProperty("user.home")}${File.separator}.local${File.separator}bin${File.separator}go-cli${File.separator}${binaryName}"
+    }
+
     def exists(usePythonCLI: Boolean) = {
-        if (WhiskProperties.useCliDownload) {
-            val binary = getDownloadedCliPath
-            val f = new File(binary)
-            assert(f.exists, s"did not find $f")
+        val cliPath = if (usePythonCLI) {
+            if (WhiskProperties.useCLIDownload) getDownloadedPythonCLIPath else WhiskProperties.getPythonCLIPath
         } else {
-            val cliPath = if (usePythonCLI) {
-                WhiskProperties.getPythonCLIPath();
-            } else {
-                WhiskProperties.getGoCLIPath();
-            }
-
-            val cliDir = if (usePythonCLI) {
-                WhiskProperties.getPythonCLIDir();
-            } else {
-                WhiskProperties.getGoCLIDir();
-            }
-
-            val dir = new File(cliDir)
-            val exec = new File(cliPath)
-            assert(dir.exists, s"did not find $dir")
-            assert(exec.exists, s"did not find $exec")
+            if (WhiskProperties.useCLIDownload) getDownloadedGoCLIPath else WhiskProperties.getGoCLIPath
         }
+
+        assert((new File(cliPath)).exists, s"did not find $cliPath")
     }
 
-    def baseCommand(usePythonCLI: Boolean) =  {
-        if (WhiskProperties.useCliDownload()) {
-            Buffer(getDownloadedCliPath)
+    def baseCommand(usePythonCLI: Boolean) =
+        if (usePythonCLI) {
+            if (WhiskProperties.useCLIDownload)
+                Buffer(WhiskProperties.python, getDownloadedPythonCLIPath)
+            else
+                Buffer(WhiskProperties.python, WhiskProperties.getPythonCLIPath)
         } else {
-            val cliPath = if (usePythonCLI) {
-                WhiskProperties.getPythonCLIPath();
-            } else {
-                WhiskProperties.getGoCLIPath();
-            }
-
-            val cliDir = if (usePythonCLI) {
-                WhiskProperties.getPythonCLIDir();
-            } else {
-                WhiskProperties.getGoCLIDir();
-            }
-
-            if (usePythonCLI) {
-                Buffer(WhiskProperties.python, new File(cliPath).toString)
-
-            } else {
-                Buffer(new File(cliPath).toString)
-            }
+            if (WhiskProperties.useCLIDownload) Buffer(getDownloadedGoCLIPath) else Buffer(WhiskProperties.getGoCLIPath)
         }
-    }
 }
 
 sealed trait RunWskCmd {


### PR DESCRIPTION
- Use a downloaded Go CLI with automationed test suite if property is specificed in whisk.properties
- Get downloaded Go CLI path
- Update WskCLI.java, and Wsk.scala to run automation against a downloaded Go CLI