### PR TITLE
Use .gitattributes to correct EOL chars for bash scripts not having .sh extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,8 @@ tools/cli/wsk      text eol=lf
 tools/cli/wskadmin text eol=lf
 
 # bash files not having the .sh extension
-tools/vagrant/simple/wsk  text eol=lf
+tools/vagrant/simple/wsk        text eol=lf
+gradlew                         text eol=lf
+core/javaAction/proxy/gradlew   text eol=lf
+tools/vagrant/hello             text eol=lf
+sdk/docker/client/action        text eol=lf


### PR DESCRIPTION
Use .gitattributes to correct EOL chars for bash scripts not having .sh extension