### PR TITLE
Enable Colors/Styles in the CLI for Windows OS, and Add Uniform Color/Sytle Support Across Commands

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -99,7 +99,7 @@ var actionCreateCmd = &cobra.Command{
             return whiskErr
         }
 
-        fmt.Printf("%s created action %s\n", color.GreenString("ok:"), boldString(action.Name))
+        fmt.Fprintf(color.Output, "%s created action %s\n", color.GreenString("ok:"), boldString(action.Name))
         return nil
     },
 }
@@ -161,7 +161,7 @@ var actionUpdateCmd = &cobra.Command{
             return whiskErr
         }
 
-        fmt.Printf("%s updated action %s\n", color.GreenString("ok:"), boldString(action.Name))
+        fmt.Fprintf(color.Output, "%s updated action %s\n", color.GreenString("ok:"), boldString(action.Name))
         return nil
     },
 }
@@ -237,11 +237,13 @@ var actionInvokeCmd = &cobra.Command{
         if flags.common.blocking && flags.action.result {
             printJsonNoColor(activation.Response.Result, outputStream)
         } else if flags.common.blocking {
-            fmt.Printf("%s invoked /%s/%s with id %s\n", color.GreenString("ok:"), boldString(qName.namespace), boldString(qName.entityName),
+            fmt.Fprintf(color.Output, "%s invoked /%s/%s with id %s\n", color.GreenString("ok:"),
+                boldString(qName.namespace), boldString(qName.entityName),
                 boldString(activation.ActivationID))
             printJsonNoColor(activation, outputStream)
         } else {
-            fmt.Printf("%s invoked /%s/%s with id %s\n", color.GreenString("ok:"), boldString(qName.namespace), boldString(qName.entityName),
+            fmt.Fprintf(color.Output, "%s invoked /%s/%s with id %s\n", color.GreenString("ok:"),
+                boldString(qName.namespace), boldString(qName.entityName),
                 boldString(activation.ActivationID))
         }
 
@@ -285,12 +287,10 @@ var actionGetCmd = &cobra.Command{
             return whiskErr
         }
 
-        // print out response
         if flags.common.summary {
-            fmt.Printf("%s /%s/%s\n", boldString("action"), action.Namespace, action.Name)
+            fmt.Fprintf(color.Output, "%s /%s/%s\n", boldString("action"), action.Namespace, action.Name)
         } else {
-            fmt.Printf("%s got action %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-            //printJSON(action)
+            fmt.Fprintf(color.Output, "%s got action %s\n", color.GreenString("ok:"), boldString(qName.entityName))
             printJsonNoColor(action)
         }
 
@@ -324,9 +324,7 @@ var actionDeleteCmd = &cobra.Command{
             return whiskErr
         }
 
-        // print out response
-        fmt.Printf("%s deleted action %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-
+        fmt.Fprintf(color.Output, "%s deleted action %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         return nil
     },
 }
@@ -358,11 +356,8 @@ var actionListCmd = &cobra.Command{
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
             }
-            client.Namespace = qName.namespace
 
-            if pkg := qName.packageName; len(pkg) > 0 {
-                // todo :: scope call to package
-            }
+            client.Namespace = qName.namespace
         }
 
         options := &whisk.ActionListOptions{

--- a/tools/go-cli/go-whisk-cli/commands/activation.go
+++ b/tools/go-cli/go-whisk-cli/commands/activation.go
@@ -26,7 +26,7 @@ import (
 
     "../../go-whisk/whisk"
 
-    //"github.com/fatih/color"
+    "github.com/fatih/color"
     "github.com/spf13/cobra"
 )
 
@@ -68,11 +68,8 @@ var activationListCmd = &cobra.Command{
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
-            client.Namespace = ns
 
-            if pkg := qName.packageName; len(pkg) > 0 {
-                // todo :: scope call to package
-            }
+            client.Namespace = ns
         }
 
         options := &whisk.ActivationListOptions{
@@ -128,8 +125,7 @@ var activationGetCmd = &cobra.Command{
             fmt.Printf("activation result for /%s/%s (%s at %s)\n", activation.Namespace, activation.Name, activation.Response.Status, time.Unix(activation.End/1000, 0))
             printJsonNoColor(activation.Response.Result)
         } else {
-            //fmt.Printf("%s got activation %s\n", color.GreenString("ok:"), boldString(id))  - MWD Does not work on Windows
-            fmt.Printf("ok: got activation %s\n", id)
+            fmt.Fprintf(color.Output, "%s got activation %s\n", color.GreenString("ok:"), boldString(id))
             printJsonNoColor(activation)
         }
 
@@ -188,8 +184,6 @@ var activationResultCmd = &cobra.Command{
             return werr
         }
 
-        //fmt.Printf("%s got activation %s result\n", color.GreenString("ok:"), boldString(id))  - MWD Does not work on Windows
-        //fmt.Printf("ok: got activation %s result\n", id)
         printJsonNoColor(result.Result)
         return nil
     },

--- a/tools/go-cli/go-whisk-cli/commands/namespace.go
+++ b/tools/go-cli/go-whisk-cli/commands/namespace.go
@@ -83,14 +83,14 @@ var namespaceGetCmd = &cobra.Command{
             return werr
         }
 
-        //fmt.Printf("Entities in namespace: %s\n", boldString(namespace.Name))  // Did not work on Windows; so replaced with following two lines
         fmt.Printf("Entities in namespace: ")
 
         if (qName.namespace != "_") {
-            color.New(color.Bold).Printf("%s\n", namespace.Name)
+            fmt.Fprintf(color.Output, "%s\n", boldString(namespace.Name))
         } else {
-            color.New(color.Bold).Printf("default\n")
+            fmt.Fprintf(color.Output, "%s\n", boldString("default"))
         }
+
 
         printList(namespace.Contents.Packages)
         printList(namespace.Contents.Actions)

--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -24,7 +24,7 @@ import (
 
     "../../go-whisk/whisk"
 
-    //"github.com/fatih/color"
+    "github.com/fatih/color"
     "github.com/spf13/cobra"
 )
 
@@ -154,7 +154,7 @@ var packageBindCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("ok: created binding %s\n", bindingName)
+        fmt.Fprintf(color.Output, "%s created binding %s\n", color.GreenString("ok:"), boldString(bindingName))
         return nil
     },
 }
@@ -243,8 +243,7 @@ var packageCreateCmd = &cobra.Command{
             return werr
         }
 
-        //fmt.Printf("%s created package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-        fmt.Printf("ok: created package %s\n", qName.entityName)
+        fmt.Fprintf(color.Output, "%s created package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         return nil
     },
 }
@@ -364,8 +363,7 @@ var packageUpdateCmd = &cobra.Command{
             return werr
         }
 
-        //fmt.Printf("%s updated package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-        fmt.Printf("ok: updated package %s\n",qName.entityName)
+        fmt.Fprintf(color.Output, "%s updated package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         return nil
     },
 }
