### PR TITLE
Refactor Go CLI error messages so that a single "error:" appears at the start of the message

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -317,7 +317,7 @@ func getPropertiesFilePath() (propsFilePath string, werr error) {
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "homedir.Expand(%s) failed: %s\n", Properties.PropsFile, err)
-            errStr := fmt.Sprintf("Unable to locate properties file '%s'; error %s", Properties.PropsFile, err)
+            errStr := fmt.Sprintf("Unable to locate properties file '%s': %s", Properties.PropsFile, err)
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return propsFilePath, werr
         }

--- a/tools/go-cli/go-whisk-cli/main.go
+++ b/tools/go-cli/go-whisk-cli/main.go
@@ -65,7 +65,7 @@ func main() {
             msgDisplayed = werr.MsgDisplayed
             exitCode = werr.ExitCode
         } else {
-            whisk.Debug(whisk.DbgError, "Got some other error - %s\n", err)
+            whisk.Debug(whisk.DbgError, "Got some other error: %s\n", err)
             fmt.Fprintf(os.Stderr, "%s\n", err)
 
             displayUsage = false   // Cobra already displayed the usage message
@@ -74,8 +74,12 @@ func main() {
 
         // If the err msg should be displayed to the console and it has not already been
         // displayed, display it now.
+        var errMsgPrefix string = "error: "
+        if (exitCode == 0) {
+            errMsgPrefix = ""
+        }
         if displayMsg && !msgDisplayed {
-            fmt.Fprintf(os.Stderr, "%s\n", err)
+            fmt.Fprintf(os.Stderr, "%s%s\n", errMsgPrefix, err)
         }
 
         // Displays usage

--- a/tools/go-cli/go-whisk/whisk/action.go
+++ b/tools/go-cli/go-whisk/whisk/action.go
@@ -135,7 +135,7 @@ func (s *ActionService) List(packageName string, options *ActionListOptions) ([]
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s, nil) error: '%s'\n", route, err)
-        errMsg := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errMsg := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
             NO_DISPLAY_USAGE)
         return nil, nil, whiskErr
@@ -180,7 +180,7 @@ func (s *ActionService) Insert(action *Action, sharedSet bool, overwrite bool) (
     req, err := s.client.NewRequest("PUT", route, sentAction)
     if err != nil {
         Debug(DbgError, "http.NewRequest(PUT, %s, %#v) error: '%s'\n", route, err, sentAction)
-        errMsg := fmt.Sprintf("Unable to create HTTP request for PUT '%s'; error: %s", route, err)
+        errMsg := fmt.Sprintf("Unable to create HTTP request for PUT '%s': %s", route, err)
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
             NO_DISPLAY_USAGE)
         return nil, nil, whiskErr
@@ -207,7 +207,7 @@ func (s *ActionService) Get(actionName string) (*Action, *http.Response, error) 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s, nil) error: '%s'\n", route, err)
-        errMsg := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errMsg := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
             NO_DISPLAY_USAGE)
         return nil, nil, whiskErr
@@ -235,7 +235,7 @@ func (s *ActionService) Delete(actionName string) (*http.Response, error) {
     req, err := s.client.NewRequest("DELETE", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(DELETE, %s, nil) error: '%s'\n", route, err)
-        errMsg := fmt.Sprintf("Unable to create HTTP request for DELETE '%s'; error: %s", route, err)
+        errMsg := fmt.Sprintf("Unable to create HTTP request for DELETE '%s': %s", route, err)
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
             NO_DISPLAY_USAGE)
         return nil, whiskErr
@@ -263,7 +263,7 @@ func (s *ActionService) Invoke(actionName string, payload *json.RawMessage, bloc
     req, err := s.client.NewRequest("POST", route, payload)
     if err != nil {
         Debug(DbgError, "http.NewRequest(POST, %s, %#v) error: '%s'\n", route, payload, err)
-        errMsg := fmt.Sprintf("Unable to create HTTP request for POST '%s'; error: %s", route, err)
+        errMsg := fmt.Sprintf("Unable to create HTTP request for POST '%s': %s", route, err)
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
             NO_DISPLAY_USAGE)
         return nil, nil, whiskErr

--- a/tools/go-cli/go-whisk/whisk/activation.go
+++ b/tools/go-cli/go-whisk/whisk/activation.go
@@ -73,7 +73,7 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
     route, err := addRouteOptions(route, options)
     if err != nil {
         Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
-        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': error %s", options, route, err)
+        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': %s", options, route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -81,7 +81,7 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s) error: '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -110,7 +110,7 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s) error: '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -138,7 +138,7 @@ func (s *ActivationService) Logs(activationID string) (*Activation, *http.Respon
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s) error: '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -165,7 +165,7 @@ func (s *ActivationService) Result(activationID string) (*Response, *http.Respon
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s) error: '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }

