### PR TITLE
Use akka-http for requests from the invoker to the containers

### DIFF
--- a/common/scala/src/main/scala/whisk/common/NewHttpUtils.scala
+++ b/common/scala/src/main/scala/whisk/common/NewHttpUtils.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl._
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+
+import java.util.concurrent.TimeoutException
+
+object NewHttpUtils {
+    def singleRequestBlocking(
+        request: HttpRequest,
+        timeout: FiniteDuration,
+        retryOnTCPErrors: Boolean = false,
+        retryOn4xxErrors: Boolean = false,
+        retryOn5xxErrors: Boolean = false,
+        retryInterval: FiniteDuration = 100.milliseconds)
+        (implicit system: ActorSystem) : Try[HttpResponse] = {
+
+        val f = singleRequest(
+            request, timeout, retryOnTCPErrors, retryOn4xxErrors, retryOn5xxErrors, retryInterval
+        )
+
+        // Duration.Inf is not an issue, since singleRequest has a built-in timeout mechanism.
+        Await.ready(f, Duration.Inf)
+
+        f.value.get
+    }
+
+    // Makes a request, expects a successful within timeout, retries on selected
+    // errors until timeout has passed.
+    def singleRequest(
+        request: HttpRequest,
+        timeout: FiniteDuration,
+        retryOnTCPErrors: Boolean = false,
+        retryOn4xxErrors: Boolean = false,
+        retryOn5xxErrors: Boolean = false,
+        retryInterval: FiniteDuration = 100.milliseconds)
+        (implicit system: ActorSystem) : Future[HttpResponse] = {
+
+        implicit val executionContext = system.dispatcher
+        implicit val materializer = ActorMaterializer()
+
+        val timeoutException = new TimeoutException(s"Request to ${request.uri.authority} could not be completed in time.")
+
+        val authority = request.uri.authority
+        val relativeRequest = request.copy(uri = request.uri.toRelative)
+        val flow = Http().outgoingConnection(authority.host.address, authority.port)
+
+        val promise = Promise[HttpResponse]
+
+        // Timeout includes all retries.
+        system.scheduler.scheduleOnce(timeout) {
+            promise.tryFailure(timeoutException)
+        }
+
+        def tryOnce() : Unit = if(!promise.isCompleted) {
+            val f = Source.single(relativeRequest).via(flow).runWith(Sink.head)
+
+            f.onSuccess {
+                case r if r.status.intValue >= 400 && r.status.intValue < 500 && retryOn4xxErrors =>
+                    // need to drain the response to close the connection
+                    r.entity.dataBytes.runWith(Sink.ignore)
+                    system.scheduler.scheduleOnce(retryInterval) { tryOnce() }
+
+                case r if r.status.intValue >= 500 && r.status.intValue < 600 && retryOn5xxErrors =>
+                    // need to drain the response to close the connection
+                    r.entity.dataBytes.runWith(Sink.ignore)
+                    system.scheduler.scheduleOnce(retryInterval) { tryOnce() }
+
+                case r =>
+                    promise.trySuccess(r)
+            }
+
+            f.onFailure {
+                case s : akka.stream.StreamTcpException if retryOnTCPErrors =>
+                    // TCP error (e.g. connection couldn't be opened)
+                    system.scheduler.scheduleOnce(retryInterval) { tryOnce() }
+
+                case t : Throwable =>
+                    // Other error. We fail the promise.
+                    promise.tryFailure(t)
+            }
+        }
+
+        tryOnce()
+
+        promise.future
+    }
+}

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
@@ -134,9 +134,8 @@ class CouchDbRestClient protected(system: ActorSystem, protocol: String, host: S
                     Unmarshal(response.entity.withoutSizeLimit()).to[JsObject].map { o => Right(o) }
                 } else {
                     // This is important, even though the response is ignored:
-                    // Unmarshalling is one way to drain the entity stream.
                     // Otherwise the connection stays open and the pool dries up.
-                    Unmarshal(response.entity).to[Array[Byte]].map { _ => Left(response.status) }
+                    response.entity.dataBytes.runWith(Sink.ignore).map { _ => Left(response.status) }
                 }
             }
         }