@@ -406,9 +404,7 @@ var packageGetCmd = &cobra.Command{
         if flags.common.summary {
             printSummary(xPackage)
         } else {
-            //fmt.Printf("%s got package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-            //printJSON(xPackage)
-            fmt.Printf("ok: got package %s\n", qName.entityName)
+            fmt.Fprintf(color.Output, "%s got package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
             printJsonNoColor(xPackage)
         }
 
@@ -449,8 +445,7 @@ var packageDeleteCmd = &cobra.Command{
             return werr
         }
 
-        //fmt.Printf("%s deleted package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-        fmt.Printf("ok: deleted package %s\n", qName.entityName)
+        fmt.Fprintf(color.Output, "%s deleted package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         return nil
     },
 }

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -26,6 +26,7 @@ import (
 
     "github.com/mitchellh/go-homedir"
     "github.com/spf13/cobra"
+    "github.com/fatih/color"
 
     "../../go-whisk/whisk"
 )
@@ -81,7 +82,7 @@ var propertySetCmd = &cobra.Command{
         if auth := flags.global.auth; len(auth) > 0 {
             props["AUTH"] = auth
             client.Config.AuthToken = auth
-            okMsg += fmt.Sprint("ok: whisk auth set\n")
+            okMsg += fmt.Sprintf("%s whisk auth set to %s\n", color.GreenString("ok:"), boldString(auth))
         }
 
         if apiHost := flags.property.apihostSet; len(apiHost) > 0 {
@@ -92,13 +93,13 @@ var propertySetCmd = &cobra.Command{
                 // Not aborting now.  Subsequent commands will result in error
                 whisk.Debug(whisk.DbgError, "url.Parse(%s) error: %s", apiHostBaseUrl, err)
             }
-            okMsg += fmt.Sprintf("ok: whisk API host set to '%s'\n", apiHost)
+            okMsg += fmt.Sprintf("%s whisk API host set to %s\n", color.GreenString("ok:"), boldString(apiHost))
         }
 
         if apiVersion := flags.property.apiversionSet; len(apiVersion) > 0 {
             props["APIVERSION"] = apiVersion
             client.Config.Version = apiVersion
-            okMsg += fmt.Sprintf("ok: whisk API version set to '%s'\n", apiVersion)
+            okMsg += fmt.Sprintf("%s whisk API version set to %s\n", color.GreenString("ok:"), boldString(apiVersion))
         }
 
         if namespace := flags.property.namespaceSet; len(namespace) > 0 {
@@ -122,7 +123,7 @@ var propertySetCmd = &cobra.Command{
                     werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 } else {
                     props["NAMESPACE"] = namespace
-                    okMsg += fmt.Sprintf("ok: whisk namespace set to '%s'\n", namespace)
+                    okMsg += fmt.Sprintf("%s whisk namespace set to %s\n", color.GreenString("ok:"), boldString(namespace))
                 }
             }
         }
@@ -134,10 +135,11 @@ var propertySetCmd = &cobra.Command{
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         }
 
-        fmt.Print(okMsg)
+        fmt.Fprintf(color.Output, okMsg)
         if (werr != nil) {
             return werr
         }
+
         return nil
     },
 }