--- a/tools/go-cli/go-whisk/whisk/info.go
+++ b/tools/go-cli/go-whisk/whisk/info.go
@@ -40,7 +40,7 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     ref, err := url.Parse(s.client.Config.Version)
     if err != nil {
         Debug(DbgError, "url.Parse(%s) error: %s\n", s.client.Config.Version, err)
-        errStr := fmt.Sprintf("Unable to URL parse '%s'; error: %s", s.client.Config.Version, err)
+        errStr := fmt.Sprintf("Unable to URL parse '%s': %s", s.client.Config.Version, err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -50,7 +50,7 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     req, err := http.NewRequest("GET", u.String(), nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s) error: %s\n", u.String(), err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", u.String(), err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", u.String(), err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }

--- a/tools/go-cli/go-whisk/whisk/namespace.go
+++ b/tools/go-cli/go-whisk/whisk/namespace.go
@@ -46,7 +46,7 @@ func (s *NamespaceService) List() ([]Namespace, *http.Response, error) {
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
         Debug(DbgError, "s.client.NewRequest(GET) error: %s\n", err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET; error: %s", err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -83,7 +83,7 @@ func (s *NamespaceService) Get(nsName string) (*Namespace, *http.Response, error
     req, err := s.client.NewRequest("GET", "", nil)
     if err != nil {
         Debug(DbgError, "s.client.NewRequest(GET) error: %s\n", err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET; error: %s", err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }

--- a/tools/go-cli/go-whisk/whisk/package.go
+++ b/tools/go-cli/go-whisk/whisk/package.go
@@ -146,15 +146,15 @@ func (s *PackageService) List(options *PackageListOptions) ([]Package, *http.Res
     route, err := addRouteOptions(route, options)
     if err != nil {
         Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
-        errStr := fmt.Sprintf("Unable to build request URL: error: %s", err)
+        errStr := fmt.Sprintf("Unable to build request URL: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create GET HTTP request for '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create GET HTTP request for '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -177,8 +177,8 @@ func (s *PackageService) Get(packageName string) (*Package, *http.Response, erro
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create GET HTTP request for '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create GET HTTP request for '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -186,7 +186,7 @@ func (s *PackageService) Get(packageName string) (*Package, *http.Response, erro
     p := new(Package)
     resp, err := s.client.Do(req, &p)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -202,8 +202,8 @@ func (s *PackageService) Insert(x_package PackageInterface, overwrite bool) (*Pa
 
     req, err := s.client.NewRequest("PUT", route, x_package)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(PUT, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create PUT HTTP request for '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(PUT, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create PUT HTTP request for '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -211,7 +211,7 @@ func (s *PackageService) Insert(x_package PackageInterface, overwrite bool) (*Pa
     p := new(Package)
     resp, err := s.client.Do(req, &p)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -225,15 +225,15 @@ func (s *PackageService) Delete(packageName string) (*http.Response, error) {
 
     req, err := s.client.NewRequest("DELETE", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(DELETE, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create DELETE HTTP request for '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(DELETE, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create DELETE HTTP request for '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, werr
     }
 
     resp, err := s.client.Do(req, nil)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return resp, werr
@@ -247,8 +247,8 @@ func (s *PackageService) Refresh() (*BindingUpdates, *http.Response, error) {
 
     req, err := s.client.NewRequest("POST", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(POST, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create POST HTTP request for '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(POST, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create POST HTTP request for '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -256,7 +256,7 @@ func (s *PackageService) Refresh() (*BindingUpdates, *http.Response, error) {
     updates := &BindingUpdates{}
     resp, err := s.client.Do(req, updates)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr

--- a/tools/go-cli/go-whisk/whisk/rule.go
+++ b/tools/go-cli/go-whisk/whisk/rule.go
@@ -50,15 +50,15 @@ func (s *RuleService) List(options *RuleListOptions) ([]Rule, *http.Response, er
     route, err := addRouteOptions(route, options)
     if err != nil {
         Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
-        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': error %s", options, route, err)
+        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': %s", options, route, err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -66,7 +66,7 @@ func (s *RuleService) List(options *RuleListOptions) ([]Rule, *http.Response, er
     var rules []Rule
     resp, err := s.client.Do(req, &rules)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -80,8 +80,8 @@ func (s *RuleService) Insert(rule *Rule, overwrite bool) (*Rule, *http.Response,
 
     req, err := s.client.NewRequest("PUT", route, rule)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(PUT, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for PUT '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(PUT, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for PUT '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -89,7 +89,7 @@ func (s *RuleService) Insert(rule *Rule, overwrite bool) (*Rule, *http.Response,
     r := new(Rule)
     resp, err := s.client.Do(req, &r)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -103,8 +103,8 @@ func (s *RuleService) Get(ruleName string) (*Rule, *http.Response, error) {
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -112,7 +112,7 @@ func (s *RuleService) Get(ruleName string) (*Rule, *http.Response, error) {
     r := new(Rule)
     resp, err := s.client.Do(req, &r)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -126,15 +126,15 @@ func (s *RuleService) Delete(ruleName string) (*http.Response, error) {
 
     req, err := s.client.NewRequest("DELETE", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(DELETE, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for DELETE '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(DELETE, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for DELETE '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, werr
     }
 
     resp, err := s.client.Do(req, nil)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return resp, werr
@@ -158,8 +158,8 @@ func (s *RuleService) SetState(ruleName string, state string) (*Rule, *http.Resp
 
     req, err := s.client.NewRequest("POST", route, ruleState /*nil*/)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(POST, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for POST '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(POST, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for POST '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -167,7 +167,7 @@ func (s *RuleService) SetState(ruleName string, state string) (*Rule, *http.Resp
     r := new(Rule)
     resp, err := s.client.Do(req, &r)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr

--- a/tools/go-cli/go-whisk/whisk/sdk.go
+++ b/tools/go-cli/go-whisk/whisk/sdk.go
@@ -43,7 +43,7 @@ func (s *SdkService) Install(relFileUrl string) (*http.Response, error) {
     req, err := http.NewRequest("GET", urlStr, nil)
     if err != nil {
         Debug(DbgError, "http.NewRequest(GET, %s, nil) error: %s\n", urlStr, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", urlStr, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", urlStr, err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, werr
     }
@@ -64,7 +64,7 @@ func (s *SdkService) Install(relFileUrl string) (*http.Response, error) {
     // Directly use the HTTP client, not the Whisk CLI client, so that the response body is left alone
     resp, err := s.client.client.Do(req)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return resp, werr

--- a/tools/go-cli/go-whisk/whisk/trigger.go
+++ b/tools/go-cli/go-whisk/whisk/trigger.go
@@ -62,15 +62,15 @@ func (s *TriggerService) List(options *TriggerListOptions) ([]TriggerFromServer,
     route, err := addRouteOptions(route, options)
     if err != nil {
         Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
-        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': error %s", options, route, err)
+        errStr := fmt.Sprintf("Unable to append options %#v to URL route '%s': %s", options, route, err)
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -78,7 +78,7 @@ func (s *TriggerService) List(options *TriggerListOptions) ([]TriggerFromServer,
     var triggers []TriggerFromServer
     resp, err := s.client.Do(req, &triggers)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -94,8 +94,8 @@ func (s *TriggerService) Insert(trigger *Trigger, overwrite bool) (*TriggerFromS
 
     req, err := s.client.NewRequest("PUT", route, trigger)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(PUT, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for PUT '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(PUT, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for PUT '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -103,7 +103,7 @@ func (s *TriggerService) Insert(trigger *Trigger, overwrite bool) (*TriggerFromS
     t := new(TriggerFromServer)
     resp, err := s.client.Do(req, &t)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -118,8 +118,8 @@ func (s *TriggerService) Get(triggerName string) (*TriggerFromServer, *http.Resp
 
     req, err := s.client.NewRequest("GET", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for GET '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -127,7 +127,7 @@ func (s *TriggerService) Get(triggerName string) (*TriggerFromServer, *http.Resp
     t := new(TriggerFromServer)
     resp, err := s.client.Do(req, &t)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -142,8 +142,8 @@ func (s *TriggerService) Delete(triggerName string) (*TriggerFromServer, *http.R
 
     req, err := s.client.NewRequest("DELETE", route, nil)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(DELETE, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for DELETE '%s'; error: %s", route, err)
+        Debug(DbgError, "http.NewRequest(DELETE, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for DELETE '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -151,7 +151,7 @@ func (s *TriggerService) Delete(triggerName string) (*TriggerFromServer, *http.R
     t := new(TriggerFromServer)
     resp, err := s.client.Do(req, &t)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr
@@ -165,8 +165,8 @@ func (s *TriggerService) Fire(triggerName string, payload *json.RawMessage) (*Tr
 
     req, err := s.client.NewRequest("POST", route, payload)
     if err != nil {
-        Debug(DbgError," http.NewRequest(POST, %s); error '%s'\n", route, err)
-        errStr := fmt.Sprintf("Unable to create HTTP request for POST '%s'; error: %s", route, err)
+        Debug(DbgError," http.NewRequest(POST, %s); error: '%s'\n", route, err)
+        errStr := fmt.Sprintf("Unable to create HTTP request for POST '%s': %s", route, err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
@@ -174,7 +174,7 @@ func (s *TriggerService) Fire(triggerName string, payload *json.RawMessage) (*Tr
     t := new(TriggerFromServer)
     resp, err := s.client.Do(req, &t)
     if err != nil {
-        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
         errStr := fmt.Sprintf("Request failure: %s", err)
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, resp, werr

--- a/tools/go-cli/go-whisk/whisk/wskerror.go
+++ b/tools/go-cli/go-whisk/whisk/wskerror.go
@@ -39,7 +39,7 @@ type WskError struct {
 }
 
 func (e WskError) Error() string {
-    return fmt.Sprintf("error: %s", e.RootErr.Error())
+    return fmt.Sprintf("%s", e.RootErr.Error())
 }
 
 // Instantiate a WskError structure


### PR DESCRIPTION
Refactor error messages so that a single "error:" appears at the start of the message
Fixes #806