### PR TITLE
Optimize completion path of active ack

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -102,6 +102,20 @@ case class WhiskActivation(
         version = version,
         publish = publish,
         annotations = annotations)
+
+    def withLogs(logs: ActivationLogs) = WhiskActivation(
+        namespace = namespace,
+        name = name,
+        subject = subject,
+        activationId = activationId,
+        start = start,
+        end = end,
+        cause = cause,
+        response = response,
+        logs = logs,
+        version = version,
+        publish = publish,
+        annotations = annotations)
 }
 
 object WhiskActivation


### PR DESCRIPTION
Currently we fetch the logs before making an activation record which we send back.  Instead, since active ack does not carry logs anyway, we can send back a log-less activation record first.  Then get the logs, make a more complete activation record, and records this in the database.  PPG811 passed

