### PR TITLE
Fix Docker Actions in Go CLI

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -335,24 +335,6 @@ class WskBasicTests
             wsk.action.create("updateMissingFile", Some("notfound"), update = true, expectedExitCode = MISUSE_EXIT)
     }
 
-    ignore should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
-        val name = "dockerContainer"
-        (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.action, name) {
-                // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-                (action, _) => action.create(name, Some("whisk/dockerskeleton"), kind = Some("docker"))
-            }
-
-            val args = Map("payload" -> "test".toJson)
-            val run = wsk.action.invoke(name, args)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    val result = activation.fields("response").asJsObject.fields("result").asJsObject
-                    result.fields("args") shouldBe args.toJson
-                    result.fields("msg") shouldBe "Hello from arbitrary C program!".toJson
-            }
-    }
-
     /**
      * Tests creating an action from a malformed js file. This should fail in
      * some way - preferably when trying to create the action. If not, then


### PR DESCRIPTION
- Set "kind" to "blackbox" when creating an action with a Docker container
- Create a CLI test that creates actions with Docker containers