### PR TITLE
Invalid syntax in annotation for split action

### DIFF
--- a/catalog/installSystem.sh
+++ b/catalog/installSystem.sh
@@ -32,8 +32,8 @@ install "$CATALOG_HOME/utils/cat.js" \
 install "$CATALOG_HOME/utils/split.js" \
      util/split \
      -a description 'Split a string into an array' \
-     -a parameters '[{"name": "payload", "required":true, "description":"A string"}], { "name": "separator", "required": false, "description": "The character, or the regular expression, to use for splitting the string }]' \
-     -a sampleInput '{ "payload": "one,two,three" "separator": "," }' \
+     -a parameters '[{"name": "payload", "required":true, "description":"A string"}], { "name": "separator", "required": false, "description": "The character, or the regular expression, to use for splitting the string" }]' \
+     -a sampleInput '{ "payload": "one,two,three", "separator": "," }' \
      -a sampleOutput '{ "lines": [one, two, three], "payload": "one,two,three"}'
 
 install "$CATALOG_HOME/utils/sort.js" \


### PR DESCRIPTION
Invalid syntax in annotation is causing wsk cli to create the input as a String instead of JSON.