--- a/core/dispatcher/src/main/scala/whisk/core/container/Container.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/Container.scala
@@ -46,12 +46,12 @@ class Container(
     val name = containerName.getOrElse("anon")
     val dockerhost = pool.dockerhost
 
-    val (containerId, containerIP) = bringup(containerName, image, network, env, args, limits, policy)
+    val (containerId, containerHostAndPort) = bringup(containerName, image, network, env, args, limits, policy)
 
     def details: String = {
         val name = containerName getOrElse "??"
         val id = containerId getOrElse "??"
-        val ip = containerIP getOrElse "??"
+        val ip = containerHostAndPort getOrElse "??"
         s"container [$name] [$id] [$ip]"
     }
 

--- a/core/dispatcher/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -51,7 +51,7 @@ trait ContainerUtils extends Logging {
      */
     def bringup(name: Option[String], image: String, network: String, env: Map[String, String], args: Array[String], limits: ActionLimits, policy: Option[String])(implicit transid: TransactionId): (ContainerId, ContainerIP) = {
         val id = makeContainer(name, image, network, env, args, limits, policy)
-        val host = if (id.isDefined) getContainerHost(name) else None
+        val host = id.flatMap(_ => getContainerHostAndPort(name))
         (id, host)
     }
 
@@ -155,7 +155,7 @@ trait ContainerUtils extends Logging {
 
     }
 
-    def getContainerHost(container: ContainerName)(implicit transid: TransactionId): ContainerIP = {
+    def getContainerHostAndPort(container: ContainerName)(implicit transid: TransactionId): ContainerIP = {
         container map { name =>
             runDockerCmd("inspect", "--format", "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'", name) map {
                 output => appendPort(output.substring(1, output.length - 1))

--- a/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -270,15 +270,15 @@ class Invoker(
         pool.getAction(action, auth) match {
             case Some((con, initResultOpt)) => Future {
                 val params = con.mergeParams(payload)
-                val timeoutMillis = action.limits.timeout.millis
+                val timeout = action.limits.timeout.duration
                 initResultOpt match {
-                    case None => (false, con.run(params, msg.meta, auth.compact, timeoutMillis,
+                    case None => (false, con.run(params, msg.meta, auth.compact, timeout,
                         action.fullyQualifiedName, msg.activationId.toString)) // cached
                     case Some((start, end, Some((200, _)))) => { // successful init
                         // TODO:  @perryibm update comment if this is still necessary else remove
                         Thread.sleep(if (con.isBlackbox) BlackBoxSlack else RegularSlack)
                         tran.initInterval = Some(start, end)
-                        (false, con.run(params, msg.meta, auth.compact, timeoutMillis,
+                        (false, con.run(params, msg.meta, auth.compact, timeout,
                             action.fullyQualifiedName, msg.activationId.toString))
                     }
                     case _ => (true, initResultOpt.get) //  unsuccessful initialization

--- a/tests/src/actionContainers/ActionProxyContainerTests.scala
+++ b/tests/src/actionContainers/ActionProxyContainerTests.scala
@@ -26,8 +26,10 @@ import spray.json.JsObject
 import spray.json.JsString
 import spray.json.JsArray
 
+import common.WskActorSystem
+
 @RunWith(classOf[JUnitRunner])
-class ActionProxyContainerTests extends BasicActionRunnerTests {
+class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
     override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
         withContainer("openwhisk/dockerskeleton", env)(code)

--- a/tests/src/actionContainers/DockerExampleContainerTests.scala
+++ b/tests/src/actionContainers/DockerExampleContainerTests.scala
@@ -24,8 +24,10 @@ import spray.json.JsNumber
 import spray.json.JsObject
 import spray.json.JsString
 
+import common.WskActorSystem
+
 @RunWith(classOf[JUnitRunner])
-class DockerExampleContainerTests extends ActionProxyContainerTestUtils {
+class DockerExampleContainerTests extends ActionProxyContainerTestUtils with WskActorSystem {
 
     def withPythonContainer(code: ActionContainer => Unit) = withContainer("openwhisk/example")(code)
 

--- a/tests/src/actionContainers/JavaActionContainerTests.scala
+++ b/tests/src/actionContainers/JavaActionContainerTests.scala
@@ -23,11 +23,12 @@ import org.scalatest.junit.JUnitRunner
 import spray.json._
 
 import ActionContainer.withContainer
+import common.WskActorSystem
 
 import collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
-class JavaActionContainerTests extends FlatSpec with Matchers {
+class JavaActionContainerTests extends FlatSpec with Matchers with WskActorSystem {
 
     // Helpers specific to javaaction
     def withJavaContainer(code: ActionContainer => Unit) = withContainer("whisk/javaaction")(code)

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -19,10 +19,11 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import ActionContainer.withContainer
+import common.WskActorSystem
 import spray.json._
 
 @RunWith(classOf[JUnitRunner])
-class NodeJsActionContainerTests extends BasicActionRunnerTests {
+class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
     lazy val nodejsContainerImageName = "whisk/nodejsaction"
 

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -22,9 +22,10 @@ import org.scalatest.junit.JUnitRunner
 import ActionContainer.withContainer
 import spray.json.JsObject
 import spray.json.JsString
+import common.WskActorSystem
 
 @RunWith(classOf[JUnitRunner])
-class PythonActionContainerTests extends BasicActionRunnerTests {
+class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
     override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
         withContainer("whisk/pythonaction", env)(code)

--- a/tests/src/actionContainers/SwiftActionContainerTests.scala
+++ b/tests/src/actionContainers/SwiftActionContainerTests.scala
@@ -23,8 +23,10 @@ import ActionContainer.withContainer
 import spray.json.JsObject
 import spray.json.JsString
 
+import common.WskActorSystem
+
 @RunWith(classOf[JUnitRunner])
-class SwiftActionContainerTests extends BasicActionRunnerTests {
+class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
     // note: "out" will likely not be empty in some swift build as the compiler
     // prints status messages and there doesn't seem to be a way to quiet them


### PR DESCRIPTION
Stepping stone towards streaming `exec` data from the database to the containers. This commit replicates existing behavior but replaces the blocking Apache HTTP client by akka-http.

This commit also introduces a new helper object, `NewHttpUtils` to make non-pooled, possibly retrying, HTTP requests using the `akka-http` data model. (Candidates for a better object name are welcome.)

FYI @rabbah @markusthoemmes 