### PR TITLE
Flip the Switch to Install the Catalog with the Go CLI

### DIFF
--- a/catalog/installSystem.sh
+++ b/catalog/installSystem.sh
@@ -32,9 +32,9 @@ install "$CATALOG_HOME/utils/cat.js" \
 install "$CATALOG_HOME/utils/split.js" \
      util/split \
      -a description 'Split a string into an array' \
-     -a parameters '[{"name": "payload", "required":true, "description":"A string"}], { "name": "separator", "required": false, "description": "The character, or the regular expression, to use for splitting the string" }]' \
+     -a parameters '[{"name": "payload", "required":true, "description":"A string"}, { "name": "separator", "required": false, "description": "The character, or the regular expression, to use for splitting the string" }]' \
      -a sampleInput '{ "payload": "one,two,three", "separator": "," }' \
-     -a sampleOutput '{ "lines": [one, two, three], "payload": "one,two,three"}'
+     -a sampleOutput '{ "lines": ["one", "two", "three"], "payload": "one,two,three"}'
 
 install "$CATALOG_HOME/utils/sort.js" \
      util/sort \

--- a/catalog/installWeather.sh
+++ b/catalog/installWeather.sh
@@ -12,9 +12,9 @@ source "$CATALOG_HOME/util.sh"
 echo Installing Weather package.
 
 createPackage weather \
-    -p bluemixServiceName "weatherinsights"
+    -p bluemixServiceName "weatherinsights" \
     -a description "Services from the Weather Company Data for IBM Bluemix" \
-    -a parameters '[ "name":"username", "required":false,"bindTime":true}, {"name":"password", "required":false, "type":"password","bindTime":true}]'
+    -a parameters '[ {"name":"username", "required":false,"bindTime":true}, {"name":"password", "required":false, "type":"password","bindTime":true}]'
 
 waitForAll
 

--- a/catalog/util.sh
+++ b/catalog/util.sh
@@ -15,7 +15,7 @@ if [ ! -f "$WHISKPROPS_FILE" ]; then
 fi
 EDGE_HOST=`fgrep edge.host= "$WHISKPROPS_FILE" | cut -d'=' -f2`
 
-USE_PYTHON_CLI=true
+USE_PYTHON_CLI=false
 
 function createPackage() {
     PACKAGE_NAME=$1

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -133,9 +133,10 @@ var propertySetCmd = &cobra.Command{
             whisk.Debug(whisk.DbgError, "writeProps(%s, %#v) failed: %s\n", Properties.PropsFile, props, err)
             errStr := fmt.Sprintf("Unable to set the property value(s): %s", err)
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+        } else {
+            fmt.Fprintf(color.Output, okMsg)
         }
 
-        fmt.Fprintf(color.Output, okMsg)
         if (werr != nil) {
             return werr
         }

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -319,8 +319,10 @@ func setDefaultProperties() {
 }
 
 func getPropertiesFilePath() (propsFilePath string, werr error) {
+    var envExists bool
+
     // Environment variable overrides the default properties file path
-    if propsFilePath = os.Getenv("WSK_CONFIG_FILE"); len(propsFilePath) > 0 {
+    if propsFilePath, envExists = os.LookupEnv("WSK_CONFIG_FILE"); envExists == true || propsFilePath != "" {
         whisk.Debug(whisk.DbgInfo, "Using properties file '%s' from WSK_CONFIG_FILE environment variable\n", propsFilePath)
         return propsFilePath, nil
     } else {


### PR DESCRIPTION
- Use the Go CLI to install the default catalog instead of the Python CLI
- Fix error occurring in installWeather.sh when creating the Weather package
- Fix annotation formatting in installWeather.sh, and installSystem.sh
- Do not use a property file if WSK_CONFIG_FILE is set, but blank