### PR TITLE
Make sure that the Github webhook URL is properly encoded before using

### DIFF
--- a/catalog/github/webhook.js
+++ b/catalog/github/webhook.js
@@ -19,7 +19,7 @@ function main(params) {
   var triggerName = params.triggerName.split("/");
 
     // URL of the whisk system. The calls of github will go here.
-  var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + endpoint + '/api/v1/namespaces/' + triggerName[1] + '/triggers/' + triggerName[2];
+  var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
 
     // The URL to create the webhook on Github
   var registrationEndpoint = 'https://api.github.com/repos/' + username + '/' + repository + '/hooks';


### PR DESCRIPTION
Resolves #702 

Without this, creating a Github trigger with a name like "my trigger" will result in a bad webhook URL being sent to Github.