@@ -161,9 +163,9 @@ var propertyUnsetCmd = &cobra.Command{
 
         if flags.property.auth {
             delete(props, "AUTH")
-            okMsg += fmt.Sprint("ok: whisk auth unset")
+            okMsg += fmt.Sprintf("%s whisk auth unset", color.GreenString("ok:"))
             if len(DefaultAuth) > 0 {
-                okMsg += fmt.Sprintf("; the default value of '%s' will be used.\n", DefaultAuth)
+                okMsg += fmt.Sprintf("; the default value of %s will be used.\n", boldString(DefaultAuth))
             } else {
                 okMsg += fmt.Sprint("; no default value will be used.\n")
             }
@@ -171,9 +173,9 @@ var propertyUnsetCmd = &cobra.Command{
 
         if flags.property.namespace {
             delete(props, "NAMESPACE")
-            okMsg += fmt.Sprint("ok: whisk namespace unset")
+            okMsg += fmt.Sprintf("%s whisk namespace unset", color.GreenString("ok:"))
             if len(DefaultNamespace) > 0 {
-                okMsg += fmt.Sprintf("; the default value of '%s' will be used.\n", DefaultNamespace)
+                okMsg += fmt.Sprintf("; the default value of %s will be used.\n", boldString(DefaultNamespace))
             } else {
                 okMsg += fmt.Sprint("; there is no default value that can be used.\n")
             }
@@ -181,9 +183,9 @@ var propertyUnsetCmd = &cobra.Command{
 
         if flags.property.apihost {
             delete(props, "APIHOST")
-            okMsg += fmt.Sprint("ok: whisk API host unset")
+            okMsg += fmt.Sprintf("%s whisk API host unset", color.GreenString("ok:"))
             if len(DefaultAPIHost) > 0 {
-                okMsg += fmt.Sprintf("; the default value of '%s' will be used.\n", DefaultAPIHost)
+                okMsg += fmt.Sprintf("; the default value of %s will be used.\n", boldString(DefaultAPIHost))
             } else {
                 okMsg += fmt.Sprint("; there is no default value that can be used.\n")
             }
@@ -191,9 +193,9 @@ var propertyUnsetCmd = &cobra.Command{
 
         if flags.property.apiversion {
             delete(props, "APIVERSION")
-            okMsg += fmt.Sprint("ok: whisk API version unset")
+            okMsg += fmt.Sprintf("%s whisk API version unset", color.GreenString("ok:"))
             if len(DefaultAPIVersion) > 0 {
-                okMsg += fmt.Sprintf("; the default value of '%s' will be used.\n", DefaultAPIVersion)
+                okMsg += fmt.Sprintf("; the default value of %s will be used.\n", boldString(DefaultAPIVersion))
             } else {
                 okMsg += fmt.Sprint("; there is no default value that can be used.\n")
             }
@@ -207,7 +209,7 @@ var propertyUnsetCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Print(okMsg)
+        fmt.Fprintf(color.Output, okMsg)
         if err = loadProperties(); err != nil {
             whisk.Debug(whisk.DbgError, "loadProperties() failed: %s\n", err)
         }
@@ -232,23 +234,23 @@ var propertyGetCmd = &cobra.Command{
         }
 
         if flags.property.all || flags.property.auth {
-            fmt.Println("whisk auth\t\t", Properties.Auth)
+            fmt.Fprintf(color.Output, "whisk auth\t\t%s\n", boldString(Properties.Auth))
         }
 
         if flags.property.all || flags.property.apihost {
-            fmt.Println("whisk API host\t\t", Properties.APIHost)
+            fmt.Fprintf(color.Output, "whisk API host\t\t%s\n", boldString(Properties.APIHost))
         }
 
         if flags.property.all || flags.property.apiversion {
-            fmt.Println("whisk API version\t", Properties.APIVersion)
+            fmt.Fprintf(color.Output, "whisk API version\t%s\n", boldString(Properties.APIVersion))
         }
 
         if flags.property.all || flags.property.namespace {
-            fmt.Println("whisk namespace\t\t", Properties.Namespace)
+            fmt.Fprintf(color.Output, "whisk namespace\t\t%s\n", boldString(Properties.Namespace))
         }
 
         if flags.property.all || flags.property.cliversion {
-            fmt.Println("whisk CLI version\t", Properties.CLIVersion)
+            fmt.Fprintf(color.Output, "whisk CLI version\t%s\n", boldString(Properties.CLIVersion))
         }
 
         if flags.property.all || flags.property.apibuild || flags.property.apibuildno {
@@ -260,10 +262,10 @@ var propertyGetCmd = &cobra.Command{
                 info.BuildNo = "Unknown"
             }
             if flags.property.all || flags.property.apibuild {
-                fmt.Println("whisk API build\t\t", info.Build)
+                fmt.Fprintf(color.Output, "whisk API build\t\t%s\n", boldString(info.Build))
             }
             if flags.property.all || flags.property.apibuildno {
-                fmt.Println("whisk API build number\t", info.BuildNo)
+                fmt.Fprintf(color.Output, "whisk API build number\t%s\n", boldString(info.BuildNo))
             }
             if err != nil {
                 errStr := fmt.Sprintf("Unable to obtain API build information: %s", err)

--- a/tools/go-cli/go-whisk-cli/commands/rule.go
+++ b/tools/go-cli/go-whisk-cli/commands/rule.go
@@ -73,7 +73,7 @@ var ruleEnableCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s enabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+        fmt.Fprintf(color.Output, "%s enabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
 }
@@ -119,7 +119,7 @@ var ruleDisableCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s disabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+        fmt.Fprintf(color.Output, "%s disabled rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
 }
@@ -164,7 +164,8 @@ var ruleStatusCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s rule %s is %s\n", color.GreenString("ok:"), boldString(ruleName), boldString(rule.Status))
+        fmt.Fprintf(color.Output, "%s rule %s is %s\n", color.GreenString("ok:"), boldString(ruleName),
+            boldString(rule.Status))
         return nil
     },
 }
@@ -241,7 +242,7 @@ var ruleCreateCmd = &cobra.Command{
         }
         whisk.Debug(whisk.DbgInfo, "Enabled rule:\n%+v\n", retRule)
 
-        fmt.Printf("%s created rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+        fmt.Fprintf(color.Output, "%s created rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
 }
@@ -303,7 +304,7 @@ var ruleUpdateCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s updated rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+        fmt.Fprintf(color.Output, "%s updated rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
 }
@@ -348,8 +349,7 @@ var ruleGetCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s got rule %s\n", color.GreenString("ok:"), boldString(ruleName))
-        //printJSON(rule)
+        fmt.Fprintf(color.Output, "%s got rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         printJsonNoColor(rule)
 
         return nil
@@ -406,7 +406,7 @@ var ruleDeleteCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("%s deleted rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+        fmt.Fprintf(color.Output, "%s deleted rule %s\n", color.GreenString("ok:"), boldString(ruleName))
         return nil
     },
 }

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -25,6 +25,7 @@ import (
     "../../go-whisk/whisk"
 
     "github.com/spf13/cobra"
+    "github.com/fatih/color"
 )
 
 // triggerCmd represents the trigger command
@@ -107,7 +108,9 @@ var triggerFireCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Printf("ok: triggered %s with id %s\n", qName.entityName, trigResp.ActivationId )
+        fmt.Fprintf(color.Output, "%s triggered /%s/%s with id %s\n", color.GreenString("ok:"),
+            boldString(qName.namespace), boldString(qName.entityName),
+            boldString(trigResp.ActivationId))
         return nil
     },
 }
@@ -259,7 +262,7 @@ var triggerCreateCmd = &cobra.Command{
             }
         }
 
-        fmt.Println("ok: created trigger")
+        fmt.Fprintf(color.Output, "%s created trigger %s\n", color.GreenString("ok:"), boldString(trigger.Name))
         return nil
     },
 }
@@ -357,8 +360,7 @@ var triggerUpdateCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Println("ok: updated trigger")
-        //MWD printJSON(retTrigger) // color does appear correctly on vagrant VM
+        fmt.Fprintf(color.Output, "%s updated trigger %s\n", color.GreenString("ok:"), boldString(trigger.Name))
         printJsonNoColor(retTrigger)
         return nil
     },
@@ -403,8 +405,8 @@ var triggerGetCmd = &cobra.Command{
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        fmt.Printf("ok: got trigger %s\n", qName.entityName)
-        //MWD printJSON(retTrigger) // color does appear correctly on vagrant VM
+
+        fmt.Fprintf(color.Output, "%s got trigger %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         printJsonNoColor(retTrigger)
         return nil
     },
@@ -493,7 +495,7 @@ var triggerDeleteCmd = &cobra.Command{
             }
         }
 
-        fmt.Printf("ok: deleted trigger %s\n", qName.entityName)
+        fmt.Fprintf(color.Output, "%s deleted trigger %s\n", color.GreenString("ok:"), boldString(qName.entityName))
         return nil
     },
 }

