### PR TITLE
Ignore experimental Swift3 tests

### DIFF
--- a/tests/src/actionContainers/Swift3ActionContainerTests.scala
+++ b/tests/src/actionContainers/Swift3ActionContainerTests.scala
@@ -30,7 +30,7 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
 
     behavior of "whisk/swift3action"
 
-    it should "properly use KituraNet and Dispatch" in {
+    ignore should "properly use KituraNet and Dispatch" in {
         val (out, err) = withSwiftContainer() { c =>
             val code = """
                 | import KituraNet
@@ -103,7 +103,7 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
         err.trim shouldBe empty
     }
 
-    it should "make Watson SDKs available to action authors" in {
+    ignore should "make Watson SDKs available to action authors" in {
         val (out, err) = withSwiftContainer() { c =>
             val code = """
                 | import RestKit

--- a/tests/src/packages/UtilsTests.scala
+++ b/tests/src/packages/UtilsTests.scala
@@ -74,7 +74,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
     /**
       * Test the Swift "cat" action using Swift 3
       */
-    it should "concatenate an array of strings using the swift cat action" in withAssetCleaner(wskprops) {
+    ignore should "concatenate an array of strings using the swift cat action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val wsk = new Wsk(usePythonCLI)
 
@@ -132,7 +132,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
     /**
       * Test the Swift "split" action using Swift 3
       */
-    it should "split a string into an array of strings using the swift split action" in withAssetCleaner(wskprops) {
+    ignore should "split a string into an array of strings using the swift split action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val wsk = new Wsk(usePythonCLI)
 
@@ -189,7 +189,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
     /**
       * Test the Swift "head" action using Swift 3
       */
-    it should "extract first n elements of an array of strings using the swift head action" in withAssetCleaner(wskprops) {
+    ignore should "extract first n elements of an array of strings using the swift head action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val wsk = new Wsk(usePythonCLI)
 
@@ -246,7 +246,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
     /**
       * Test the Swift "sort" action using Swift 3
       */
-    it should "sort an array of strings using the swift sort action" in withAssetCleaner(wskprops) {
+    ignore should "sort an array of strings using the swift sort action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val wsk = new Wsk(usePythonCLI)
 
@@ -303,7 +303,7 @@ class UtilsTests extends TestHelpers with WskTestHelpers with Matchers {
     /**
       * Test the Swift "wordCount" action using Swift 3
       */
-    it should "count the number of words in a string using the swift word count action" in withAssetCleaner(wskprops) {
+    ignore should "count the number of words in a string using the swift word count action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val wsk = new Wsk(usePythonCLI)
 

--- a/tests/src/system/basic/CLISwiftTests.scala
+++ b/tests/src/system/basic/CLISwiftTests.scala
@@ -72,8 +72,10 @@ class CLISwiftTests
 
     /**
      * Test the Swift 3 example
+     *
+     * It is ignored because Swift3 is experimental. The test is failed sometimes and breaks the CI pipeline. This was agreed.
      */
-    it should "invoke a swift:3 action" in withAssetCleaner(wskprops) {
+    ignore should "invoke a swift:3 action" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "helloSwift3"
             assetHelper.withCleaner(wsk.action, name) {

--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -43,7 +43,7 @@ class Swift3WhiskObjectTests
 
     behavior of "Swift 3 Whisk backend API"
 
-    it should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
+    ignore should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // use CLI to create action from dat/actions/invokeAction.swift
             val file = TestUtils.getCatalogFilename("/samples/invoke.swift")
@@ -67,7 +67,7 @@ class Swift3WhiskObjectTests
             }
     }
 
-    it should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
+    ignore should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // create a trigger
             val triggerName = s"TestTrigger ${System.currentTimeMillis()}"


### PR DESCRIPTION
Some of these tests are failed sometimes and breaks the CI pipeline. Ignoring the tests was agreed.