### PR TITLE
API host property value will default to "" (empty string) if the API host value is not configured

### DIFF
--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -333,6 +333,12 @@ public class TestUtils {
         return rr;
     }
 
+    /*
+     * WARNING: Consider using the WSK_CONFIG_FILE environment variable in
+     *          tests that will be manipulating the CLI property values.
+     *          Use this method only after determining WSK_CONFIG_FILE will
+     *          not work for the test case.
+     */
     public static File backupWskProps() throws IOException {
         String homedir = System.getProperty("user.home");
         Path wskpropsPath = FileSystems.getDefault().getPath(homedir, ".wskprops");
@@ -347,6 +353,12 @@ public class TestUtils {
         return tempfilePath.toFile();
     }
 
+    /*
+     * WARNING: Consider using the WSK_CONFIG_FILE environment variable in
+     *          tests that will be manipulating the CLI property values.
+     *          Use this method only after determining WSK_CONFIG_FILE will
+     *          not work for the test case.
+     */
     public static void restoreWskProps(File backupWskProps) throws IOException {
         String homedir = System.getProperty("user.home");
         Path wskpropsPath = FileSystems.getDefault().getPath(homedir, ".wskprops");

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -21,6 +21,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,6 +33,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collections;
+import java.util.UUID;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
@@ -325,5 +331,35 @@ public class TestUtils {
         RunResult rr = new RunResult(exitCode, new String(bl.getStdout()), new String(bl.getStderr()));
         rr.validateExitCode(expectedExitCode);
         return rr;
+    }
+
+    public static File backupWskProps() throws IOException {
+        String homedir = System.getProperty("user.home");
+        Path wskpropsPath = FileSystems.getDefault().getPath(homedir, ".wskprops");
+        String tempfileName =  UUID.randomUUID().toString()+".wskprops";
+        Path tempfilePath = FileSystems.getDefault().getPath(homedir, tempfileName);
+        try {
+            Files.copy(wskpropsPath, tempfilePath, StandardCopyOption.REPLACE_EXISTING );
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        return tempfilePath.toFile();
+    }
+
+    public static void restoreWskProps(File backupWskProps) throws IOException {
+        String homedir = System.getProperty("user.home");
+        Path wskpropsPath = FileSystems.getDefault().getPath(homedir, ".wskprops");
+        try {
+            Files.copy(backupWskProps.toPath(), wskpropsPath, StandardCopyOption.REPLACE_EXISTING );
+        }
+        catch (IOException e) {
+            throw e;
+        }
+    }
+
+    public static File getWskPropsFile() {
+        String homedir = System.getProperty("user.home");
+        return new File(homedir + File.separator + ".wskprops");
     }
 }

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -782,7 +782,7 @@ sealed trait RunWskCmd {
             showCmd: Boolean = false): RunResult = {
         val args = baseCommand
         if (verbose) args += "--verbose"
-        if (showCmd) println(params.mkString(" "))
+        if (showCmd) println(args +" "+ params.mkString(" "))
         val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, args ++ params: _*)
         rr.validateExitCode(expectedExitCode)
         rr

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -90,9 +90,38 @@ class WskBasicTests
         stdout should include regex ("""(?i)whisk API version\s+v1""")
     }
 
+    it should "validate default property values" in {
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+        try {
+            wsk.cli(Seq("property", "unset", "--auth", "--apihost", "--apiversion", "--namespace"), env = env)
+            var stdout = wsk.cli(Seq("property", "get", "--auth"), env = env).stdout
+            stdout should include regex ("""(?i)whisk auth\s*$""")      // default = empty string
+            stdout = wsk.cli(Seq("property", "get", "--apihost"), env = env).stdout
+            stdout should include regex ("""(?i)whisk API host\s*$""")  // default = empty string
+            stdout = wsk.cli(Seq("property", "get", "--namespace"), env = env).stdout
+            stdout should include regex ("""(?i)whisk namespace\s*_$""")// default = _
+        }
+        finally {
+            tmpwskprops.delete()
+        }
+    }
+
     it should "show api build version" in {
-        val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuild")).stdout
-        stdout should include regex ("""(?i)whisk API build\s+201.*""")
+        //val wskpropsBackup = TestUtils.backupWskProps()
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+        wsk.cli(wskprops.overrides ++ Seq("property", "set"), env = env )
+        val stdout = wsk.cli(Seq("property", "get", "--apibuild", "-i"), env = env).stdout
+        try {
+            stdout should include regex ("""(?i)whisk API build\s+201.*""")
+        }
+        finally {
+            tmpwskprops.delete()
+            //TestUtils.restoreWskProps(wskpropsBackup)
+            //wskpropsBackup.delete()
+        }
+
     }
 
     it should "fail to show api build when setting apihost to bogus value" in {
@@ -110,42 +139,62 @@ class WskBasicTests
     }
 
     it should "show api build number" in {
-        val stdout = wsk.cli(wskprops.overrides ++ Seq("property", "get", "--apibuildno")).stdout
-        stdout should include regex ("""(?i)whisk API build.*\s+.*""")
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+        wsk.cli(wskprops.overrides ++ Seq("property", "set"), env = env)
+        val stdout = wsk.cli(Seq("property", "get", "--apibuildno", "-i"), env = env).stdout
+        try {
+            stdout should include regex ("""(?i)whisk API build.*\s+.*""")
+        }
+        finally {
+            tmpwskprops.delete()
+        }
     }
 
     it should "set auth in property file" in {
-        val wskprops = File.createTempFile("wskprops", ".tmp")
-        val env = Map("WSK_CONFIG_FILE" -> wskprops.getAbsolutePath())
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
         wsk.cli(Seq("property", "set", "--auth", "testKey"), env = env)
-        val fileContent = FileUtils.readFileToString(wskprops)
-        fileContent should include("AUTH=testKey")
-        wskprops.delete()
+        try {
+            val fileContent = FileUtils.readFileToString(tmpwskprops)
+            fileContent should include("AUTH=testKey")
+        }
+        finally {
+            tmpwskprops.delete()
+        }
     }
 
     it should "set multiple property values with single command" in {
         val tmpwskprops = File.createTempFile("wskprops", ".tmp")
         val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
         val stdout = wsk.cli(Seq("property", "set", "--auth", "testKey", "--apihost", "openwhisk.ng.bluemix.net", "--apiversion", "v1"), env = env).stdout
-        stdout should include regex ("ok: whisk auth set")
-        stdout should include regex ("ok: whisk API host set")
-        stdout should include regex ("ok: whisk API version set")
-        val fileContent = FileUtils.readFileToString(tmpwskprops)
-        fileContent should include("AUTH=testKey")
-        fileContent should include("APIHOST=openwhisk.ng.bluemix.net")
-        fileContent should include("APIVERSION=v1")
-        tmpwskprops.delete()
+        try {
+            stdout should include regex ("ok: whisk auth set")
+            stdout should include regex ("ok: whisk API host set")
+            stdout should include regex ("ok: whisk API version set")
+            val fileContent = FileUtils.readFileToString(tmpwskprops)
+            fileContent should include("AUTH=testKey")
+            fileContent should include("APIHOST=openwhisk.ng.bluemix.net")
+            fileContent should include("APIVERSION=v1")
+        }
+        finally {
+            tmpwskprops.delete()
+        }
     }
 
     it should "delete multiple property values with single command" in {
         val tmpwskprops = File.createTempFile("wskprops", ".tmp")
         val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
         val stdout = wsk.cli(Seq("property", "unset", "--auth", "--apihost", "--apiversion", "--namespace"), env = env).stdout
-        stdout should include regex ("ok: whisk auth unset")
-        stdout should include regex ("ok: whisk API host unset")
-        stdout should include regex ("ok: whisk API version unset")
-        stdout should include regex ("ok: whisk namespace unset")
-        tmpwskprops.delete()
+        try {
+            stdout should include regex ("ok: whisk auth unset")
+            stdout should include regex ("ok: whisk API host unset")
+            stdout should include regex ("ok: whisk API version unset")
+            stdout should include regex ("ok: whisk namespace unset")
+        }
+        finally {
+            tmpwskprops.delete()
+        }
     }
 
     it should "reject creating duplicate entity" in withAssetCleaner(wskprops) {
@@ -226,12 +275,17 @@ class WskBasicTests
     }
 
     it should "reject authenticated command when no auth key is given" in {
-        // override wsk props file in case it exists
-        val wskprops = File.createTempFile("wskprops", ".tmp")
-        val env = Map("WSK_CONFIG_FILE" -> wskprops.getAbsolutePath())
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+        wsk.cli(Seq("property", "unset", "--auth"), env = env)
         val stderr = wsk.cli(Seq("list"), env = env, expectedExitCode = MISUSE_EXIT).stderr
-        stderr should include regex (s"usage[:.]") // Python CLI: "usage:", Go CLI: "usage."
-        stderr should include("--auth is required")
+        try {
+            stderr should include regex (s"usage[:.]") // Python CLI: "usage:", Go CLI: "usage."
+            stderr should include("--auth is required")
+        }
+        finally {
+            tmpwskprops.delete()
+        }
     }
 
     behavior of "Wsk Package CLI"

--- a/tools/go-cli/go-whisk-cli/commands/commands.go
+++ b/tools/go-cli/go-whisk-cli/commands/commands.go
@@ -147,6 +147,7 @@ func parseArgs(args []string) ([]string, []string, []string, error) {
 func Execute() error {
     var err error
 
+    whisk.Debug(whisk.DbgInfo, "wsk args: %#v\n", os.Args)
     os.Args, flags.common.param, flags.common.annotation, err = parseArgs(os.Args)
 
     if err != nil {

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -42,7 +42,7 @@ var Properties struct {
 }
 
 const DefaultAuth       string = ""
-const DefaultAPIHost    string = "openwhisk.ng.bluemix.net"
+const DefaultAPIHost    string = ""
 const DefaultAPIVersion string = "v1"
 const DefaultAPIBuild   string = ""
 const DefaultAPIBuildNo string = ""
@@ -227,7 +227,7 @@ var propertyGetCmd = &cobra.Command{
         if !(flags.property.all || flags.property.auth ||
              flags.property.apiversion || flags.property.cliversion ||
              flags.property.namespace || flags.property.apibuild ||
-             flags.property.apibuildno) {
+             flags.property.apihost || flags.property.apibuildno) {
             flags.property.all = true
         }
 


### PR DESCRIPTION
- Use a default api host value of "" (empty string) when API host value is not configured
- --apihost argument still overrides configured apihost value (including the default value)

Fixes #803 