### PR TITLE
Github organization support

### DIFF
--- a/catalog/github/webhook.js
+++ b/catalog/github/webhook.js
@@ -14,6 +14,19 @@ function main(params) {
   var repository = params.repository;
   var accessToken = params.accessToken;
 
+  var organization,
+    repository;
+
+  if(params.repository) {
+    var repoSegments = params.repository.split('/');
+    if(repoSegments.length == 2) {
+      organization = repoSegments[0];
+      repository = repoSegments[1];
+    } else {
+      repository = params.repository;
+    }
+  }
+
   var endpoint = 'openwhisk.ng.bluemix.net';
   var lifecycleEvent = params.lifecycleEvent;
   var triggerName = params.triggerName.split("/");
@@ -22,7 +35,8 @@ function main(params) {
   var whiskCallbackUrl = 'https://' + whisk.getAuthKey() + "@" + endpoint + '/api/v1/namespaces/' + encodeURIComponent(triggerName[1]) + '/triggers/' + encodeURIComponent(triggerName[2]);
 
     // The URL to create the webhook on Github
-  var registrationEndpoint = 'https://api.github.com/repos/' + username + '/' + repository + '/hooks';
+  var registrationEndpoint = 'https://api.github.com/repos/' + (organization ? organization : username) + '/' + repository + '/hooks';
+  console.log("Using endpoint: " + registrationEndpoint);
 
   var authorizationHeader = 'Basic ' + new Buffer(username + ':' +
   accessToken).toString('base64');


### PR DESCRIPTION
Resolves #910 

Allow the Github feed to work for repositories that are owned by an organization (and not personally owned by an individual user).