### PR TITLE
Jenkins/Travis tools script, for monitoring and analyzing jobs from CI.

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,27 +1,64 @@
 # Build helper scripts
 
-This directory contains `scanCode.py`, which checks all code for conformance with respect to certain conventions, and the `redo` script, a wrapper around Ansible and Gradle commands, for which examples are given below.
+This directory contains the following utilities:
+- `scanCode.py`: checks all code for conformance with respect to certain conventions,
+- `redo`: a wrapper around Ansible and Gradle commands, for which examples are given below,
+- `citool`: allows for command line monitoring of Jenkins and Travis CI builds.
 
-## Usage information
-`redo -h`
 
-## Initialize environment and `docker-machine` (for mac)
-`redo setup prereqs`
+## How to use `redo`
 
-### Start CouchDB container and initialize DB with system and guest keys
-`redo couchdb initdb`
+The script is called `redo` because for most development, one will want to "redo" the compilation and deployment.
 
-### Deploy
-`redo deploy`
+- usage information: `redo -h`
+- initialize environment and `docker-machine` (for mac): `redo setup prereqs`
+- start CouchDB container and initialize DB with system and guest keys: `redo couchdb initdb`
+- build and deploy system: `redo deploy`
+- run tests: `redo props tests`
 
-...and optionally to run tests:
-`redo props tests`
+To do a fresh build and deploy all with one line for a first time run `redo setup prereqs couchdb initdb deploy tests` as each of these is executed sequentially.
 
-*Or* to do it all with one line for a first time run `redo setup prereqs couchdb initdb deploy tests` as each of these is executed sequentially.
-
-The script is called `redo` because for most development, one will want to "redo" the compilation and deployment of a unit as in `redo controller` which will `gradle` build the `controller`, teardown down the previous container and replace it with a new container (aka "hotswapping").
+Individual components such as the `controller` may be rebuilt and redeployed as well.
 
   * To only build: `redo controller -b`.
   * To only teardown: `redo controller -x`.
   * To redeploy only: `redo controller -d`.
   * To do all at once: `redo controller -bxd` which is the default.
+
+## How to use `citool` 
+
+This script allows for monitoring of ongoing Jenkins and Travis builds.
+The script assumes by default that the monitored job is a Travis CI build hosted here `https://api.travis-ci.org/`.
+To change the Travis (or Jenkins) host URL, use `-u`.
+
+- usage information: `citool -h`
+- monitor a Travis CI build with job number `N`: `citool monitor N`
+- monitor same job `N` until completion: `citool monitor -p N`
+- save job output to a file: `citool -o monitor N`
+
+To monitor a Jenkins build `B` with job number `N` on host `https://jenkins.host:port`:
+```
+citool -u https://jenkins.host:port -b B monitor N
+```
+
+The script also allows for gathering controller and invoker log artifacts from a Jenkins build job. For example,
+to retrieve logs for a deployment with 1 controller and 1 invoker for build `B` with job number `N` on
+host `https://jenkins.host:port` with the artifacts are stored in `whisk/logs` relative to the job URL:
+
+```
+citool -u https://jenkins.host:port -b B cat whisk/logs N
+```
+
+It is sometimes convenient to save the logs locally (via `citool -o ...`) to avoid fetching them repeatedly if one wishes
+to inspect the logs and extract a specific transaction. Logs statements may be sorted according to their timestamps using `cat -s`.
+Additionally to grep for a specific expression, use `cat -g`.
+
+```
+citool -o -u https://jenkins.host:port -b B cat -s -g "tid_123" whisk/logs N
+```
+
+The logs are saved to `./B-build.log` and can be reprocessed using `citool` with `-i`.
+
+```
+citool -i -b B cat -s -g "tid_124" whisk/logs N
+```

