### PR TITLE
Allow controller to run without container

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -108,7 +108,7 @@ object Config extends Logging {
 
         consulString match {
             case Some(consul) => {
-                info("config", s"reading properties from consul at $consul")
+                info(this, s"reading properties from consul at $consul")
                 val kvStore = new ConsulKV(consul)
 
                 val whiskProps = kvStore.getRecurse(ConsulKV.WhiskProps.whiskProps)
@@ -126,7 +126,7 @@ object Config extends Logging {
                     }
                 }
             }
-            case _ => info("config", "no consul server defined.")
+            case _ => info(this, "no consul server defined")
         }
     }
 
@@ -139,7 +139,7 @@ object Config extends Logging {
             val envp = p.replace('.', '_').toUpperCase
             val envv = sys.env.get(envp)
             if (envv.isDefined) {
-                info("config", s"environment set value for $p")
+                info(this, s"environment set value for $p")
                 properties += p -> envv.get
             }
         }
@@ -151,16 +151,16 @@ object Config extends Logging {
      */
     def readPropertiesFromFile(properties: Settings, file: File) = {
         if (file != null && file.exists) {
-            info("config", s"reading properties from file $file")
+            info(this, s"reading properties from file $file")
             for (line <- Source.fromFile(file).getLines if line.trim != "") {
                 val parts = line.split('=')
                 if (parts.length >= 1) {
                     val p = parts(0).trim
                     val v = if (parts.length == 2) parts(1).trim else ""
                     properties += p -> v
-                    info("config", s"properties file set value for $p")
+                    info(this, s"properties file set value for $p")
                 } else {
-                    warn("config", s"ignoring properties $line")
+                    warn(this, s"ignoring properties $line")
                 }
             }
         }
@@ -177,7 +177,7 @@ object Config extends Logging {
             required.keys.map { p =>
                 val v = properties(p)
                 if (v == null) {
-                    error("config", s"required property $p still not set")
+                    error(this, s"required property $p still not set")
                     false
                 } else true
             }.reduce((x: Boolean, y: Boolean) => x & y)

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -55,7 +55,7 @@ class Controller(
     with Actor {
 
     // each akka Actor has an implicit context
-    override def actorRefFactory : ActorContext = context
+    override def actorRefFactory: ActorContext = context
 
     /**
      * A Route in spray is technically a function taking a RequestContext as a parameter.
@@ -64,7 +64,7 @@ class Controller(
      * tree structure.
      * @see http://spray.io/documentation/1.2.3/spray-routing/key-concepts/routes/#composing-routes
      */
-    override def routes(implicit transid: TransactionId) : Route = {
+    override def routes(implicit transid: TransactionId): Route = {
         // handleRejections wraps the inner Route with a logical error-handler for
         // unmatched paths
         handleRejections(customRejectionHandler) {
@@ -88,13 +88,9 @@ object Controller {
     // requiredProperties is a Map whose keys define properties that must be bound to
     // a value, and whose values are default values.   A null value in the Map means there is
     // no default value specified, so it must appear in the properties file
-    def requiredProperties =
-        Map(WhiskConfig.servicePort -> 8080.toString) ++
-            RestAPIVersion_v1.requiredProperties ++
-            consulServer ++
-            kafkaHost ++
-            Map(kafkaPartitions -> null) ++
-            LoadBalancerService.requiredProperties
+    def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
+        RestAPIVersion_v1.requiredProperties ++
+        LoadBalancerService.requiredProperties
 
     // akka-style factory to create a Controller object
     private class ServiceBuilder(config: WhiskConfig, instance: Int) extends Creator[Controller] {
@@ -109,10 +105,9 @@ object Controller {
         // second argument.  (TODO .. seems fragile)
         val instance = if (args.length > 0) args(1).toInt else 0
 
-        val system = ActorSystem("controller-actor-system")
-
         if (config.isValid) {
             val port = config.servicePort.toInt
+            val system = ActorSystem("controller-actor-system")
             BasicHttpService.startService(system, "controller", "0.0.0.0", port, new ServiceBuilder(config, instance))
         }
     }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -41,7 +41,6 @@ import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 import whisk.core.WhiskConfig.kafkaHost
 import whisk.core.WhiskConfig.kafkaPartitions
-import whisk.core.WhiskConfig.servicePort
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.CompletionMessage
 import whisk.core.entity.ActivationId
@@ -154,13 +153,11 @@ class LoadBalancerService(config: WhiskConfig, verbosity: Verbosity.Level)(
 }
 
 object LoadBalancerService {
-    def requiredProperties =
-        Map(servicePort -> null) ++
-            kafkaHost ++
-            consulServer ++
-            Map(kafkaPartitions -> null) ++
-            InvokerHealth.requiredProperties ++
-            ActivationThrottle.requiredProperties
+    def requiredProperties = Map(kafkaPartitions -> null) ++
+        kafkaHost ++
+        consulServer ++
+        InvokerHealth.requiredProperties ++
+        ActivationThrottle.requiredProperties
 }
 
 private case class ActiveAckTimeout(activationId: ActivationId) extends TimeoutException

--- a/tools/cli/wsk
+++ b/tools/cli/wsk
@@ -161,7 +161,7 @@ def propCmd(args, props, userprops, propsLocation):
         if args.namespace:
             if args.apihost is not None:
                 props['apihost'] = args.apihost
-            url = 'https://%(apibase)s/namespaces/' % { 'apibase': apiBase(props) }
+            url = '%(apibase)s/namespaces/' % { 'apibase': apiBase(props) }
             if args.auth:
                 auth = args.auth
             else:
@@ -221,26 +221,26 @@ def propCmd(args, props, userprops, propsLocation):
             print 'whisk CLI version\t%s' % props['clibuild']
         if args.all or args.apibuild:
             if props['apihost'] is not None:
-                url = 'https://%(apibase)s' % { 'apibase' : apiBase(props) }
+                url = '%(apibase)s' % { 'apibase' : apiBase(props) }
                 res = request('GET', url, verbose=args.verbose)
                 if res.status == httplib.OK:
                     result = json.loads(res.read())
                     print 'whisk API build\t\t%s' % result['build']
                 else:
-                    print 'whisk API build\t\tCannot determine API build:',
-                    return responseError(res, prefix=None)
+                    print 'whisk API build\t\tCannot determine API build',
+                    return responseError(res, prefix = None)
             else:
                 print 'whisk API build\t\tNone',
         if args.all or args.apibuildno:
             if props['apihost'] is not None:
-                url = 'https://%(apibase)s' % { 'apibase' : apiBase(props) }
+                url = '%(apibase)s' % { 'apibase' : apiBase(props) }
                 res = request('GET', url, verbose=args.verbose)
                 if res.status == httplib.OK:
                     result = json.loads(res.read())
                     print 'whisk API buildno\t%s' % result['buildno']
                 else:
-                    print 'whisk API build\t\tCannot determine API buildno:',
-                    return responseError(res, prefix=None)
+                    print 'whisk API build\t\tCannot determine API buildno',
+                    return responseError(res, prefix = None)
             else:
                 print 'whisk API buildno\t\tNone',
         return 0

--- a/tools/cli/wskaction.py
+++ b/tools/cli/wskaction.py
@@ -132,7 +132,7 @@ class Action(Item):
     # invokes the action and returns HTTP response
     def doInvoke(self, args, props):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/actions/%(name)s?blocking=%(blocking)s&result=%(result)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/actions/%(name)s?blocking=%(blocking)s&result=%(result)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'name': self.getSafeName(pname),

--- a/tools/cli/wskactivation.py
+++ b/tools/cli/wskactivation.py
@@ -131,7 +131,7 @@ class Activation(Item):
     def result(self, args, props):
         fqid = getQName(args.id, '_') # kludge: use default namespace unless explicitly specified
         namespace, aid = parseQName(fqid, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/activations/%(id)s/result' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/activations/%(id)s/result' % {
            'apibase': apiBase(props),
            'namespace': urllib.quote(namespace),
            'id': aid
@@ -151,7 +151,7 @@ class Activation(Item):
     def logs(self, args, props):
         fqid = getQName(args.id, '_') # kludge: use default namespace unless explicitly specified
         namespace, aid = parseQName(fqid, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/activations/%(id)s/logs' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/activations/%(id)s/logs' % {
            'apibase': apiBase(props),
            'namespace': urllib.quote(namespace),
            'id': aid
@@ -182,7 +182,7 @@ class Activation(Item):
     # return the result of a 'wsk activation list' call, an HTTPResponse
     def listCmd(self, args, props):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/activations?docs=%(full)s&skip=%(skip)s&limit=%(limit)s&%(filter)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/activations?docs=%(full)s&skip=%(skip)s&limit=%(limit)s&%(filter)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'collection': self.collection,

--- a/tools/cli/wskitem.py
+++ b/tools/cli/wskitem.py
@@ -154,7 +154,7 @@ class Item:
         namespace, pname = parseQName(args.name, props)
         if pname:
             pname = ('/%s' % pname) if pname.endswith('/') else '/%s/' % pname
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/%(collection)s%(package)s?skip=%(skip)s&limit=%(limit)s%(public)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/%(collection)s%(package)s?skip=%(skip)s&limit=%(limit)s%(public)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'collection': self.collection,
@@ -178,7 +178,7 @@ class Item:
     # returns the HTTP response for saving an item.
     def httpPut(self, args, props, update, payload):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s%(update)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s%(update)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'collection': self.collection,
@@ -202,7 +202,7 @@ class Item:
         if pname is None or pname.strip() == '':
             print 'error: entity name missing, did you mean to list collection'
             sys.exit(2)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'collection': self.collection,
@@ -218,7 +218,7 @@ class Item:
             return code
 
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/%(collection)s/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'collection': self.collection,

--- a/tools/cli/wsknamespace.py
+++ b/tools/cli/wsknamespace.py
@@ -47,7 +47,7 @@ class Namespace:
             return self.listEntitiesInNamespace(args, props)
 
     def listNamespaces(self, args, props):
-        url = 'https://%(apibase)s/namespaces' % { 'apibase': apiBase(props) }
+        url = '%(apibase)s/namespaces' % { 'apibase': apiBase(props) }
         res = request('GET', url, auth=args.auth, verbose=args.verbose)
 
         if res.status == httplib.OK:
@@ -61,7 +61,7 @@ class Namespace:
 
     def listEntitiesInNamespace(self, args, props):
         namespace, _ = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s' % { 'apibase': apiBase(props), 'namespace': urllib.quote(namespace) }
+        url = '%(apibase)s/namespaces/%(namespace)s' % { 'apibase': apiBase(props), 'namespace': urllib.quote(namespace) }
         res = request('GET', url, auth=args.auth, verbose=args.verbose)
 
         if res.status == httplib.OK:

--- a/tools/cli/wskpackage.py
+++ b/tools/cli/wskpackage.py
@@ -77,7 +77,7 @@ class Package(Item):
 
     def bind(self, args, props):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/packages/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/packages/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'name': self.getSafeName(pname)
@@ -106,7 +106,7 @@ class Package(Item):
 
     def refresh(self, args, props):
         namespace, _ = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/packages/refresh' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/packages/refresh' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace)
         }

--- a/tools/cli/wskrule.py
+++ b/tools/cli/wskrule.py
@@ -90,7 +90,7 @@ class Rule(Item):
         namespace, pname = parseQName(args.name, props)
         desc = 'active' if enable else 'inactive'
         status = json.dumps({ 'status': desc })
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/rules/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/rules/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'name': self.getSafeName(pname)
@@ -112,7 +112,7 @@ class Rule(Item):
 
     def getState(self, args, props):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/rules/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/rules/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'name': self.getSafeName(pname)

--- a/tools/cli/wsksdk.py
+++ b/tools/cli/wsksdk.py
@@ -17,7 +17,7 @@
 import os
 import subprocess
 import httplib
-from wskutil import request
+from wskutil import hostBase, request
 
 #
 # 'wsk sdk' CLI
@@ -61,7 +61,7 @@ class Sdk:
         if os.path.exists(blackboxDir):
             print('The path ' + blackboxDir + ' already exists.  Please delete it and retry.')
             return -1
-        url = 'https://%s/%s' % (props['apihost'], tarFile)
+        url = '%s/%s' % (hostBase(props), tarFile)
         try:
             res = request('GET', url)
             if res.status == httplib.OK:
@@ -83,14 +83,14 @@ class Sdk:
         if os.path.exists(zipFile):
             print('The path ' + zipFile + ' already exists.  Please delete it and retry.')
             return -1
-        url = 'https://%s/%s' % (props['apihost'], zipFile)
+        url = '%s/%s' % (hostBase(props), zipFile)
         try:
             res = request('GET', url)
             if res.status == httplib.OK:
                 with open(zipFile, 'wb') as f:
                     f.write(res.read())
 
-        except IOError as e:
+        except IOError:
             print('Download of OpenWhisk iOS starter app failed.')
             return -1
         print('\nDownloaded OpenWhisk iOS starter app. Unzip ' + zipFile + ' and open the project in Xcode.')

--- a/tools/cli/wsktrigger.py
+++ b/tools/cli/wsktrigger.py
@@ -82,7 +82,7 @@ class Trigger(Item):
 
     def fire(self, args, props):
         namespace, pname = parseQName(args.name, props)
-        url = 'https://%(apibase)s/namespaces/%(namespace)s/triggers/%(name)s' % {
+        url = '%(apibase)s/namespaces/%(namespace)s/triggers/%(name)s' % {
             'apibase': apiBase(props),
             'namespace': urllib.quote(namespace),
             'name': self.getSafeName(pname)

--- a/tools/cli/wskutil.py
+++ b/tools/cli/wskutil.py
@@ -306,7 +306,15 @@ def getQName(qname, namespace = None):
         namespace = namespace if namespace else resolveNamespace({})
         return '%s%s%s%s' % (delimiter, namespace, delimiter, qname)
 
-def apiBase(props):
+def hostBase(props):
     host = props['apihost']
+    url = urlparse(host)
+    if url.scheme is '':
+        return 'https://%s' % host
+    else:
+        return host
+
+def apiBase(props):
+    host = hostBase(props)
     version = props['apiversion']
     return '%s/api/%s' % (host, version)


### PR DESCRIPTION
For local development and testing it is sometimes desirable to run the controller without a container. This patch restores the ability to run the controller natively by 1. removing redundant required properties that prevent the default port to be set, 2. allows the wsk CLI to point to a http-based controller by specifying the api host fully via `--apihost`.

PG and squash pending.