--- a/tools/go-cli/go-whisk-cli/commands/util.go
+++ b/tools/go-cli/go-whisk-cli/commands/util.go
@@ -273,7 +273,6 @@ func parseAnnotations(args []string) (whisk.Annotations, error) {
 }
 
 var boldString = color.New(color.Bold).SprintFunc()
-var boldPrintf = color.New(color.Bold).PrintfFunc()
 
 func printList(collection interface{}) {
     switch collection := collection.(type) {
@@ -326,7 +325,7 @@ func printSummary(collection interface{}) {
 }
 
 func printActionList(actions []whisk.Action) {
-    boldPrintf("actions\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("actions"))
     for _, action := range actions {
         publishState := "private"
         if action.Publish {
@@ -337,7 +336,7 @@ func printActionList(actions []whisk.Action) {
 }
 
 func printTriggerList(triggers []whisk.TriggerFromServer) {
-    boldPrintf("triggers\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("triggers"))
     for _, trigger := range triggers {
         publishState := "private"
         if trigger.Publish {
@@ -348,7 +347,7 @@ func printTriggerList(triggers []whisk.TriggerFromServer) {
 }
 
 func printPackageList(packages []whisk.Package) {
-    boldPrintf("packages\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("packages"))
     for _, xPackage := range packages {
         publishState := "private"
         if xPackage.Publish {
@@ -359,7 +358,7 @@ func printPackageList(packages []whisk.Package) {
 }
 
 func printRuleList(rules []whisk.Rule) {
-    boldPrintf("rules\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("rules"))
     for _, rule := range rules {
         publishState := "private"
         if rule.Publish {
@@ -370,21 +369,21 @@ func printRuleList(rules []whisk.Rule) {
 }
 
 func printNamespaceList(namespaces []whisk.Namespace) {
-    boldPrintf("namespaces\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("namespaces"))
     for _, namespace := range namespaces {
         fmt.Printf("%s\n", namespace.Name)
     }
 }
 
 func printActivationList(activations []whisk.Activation) {
-    boldPrintf("activations\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("activations"))
     for _, activation := range activations {
         fmt.Printf("%s%20s\n", activation.ActivationID, activation.Name)
     }
 }
 
 func printFullActivationList(activations []whisk.Activation) {
-    boldPrintf("activations\n")
+    fmt.Fprintf(color.Output, "%s\n", boldString("activations"))
     for _, activation := range activations {
         printJsonNoColor(activation)
     }
@@ -419,7 +418,6 @@ func printPackageSummary(p *whisk.Package) {
 }
 
 func logoText() string {
-
     logo := `
         ____      ___                   _    _ _     _     _
        /\   \    / _ \ _ __   ___ _ __ | |  | | |__ (_)___| | __
@@ -428,9 +426,6 @@ func logoText() string {
  \   \  /  \/    \___/| .__/ \___|_| |_|__/\__|_| |_|_|___/_|\_\
   \___\/ tm           |_|
 `
-
-    // Cobra will trim that string again. Inserting a zero-width space to save the logo.
-    logo = "\u200B        " + strings.TrimSpace(logo);
 
     return logo
 }

--- a/tools/go-cli/go-whisk-cli/commands/wsk.go
+++ b/tools/go-cli/go-whisk-cli/commands/wsk.go
@@ -29,7 +29,12 @@ var WskCmd = &cobra.Command{
     PersistentPreRunE:parseConfigFlags,
 }
 
+
+
+
 func init() {
+    WskCmd.SetHelpTemplate(`{{with or .Long .Short }}{{.}}
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`)
 
     WskCmd.AddCommand(
         actionCmd,


### PR DESCRIPTION
- Updating printing of colors and styles so they are displayed on the Windows operating system
- Ensure that printing of colors, and styles is uniform across commands
- Fix logo display on Windows/Mac