### PR TITLE
BUG: Unsafe parameter passing in Python action

### DIFF
--- a/core/pythonAction/pythonaction.py
+++ b/core/pythonAction/pythonaction.py
@@ -61,7 +61,7 @@ def run():
     result = None
     try:
         exec(flask.g, namespace)
-        exec("param = " + json.dumps(value), namespace)
+        namespace["param"] = value
         exec("fun = main(param)", namespace)
         result = namespace['fun']
     except Exception:


### PR DESCRIPTION
The line is incorrect because JSON is not valid Python, e.g., `null` is not defined in Python.