### PR TITLE
Include Auth Key from Properties when Creating and Deleting Triggers

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -466,6 +466,19 @@ class WskBasicTests
             wsk.trigger.list().stdout should include(name)
     }
 
+    it should "create a trigger using property file" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "listTriggers"
+            val tmpProps = File.createTempFile("wskprops", ".tmp")
+            val env = Map("WSK_CONFIG_FILE" -> tmpProps.getAbsolutePath())
+            wsk.cli(Seq("property", "set", "--auth", wp.authKey) ++ wskprops.overrides, env = env)
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    wsk.cli(Seq("-i", "trigger", "create", name), env = env)
+            }
+            tmpProps.delete()
+    }
+
     it should "create, and list a trigger with a long name" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -191,7 +191,7 @@ var triggerCreateCmd = &cobra.Command{
 
 
             feedParams = append(feedParams, "authKey")
-            feedParams = append(feedParams, flags.global.auth)  // MWD ?? only from CLI arg
+            feedParams = append(feedParams, client.Config.AuthToken)
 
             //parameters = whisk.Parameters{}
             parameters = nil
@@ -481,7 +481,7 @@ var triggerDeleteCmd = &cobra.Command{
             feedParams = append(feedParams, fullTriggerName)
 
             feedParams = append(feedParams, "authKey")
-            feedParams = append(feedParams, flags.global.auth)  // MWD ?? only from CLI arg
+            feedParams = append(feedParams, client.Config.AuthToken)
 
             err = deleteFeed(qName.entityName, fullFeedName, feedParams)
             if err != nil {


### PR DESCRIPTION
- If the auth key was not specified via the command line, it would not be sent when triggers were being created, or deleted