### PR TITLE
Make the catalog able to install from openwhisk-catalog repos

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -48,3 +48,47 @@ db:
   authkeys:
   - guest
   - whisk.system
+
+# The default value for catalog_source is empty, meaning that
+# openwhisk will not install the catalog from the catalog repositories.
+# If catalog_source is not set to "catalog-repos", the other variables
+# like catalog_namespace, catalog_auth_key and catalog_repos will not
+# be effective.
+catalog_source: ""
+
+# The default name space is /whisk.system. The catalog namespace must begin with a slash "/".
+catalog_namespace: "/whisk.system"
+
+# The catalog_auth_key is used to determine the secret key to authenticate the openwhisk service.
+# The value for this variable can be set to either the secret key itself or the file, which
+# saves the secret key.
+# By default, we take the key from {{ openwhisk_home }}/ansible/files/auth.whisk.system.
+catalog_auth_key: "{{ openwhisk_home }}/ansible/files/auth.whisk.system"
+
+# The catalog_repos is used to specify all the catalog names and repository URLs,
+# so that openwhisk knows where to download the catalog and install them. The key
+# specifies the catalog name and the url saves the URL of the repository. The location
+# specifies the location to save the code of the catalog. The version specifies the hash
+# of the commit to be cloned. If it is omit or set to HEAD, the latest commit will be
+# selected. The repo_update specifies whether to retrieve new revisions from the origin
+# repository and the default value is yes, meaning that it will retrieve the new
+# revisions. The keys url and location are mandatory and the keys version and repo_update
+# are optional. To add a new repository, please follow the template by adding:
+#
+# catalog_repos:
+#   ...
+#   <catalog-name>:
+#     url: <URL of repository>, mandatory.
+#     location: <local location to save the catalog>, mandatory.
+#     version: <hash of the commit>, optional, default to HEAD.
+#     repo_update: <whether to retrieve new revisions from the origin repository>,
+#                  optional, default to yes. Yes means to retrieve the new revisions, and
+#                  no means not to retrieve the new revisions.
+#
+catalog_repos:
+  openwhisk-catalog:
+    url: https://github.com/openwhisk/openwhisk-catalog.git
+    # Set the local location as the same level as openwhisk home, but it can be changed.
+    location: "{{ openwhisk_home }}/../openwhisk-catalog"
+    version: "HEAD"
+    repo_update: "yes"

--- a/ansible/postdeploy.yml
+++ b/ansible/postdeploy.yml
@@ -6,4 +6,8 @@
 - hosts: ansible
   tasks:
     - include: tasks/installCatalog.yml
-      when: mode == "deploy"
+      when: (mode == "deploy" and catalog_source != "catalog-repos")
+      
+    - include: tasks/installOpenwhiskCatalog.yml
+      when: (mode == "deploy" and catalog_source == "catalog-repos")
+      with_dict: "{{ catalog_repos }}"

--- a/ansible/tasks/installOpenwhiskCatalog.yml
+++ b/ansible/tasks/installOpenwhiskCatalog.yml
@@ -1,0 +1,34 @@
+---
+# This task will install the standard actions and packages available in openwhisk-catalog repos.
+
+- set_fact:
+    catalog_location={{ item.value.location }}
+    catalog_repo_url={{ item.value.url }}
+    api_host={{ groups['edge'] | first }}
+    version="HEAD"
+    repo_update="yes"
+
+- set_fact:
+    version={{ item.value.version }}
+  when: item.value.version is defined
+
+- set_fact:
+    repo_update={{ item.value.repo_update }}
+  when: item.value.repo_update is defined
+
+- name: "ensure catalog_location directory exists"
+  file:
+    path: "{{ catalog_location }}"
+    state: directory
+
+- name: download the catalog repository to the catalog location if necessary
+  git:
+    repo: "{{ catalog_repo_url }}"
+    dest: "{{ catalog_location }}"
+    update: "{{ repo_update }}"
+    version: "{{ version }}"
+
+- name: install the catalog from the catalog location
+  shell: ./installCatalog.sh {{ catalog_auth_key }} {{ api_host }} {{ catalog_namespace }} chdir="{{ catalog_location }}/packages"
+  environment:
+    OPENWHISK_HOME: "{{ openwhisk_home }}"


### PR DESCRIPTION
Currently, the catalog is installed by default together with
openwhisk. This patch adds a parameter named catalog_source to
determine whether to install the catalog from openwhisk-catalog.

If it is "catalog-repos", install the catalog from all the available
catalog repos. If it is set to any value except "catalog-repos",
openwhisk will not install catalog from the openwhisk-catalog.
The command to install the catalog from openwhisk-catalog is:
"ansible-playbook -i environments/local postdeploy.yml -e catalog_source=catalog-repos".

The script installCatalog.sh in the catalog needs to be able to
parse catalog_auth_key, api_host and catalog_namespace as the arguments.

Closes-Bug: #719