--- a/tools/build/citool
+++ b/tools/build/citool
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# Jenkins/Travis tools script, for monitoring and analyzing jobs from CI.
+#
+# Example use to monitor a travis build, job number N:
+# > citool monitor N
+#
+# To monitor same job until completion:
+# > citool monitor -p N
+#
+# To save job output to a file:
+# > citool -o monitor N
+#
+# Example use to monitor a jenkins build B with job number N:
+# > citool -u https://jenkins.host:port -b B monitor N
+##
+
+import sys
+import time
+import traceback
+import argparse
+import httplib
+import re
+import threading
+from xml.dom import minidom
+from subprocess import Popen, PIPE, STDOUT
+from urlparse import urlparse
+
+def main():
+    exitCode = 0
+    try:
+        args = parseArgs()
+        exitCode = {
+            'monitor' : monitor,
+            'cat': cat
+        }[args.cmd](args)
+    except Exception as e:
+        print 'Exception: ', e
+        if args.verbose:
+            traceback.print_exc()
+        exitCode = 1
+    sys.exit(exitCode)
+
+def parseArgs():
+    parser = argparse.ArgumentParser(description='tool for analyzing logs from CI')
+    subparsers = parser.add_subparsers(title='available commands', dest='cmd')
+
+    parser.add_argument('job', help='job number')
+    parser.add_argument('-b', '--build', help='build name', default='travis')
+    parser.add_argument('-v', '--verbose', help='verbose output', action='store_true')
+    parser.add_argument('-i', '--input-file', help='read logs from file rather than CI', action='store_true', dest='ifile')
+    parser.add_argument('-o', '--output-file', help='store intermediate buffer to a file (e.g., jenkins console or component logs)', action='store_true', dest='ofile')
+    parser.add_argument('-u', '--url', help='URL for CI build job (default is Travis CI)', default='https://api.travis-ci.org/')
+
+    subparser = subparsers.add_parser('monitor', help='report passing or failing tests (only failing tests by default)')
+    subparser.add_argument('-a', '--all', help='show all tests suites, passing and failing', action='store_true')
+    subparser.add_argument('-p', '--poll', help='repeat monitor every 10 seconds', action='store_true')
+
+    subparser = subparsers.add_parser('cat', help='concatenate logs from build (limited to Jenkins)')
+    subparser.add_argument('artifactPath', help='path to artifacts store')
+    subparser.add_argument('-g', '--grep', help='run grep against logs using provided value')
+    subparser.add_argument('-s', '--sort', help='sort logs by timestamp', action='store_true')
+    subparser.add_argument('-n', '--invokers', help='number of invokers', type=int, default=3)
+    subparser.add_argument('-c', '--controllers', help='number of controllers', type=int, default=1)
+
+    return parser.parse_args()
+
+def request(method, urlString, body = "", headers = {}, auth = None, verbose = False):
+    url = urlparse(urlString)
+    if url.scheme == 'http':
+        conn = httplib.HTTPConnection(url.netloc)
+    else:
+        conn = httplib.HTTPSConnection(url.netloc)
+
+    if verbose:
+        print "%s %s" % (method, urlString)
+
+    conn.request(method.upper(), urlString, body)
+    res = conn.getresponse()
+
+    if verbose:
+        print 'Got response with code %s' % res.status
+    return res
+
+def shell(cmd, data=None, verbose=False):
+    start = time.time()
+
+    if input:
+        p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE)
+        out, err = p.communicate(input=data)
+    else:
+        out, err = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT)
+
+    p.wait()
+    end = time.time()
+    delta = end - start
+    return (delta, out, err)
+
+def getJobUrl(args):
+    if args.build.lower() == 'travis':
+        url = '%s/jobs/%s' % (args.url, args.job)
+    else: # assume jenkins
+        url = '%s/job/%s/%s' % (args.url, args.build, args.job)
+    return url
+
+def monitor(args):
+    def poll():
+        (ex, finished) = monitorOnce(args)
+        if not finished:
+            threading.Timer(10.0, poll).start()
+
+    if args.poll:
+        poll()
+    else:
+        (ex, finished) = monitorOnce(args)
+        return ex
+
+def monitorOnce(args):
+    if args.ifile:
+        file = open('%s' % args.job, 'r')
+        body = file.read()
+        file.close()
+    else:
+        if args.build.lower() == 'travis':
+            url = '%s/log.txt' % getJobUrl(args)
+            res = request('get', url, verbose = args.verbose)
+            if res.status == httplib.TEMPORARY_REDIRECT:
+                url = res.getheader('location')
+                res = request('get', url, verbose = args.verbose)
+        else: # assume jenkins
+            url = '%s/logText/progressiveHtml' % getJobUrl(args)
+            res = request('get', url, verbose = args.verbose)
+        body = res.read()
+        if res.status != httplib.OK:
+            if body.startswith('<'):
+                dom = minidom.parseString(body)
+                print(dom.toprettyxml()),
+            else:
+                print(body)
+            exit(res.status)
+
+    if args.ofile:
+        file = open('%s-console.log' % args.job, 'w')
+        file.write(body)
+        file.close()
+    if args.ifile or res.status == httplib.OK:
+        grepForFailingTests(args, body)
+        return reportBuildStatus(args, body)
+    elif args.ofile is False:
+        print(body)
+        return res.status
+
+def grepForFailingTests(args, body):
+    cmd = 'grep -E "^\w+\.*.*[&gt;|>] \w*.* FAILED%s"' % ("|PASSED" if args.all else "")
+    (time, output, error) = shell(cmd, body, args.verbose)
+    if output == '':
+        print 'all tests passing'
+    else:
+        print(output.replace('&gt;', '>')),
+
+def reportBuildStatus(args, body):
+    cmd = 'tail -1'
+    (time, output, error) = shell(cmd, body, args.verbose)
+    if output.startswith('Finished: ') or output.startswith('Done.'):
+        print output.strip()
+        return (0, True)
+    else:
+        print 'Build: ONGOING'
+        return (0, False)
+
+def cat(args):
+    def getComponentList(components):
+        list = []
+        for k,v in components.items():
+            if v > 1:
+                for i in range(v):
+                    list.append('%s%d' % (k, i))
+            else:
+                list.append(k)
+        return list
+
+    def getComponentLogs(component):
+        url = '%s/artifact/%s/%s/%s_logs.log' % (getJobUrl(args), args.artifactPath, component, component)
+        res = request('get', url, verbose = args.verbose)
+        body = res.read()
+        if res.status == httplib.OK:
+            return body
+        else:
+            return ''
+
+    def unzip(iterable):
+        return zip(*iterable)
+
+    def extractDate(line):
+        matches = re.search(r'\d{4}-[01]{1}\d{1}-[0-3]{1}\d{1}T[0-2]{1}\d{1}:[0-6]{1}\d{1}:[0-6]{1}\d{1}.\d{3}Z', line)
+        if matches is not None:
+            date = matches.group(0)
+            return date
+        else:
+            return None
+
+    if args.ifile:
+        file = open('%s-build.log' % args.job, 'r')
+        joined = file.read()
+        file.close()
+    elif args.build.lower == 'travis':
+        print('feature not yet supported for Travis builds')
+        return 2
+    else:
+        components = {
+            'controller': args.controllers,
+            'invoker': args.invokers
+        }
+        logs = map(getComponentLogs, getComponentList(components))
+        joined = ''.join(logs)
+    if args.ofile:
+        file = open('%s-build.log' % args.job, 'w')
+        file.write(joined)
+        file.close()
+
+    if args.grep is not None:
+        cmd = 'grep "%s"' % args.grep
+        (time, output, error) = shell(cmd, joined, args.verbose)
+        output = output.strip()
+        if args.sort:
+            parts = output.split('\n')
+            filter = [p for p in parts if p != '']
+            date = map(extractDate, filter)
+            keyed = zip(date, parts)
+            sort = sorted(keyed, key=lambda t: t[1])
+            msgs = unzip(sort)[1]
+            print('\n'.join(msgs))
+            return 0
+        else:
+            print(output)
+        return 0
+    elif args.ofile is False:
+        print(joined)
+        return 0
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Example use to monitor a travis build, job number N:
> citool monitor N

To monitor same job until completion:
> citool monitor -p N

To save job output to a file:
> citool -o monitor N

Example use to monitor a jenkins build B with job number N:
> citool -u https://jenkins.host:port -b B monitor N

see readme in commit for more examples.