### PR TITLE
Annotations Must be Parsed as Raw JSON

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -23,6 +23,7 @@ import org.apache.commons.io.FileUtils
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.json.pimpAny
 import spray.json.pimpString
@@ -337,6 +338,86 @@ class WskBasicTests
             stdout should not include regex(""""key": "xxx"""")
     }
 
+    it should "create, and get a package to verify annotation parsing" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "packageAnnotations"
+
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    pkg.create(name, annotations = getValidJSONTestArgInput)
+            }
+
+            val stdout = wsk.pkg.get(name).stdout
+            assert(stdout.startsWith(s"ok: got package $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getValidJSONTestArgOutput)
+    }
+
+    it should "create, and get a package to verify parameter parsing" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "packageParameters"
+
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    pkg.create(name, parameters = getValidJSONTestArgInput)
+            }
+
+            val stdout = wsk.pkg.get(name).stdout
+            assert(stdout.startsWith(s"ok: got package $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getValidJSONTestArgOutput)
+    }
+
+    it should "not create a package when -a is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("package", "create", "packageName", "--auth", wp.authKey,
+                "-a"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Annotation arguments must be a key value pair")
+    }
+
+    it should "not create a package when -p is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("package", "create", "packageName", "--auth", wp.authKey,
+                "-p"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Parameter arguments must be a key value pair")
+    }
+
+    it should "create a package with the proper parameter escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "packageName"
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("package", "create", wsk.pkg.fqn(name), "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput()
+                    )
+            }
+
+            val stdout = wsk.pkg.get(name).stdout
+            assert(stdout.startsWith(s"ok: got package $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getEscapedJSONTestArgOutput)
+    }
+
+    it should "create an package with the proper annotation escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "packageName"
+            assetHelper.withCleaner(wsk.pkg, name) {
+                (pkg, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("package", "create", wsk.pkg.fqn(name), "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput(false)
+                    )
+            }
+
+            val stdout = wsk.pkg.get(name).stdout
+            assert(stdout.startsWith(s"ok: got package $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getEscapedJSONTestArgOutput)
+    }
+
     behavior of "Wsk Action CLI"
 
     it should "create the same action twice with different cases" in withAssetCleaner(wskprops) {
@@ -449,22 +530,88 @@ class WskBasicTests
             wsk.action.create("updateMissingFile", Some("notfound"), update = true, expectedExitCode = MISUSE_EXIT)
     }
 
-    ignore should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
-        val name = "dockerContainer"
+    it should "create, and get an action to verify annotation parsing" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
+            val name = "actionAnnotations"
+
+            val file = Some(TestUtils.getCatalogFilename("samples/hello.js"))
             assetHelper.withCleaner(wsk.action, name) {
-                // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-                (action, _) => action.create(name, Some("whisk/dockerskeleton"), kind = Some("docker"))
+                (action, _) =>
+                    action.create(name, file, annotations = getValidJSONTestArgInput)
             }
 
-            val args = Map("payload" -> "test".toJson)
-            val run = wsk.action.invoke(name, args)
-            withActivation(wsk.activation, run) {
-                activation =>
-                    val result = activation.fields("response").asJsObject.fields("result").asJsObject
-                    result.fields("args") shouldBe args.toJson
-                    result.fields("msg") shouldBe "Hello from arbitrary C program!".toJson
+            val stdout = wsk.action.get(name).stdout
+            assert(stdout.startsWith(s"ok: got action $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getValidJSONTestArgOutput)
+    }
+
+    it should "create, and get an action to verify parameter parsing" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "actionParameters"
+
+            val file = Some(TestUtils.getCatalogFilename("samples/hello.js"))
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, parameters = getValidJSONTestArgInput)
             }
+
+            val stdout = wsk.action.get(name).stdout
+            assert(stdout.startsWith(s"ok: got action $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getValidJSONTestArgOutput)
+    }
+
+    it should "not create an action when -a is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("action", "create", "actionName", "--auth", wp.authKey,
+                "-a"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Annotation arguments must be a key value pair")
+    }
+
+    it should "not create an action when -p is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("action", "create", "actionName", "--auth", wp.authKey,
+                "-p"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Parameter arguments must be a key value pair")
+    }
+
+    it should "create an action with the proper parameter escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "actionName"
+            val file = TestUtils.getCatalogFilename("samples/hello.js")
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("action", "create", wsk.action.fqn(name), file, "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput()
+                    )
+            }
+
+            val stdout = wsk.action.get(name).stdout
+            assert(stdout.startsWith(s"ok: got action $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getEscapedJSONTestArgOutput)
+    }
+
+    it should "create an action with the proper annotation escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "actionName"
+            val file = TestUtils.getCatalogFilename("samples/hello.js")
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("action", "create", wsk.action.fqn(name), file, "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput(false)
+                    )
+            }
+
+            val stdout = wsk.action.get(name).stdout
+            assert(stdout.startsWith(s"ok: got action $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getEscapedJSONTestArgOutput)
     }
 
     /**
@@ -583,6 +730,86 @@ class WskBasicTests
             }
     }
 
+    it should "create, and get a trigger to verify annotation parsing" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "triggerAnnotations"
+
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    trigger.create(name, annotations = getValidJSONTestArgInput)
+            }
+
+            val stdout = wsk.trigger.get(name).stdout
+            assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getValidJSONTestArgOutput)
+    }
+
+    it should "create, and get a trigger to verify parameter parsing" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "triggerParameters"
+
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    trigger.create(name, parameters = getValidJSONTestArgInput)
+            }
+
+            val stdout = wsk.trigger.get(name).stdout
+            assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getValidJSONTestArgOutput)
+    }
+
+    it should "not create a trigger when -a is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("trigger", "create", "triggerName", "--auth", wp.authKey,
+                "-a"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Annotation arguments must be a key value pair")
+    }
+
+    it should "not create a trigger when -p is specified without arguments" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val stderr = wsk.cli(wskprops.overrides ++ Seq("trigger", "create", "triggerName", "--auth", wp.authKey,
+                "-p"), expectedExitCode = ERROR_EXIT).stderr
+            stderr should include("Parameter arguments must be a key value pair")
+    }
+
+    it should "create a trigger with the proper parameter escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "triggerName"
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("trigger", "create", wsk.trigger.fqn(name), "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput()
+                    )
+            }
+
+            val stdout = wsk.trigger.get(name).stdout
+            assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("parameters") == getEscapedJSONTestArgOutput)
+    }
+
+    it should "create a trigger with the proper annotation escapes" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "triggerName"
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    wsk.cli(wskprops.overrides ++ Seq("trigger", "create", wsk.trigger.fqn(name), "--auth", wp.authKey) ++
+                      getEscapedJSONTestArgInput(false)
+                    )
+            }
+
+            val stdout = wsk.trigger.get(name).stdout
+            assert(stdout.startsWith(s"ok: got trigger $name\n"))
+
+            val resJSON = stdout.substring(stdout.indexOf("\n") + 1).parseJson.asJsObject
+            assert(resJSON.fields("annotations") == getEscapedJSONTestArgOutput)
+    }
+
     behavior of "Wsk Rule CLI"
 
     it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) {
@@ -642,4 +869,129 @@ class WskBasicTests
             stdout should include("default")
     }
 
+    def getEscapedJSONTestArgInput(parameters: Boolean = true) = Seq(
+        if (parameters) "-p" else "-a",
+        "\"key\"with\\escapes",
+        "{\"invalid\": \"J\"S\"ON\"}",          // Cannot put qoutes inside JSON
+        if (parameters) "-p" else "-a",
+        "another\"escape\"",
+        "{\"valid\": \"\\nJ\\rO\\tS\\bN\\f\"}",   // Can escape \n, \r, \t, \b, \f
+        if (parameters) "-p" else "-a",
+        "escape\\again",
+        "{\"invalid\": \"JS\\ON\"}"             // Cannot escape anything besides \n, \r, \t, \b, \f
+    )
+
+    def getEscapedJSONTestArgOutput() = JsArray(
+        JsObject(
+            "key" -> JsString("\"key\"with\\escapes"),
+            "value" -> JsString("{\"invalid\": \"J\"S\"ON\"}")
+        ),
+        JsObject(
+            "key" -> JsString("another\"escape\""),
+            "value" -> JsObject(
+                "valid" -> JsString("\nJ\rO\tS\bN\f")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("escape\\again"),
+            "value" -> JsString("{\"invalid\": \"JS\\ON\"}")
+        )
+    )
+
+    def getValidJSONTestArgOutput() = JsArray(
+        JsObject(
+            "key" -> JsString("number"),
+            "value" -> JsNumber(8)
+        ),
+        JsObject(
+            "key" -> JsString("objArr"),
+            "value" -> JsArray(
+                JsObject(
+                    "name" -> JsString("someName"),
+                    "required" -> JsBoolean(true)
+                ),
+                JsObject(
+                    "name" -> JsString("events"),
+                    "count" -> JsNumber(10)
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("strArr"),
+            "value" -> JsArray(
+                JsString("44"),
+                JsString("55")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("string"),
+            "value" -> JsString("This is a string")
+        ),
+        JsObject(
+            "key" -> JsString("numArr"),
+            "value" -> JsArray(
+                JsNumber(44),
+                JsNumber(55)
+            )
+        ),
+        JsObject(
+            "key" -> JsString("object"),
+            "value" -> JsObject(
+                "objString" -> JsString("aString"),
+                "objStrNum" -> JsString("123"),
+                "objNum" -> JsNumber(300),
+                "objBool" -> JsBoolean(false),
+                "objNumArr" -> JsArray(
+                    JsNumber(1),
+                    JsNumber(2)
+                ),
+                "objStrArr" -> JsArray(
+                    JsString("1"),
+                    JsString("2")
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("strNum"),
+            "value" -> JsString("9")
+        )
+    )
+
+    def getValidJSONTestArgInput() = Map(
+        "string" -> JsString("This is a string"),
+        "strNum" -> JsString("9"),
+        "number" -> JsNumber(8),
+        "numArr" -> JsArray(
+            JsNumber(44),
+            JsNumber(55)
+        ),
+        "strArr" -> JsArray(
+            JsString("44"),
+            JsString("55")
+        ),
+        "objArr" -> JsArray(
+            JsObject(
+                "name" -> JsString("someName"),
+                "required" -> JsBoolean(true)
+            ),
+            JsObject(
+                "name" -> JsString("events"),
+                "count" -> JsNumber(10)
+            )
+        ),
+        "object" -> JsObject(
+            "objString" -> JsString("aString"),
+            "objStrNum" -> JsString("123"),
+            "objNum" -> JsNumber(300),
+            "objBool" -> JsBoolean(false),
+            "objNumArr" -> JsArray(
+                JsNumber(1),
+                JsNumber(2)
+            ),
+            "objStrArr" -> JsArray(
+                JsString("1"),
+                JsString("2")
+            )
+        )
+    )
 }

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -199,9 +199,9 @@ var actionInvokeCmd = &cobra.Command{
         if len(flags.common.param) > 0 {
             whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
 
-            parameters, err := parseParameters(flags.common.param)
+            parameters, err := getJSONFromArguments(flags.common.param, false)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
+                whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, false) failed: %s\n", flags.common.param, err)
                 errMsg := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -486,9 +486,9 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := parseParametersArray(flags.common.param)
+    parameters, err := getJSONFromArguments(flags.common.param, true)
     if err != nil {
-        whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+        whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
         errMsg := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -496,9 +496,9 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := parseAnnotations(flags.common.annotation)
+    annotations, err := getJSONFromArguments(flags.common.annotation, true)
     if err != nil {
-        whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+        whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
         errMsg := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)

--- a/tools/go-cli/go-whisk-cli/commands/commands.go
+++ b/tools/go-cli/go-whisk-cli/commands/commands.go
@@ -124,9 +124,9 @@ func parseArgs(args []string) ([]string, []string, []string, error) {
                 annotArgs = append(annotArgs, "")
                 args = append(args[:i], args[i + 2:]...)
             } else {
-                whisk.Debug(whisk.DbgError, "Parameter arguments must be a key value pair; args: %s", args)
+                whisk.Debug(whisk.DbgError, "Annotation arguments must be a key value pair; args: %s", args)
 
-                errMsg = fmt.Sprintf("Parameter arguments must be a key value pair: %s", args)
+                errMsg = fmt.Sprintf("Annotation arguments must be a key value pair: %s", args)
                 whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
                     whisk.DISPLAY_USAGE)
 

--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -112,10 +112,10 @@ var packageBindCmd = &cobra.Command{
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
 
         whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-        parameters, err := parseParametersArray(flags.common.param)
+        parameters, err := getJSONFromArguments(flags.common.param, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -125,10 +125,10 @@ var packageBindCmd = &cobra.Command{
         // The 1 or more --annotation arguments have all been combined into a single []string
         // e.g.   --a arg1,arg2 --a arg3,arg4   ->  [arg1, arg2, arg3, arg4]
         whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-        annotations, err := parseAnnotations(flags.common.annotation)
+        annotations, err := getJSONFromArguments(flags.common.annotation, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -197,20 +197,20 @@ var packageCreateCmd = &cobra.Command{
         }
 
         whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-        parameters, err := parseParametersArray(flags.common.param)
+        parameters, err := getJSONFromArguments(flags.common.param, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
         whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-        annotations, err := parseAnnotations(flags.common.annotation)
+        annotations, err := getJSONFromArguments(flags.common.annotation, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -319,19 +319,19 @@ var packageUpdateCmd = &cobra.Command{
         }
 
         whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-        parameters, err := parseParametersArray(flags.common.param)
+        parameters, err := getJSONFromArguments(flags.common.param, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
         whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-        annotations, err := parseAnnotations(flags.common.annotation)
+        annotations, err := getJSONFromArguments(flags.common.annotation, true)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -70,9 +70,9 @@ var triggerFireCmd = &cobra.Command{
         var payload *json.RawMessage
 
         if len(flags.common.param) > 0 {
-            parameters, err := parseParameters(flags.common.param)
+            parameters, err := getJSONFromArguments(flags.common.param, false)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
+                whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, false) failed: %s\n", flags.common.param, err)
                 errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
@@ -151,10 +151,10 @@ var triggerCreateCmd = &cobra.Command{
         // The 1 or more --param arguments have all been combined into a single []string
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
         whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-        parameters, err := parseParametersArray(flags.common.param)
+        parameters, err := getJSONFromArguments(flags.common.param, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -193,25 +193,26 @@ var triggerCreateCmd = &cobra.Command{
             feedParams = append(feedParams, "authKey")
             feedParams = append(feedParams, client.Config.AuthToken)
 
-            //parameters = whisk.Parameters{}
             parameters = nil
             whisk.Debug(whisk.DbgInfo, "Trigger feed action parameters: %#v\n", feedParams)
         }
 
-        whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-        annotations, err := parseAnnotations(flags.common.annotation)
+        var annotations *json.RawMessage
+        if feedArgPassed {
+            feedAnnotations := []string{"feed", flags.common.feed}
+            feedAnnotations = append(feedAnnotations, flags.common.annotation...)
+            whisk.Debug(whisk.DbgInfo, "Parsing trigger feed annotations: %#v\n", feedAnnotations)
+            annotations, err = getJSONFromArguments(feedAnnotations, true)
+        } else {
+            whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
+            annotations, err = getJSONFromArguments(flags.common.annotation, true)
+        }
+
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotations argument value '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
-        }
-        if feedArgPassed {
-            feedAnnotation := make(map[string]interface{}, 0)
-            feedAnnotation["key"] = "feed"
-            feedAnnotation["value"] = flags.common.feed
-            annotations = append(annotations, feedAnnotation)
-            whisk.Debug(whisk.DbgInfo, "Trigger feed annotations: %#v\n", annotations)
         }
 
         whisk.Debug(whisk.DbgInfo, "Trigger shared: %s\n", flags.common.shared)
@@ -302,20 +303,20 @@ var triggerUpdateCmd = &cobra.Command{
         // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
 
         whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-        parameters, err := parseParametersArray(flags.common.param)
+        parameters, err := getJSONFromArguments(flags.common.param, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
             errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
 
         whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-        annotations, err := parseAnnotations(flags.common.annotation)
+        annotations, err := getJSONFromArguments(flags.common.annotation, true)
 
         if err != nil {
-            whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+            whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
             errStr := fmt.Sprintf("Invalid annotations argument value '%#v': %s", flags.common.annotation, err)
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
@@ -456,40 +457,27 @@ var triggerDeleteCmd = &cobra.Command{
 
         // Get full feed name from trigger delete request as it is needed to delete the feed
         if retTrigger != nil && retTrigger.Annotations != nil {
-            for i := 0; i < len(retTrigger.Annotations); i++ {
+            fullFeedName = getValueFromAnnotations(retTrigger.Annotations, "feed")
 
-                switch key := retTrigger.Annotations[i]["key"].(type) {
-                    case string: {
-                        if key == "feed" {
-                            switch value := retTrigger.Annotations[i]["value"].(type) {
-                                case string: {
-                                    fullFeedName = value
-                                }
-                            }
-                        }
-                    }
+            if len(fullFeedName) > 0 {
+                feedParams = append(feedParams, "lifecycleEvent")
+                feedParams = append(feedParams, "DELETE")
+
+                fullTriggerName := fmt.Sprintf("/%s/%s", qName.namespace, qName.entityName)
+                feedParams = append(feedParams, "triggerName")
+                feedParams = append(feedParams, fullTriggerName)
+
+                feedParams = append(feedParams, "authKey")
+                feedParams = append(feedParams, client.Config.AuthToken)
+
+                err = deleteFeed(qName.entityName, fullFeedName, feedParams)
+                if err != nil {
+                    whisk.Debug(whisk.DbgError, "deleteFeed(%s, %s, %+v) failed: %s\n", qName.entityName, flags.common.feed, feedParams, err)
+                    errStr := fmt.Sprintf("Unable to delete trigger '%s': %s", qName.entityName, err)
+                    werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+
+                    return werr
                 }
-            }
-        }
-
-        if len(fullFeedName) > 0 {
-            feedParams = append(feedParams, "lifecycleEvent")
-            feedParams = append(feedParams, "DELETE")
-
-            fullTriggerName := fmt.Sprintf("/%s/%s", qName.namespace, qName.entityName)
-            feedParams = append(feedParams, "triggerName")
-            feedParams = append(feedParams, fullTriggerName)
-
-            feedParams = append(feedParams, "authKey")
-            feedParams = append(feedParams, client.Config.AuthToken)
-
-            err = deleteFeed(qName.entityName, fullFeedName, feedParams)
-            if err != nil {
-                whisk.Debug(whisk.DbgError, "deleteFeed(%s, %s, %+v) failed: %s\n", qName.entityName, flags.common.feed, feedParams, err)
-                errStr := fmt.Sprintf("Unable to delete trigger '%s': %s", qName.entityName, err)
-                werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-
-                return werr
             }
         }
 
@@ -524,10 +512,6 @@ var triggerListCmd = &cobra.Command{
             }
             client.Namespace = ns
             whisk.Debug(whisk.DbgInfo, "Using namespace '%s' from argument '%s''\n", ns, args[0])
-
-            if pkg := qName.packageName; len(pkg) > 0 {
-                // todo :: scope call to package
-            }
         }
 
         options := &whisk.TriggerListOptions{

--- a/tools/go-cli/go-whisk/whisk/action.go
+++ b/tools/go-cli/go-whisk/whisk/action.go
@@ -20,7 +20,6 @@ import (
     "fmt"
     "net/http"
     "errors"
-    "reflect"
     "encoding/json"
     "net/url"
 )
@@ -30,65 +29,38 @@ type ActionService struct {
 }
 
 type Action struct {
-    Namespace   string      `json:"namespace,omitempty"`
-    Name        string      `json:"name,omitempty"`
-    Version     string      `json:"version,omitempty"`
-    Publish     bool        `json:"publish"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`   // Can be either []KeyValue or []KeyValues (action seq)
-    Limits      *Limits     `json:"limits,omitempty"`
-}
-
-func (p *Action) GetAnnotationKeyValue(key string) string {
-    var val string = ""
-
-    Debug(DbgInfo, "Looking for annotation with key of '%s'\n", key)
-    if p.Annotations != nil {
-        for i,_ := range p.Annotations {
-            Debug(DbgInfo, "Examining annotation %+v\n", p.Annotations[i])
-            annotation := p.Annotations[i]
-            if k, ok := annotation["key"].(string); ok {
-                if k == key {
-                    if val, ok := annotation["value"].(string); ok {
-                        Debug(DbgInfo, "annotation[%s] = '%s'\n", key, val)
-                        if val != "" {
-                            return val
-                        }
-                    } else {
-                        Debug(DbgWarn, "Annotation 'value' is not a string type: %s", reflect.TypeOf(annotation["value"]).String())
-                    }
-                }
-            } else {
-                Debug(DbgWarn, "Annotation 'key' is not a string type: %s", reflect.TypeOf(annotation["key"]).String())
-            }
-        }
-    }
-    return val
+    Namespace   string              `json:"namespace,omitempty"`
+    Name        string              `json:"name,omitempty"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
 }
 
 type SentActionPublish struct {
-    Namespace   string      `json:"-"`
-    Version     string      `json:"-"`
-    Publish     bool        `json:"publish"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Limits      *Limits     `json:"limits,omitempty"`
-    Error       string      `json:"error,omitempty"`
-    Code        int         `json:"code,omitempty"`
+    Namespace   string              `json:"-"`
+    Version     string              `json:"-"`
+    Publish     bool                `json:"publish"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
+    Error       string              `json:"error,omitempty"`
+    Code        int                 `json:"code,omitempty"`
 }
 
 type SentActionNoPublish struct {
-    Namespace   string      `json:"-"`
-    Version     string      `json:"-"`
-    Publish     bool        `json:"publish,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Limits      *Limits     `json:"limits,omitempty"`
-    Error       string      `json:"error,omitempty"`
-    Code        int         `json:"code,omitempty"`
+    Namespace   string              `json:"-"`
+    Version     string              `json:"-"`
+    Publish     bool                `json:"publish,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
+    Error       string              `json:"error,omitempty"`
+    Code        int                 `json:"code,omitempty"`
 }
 
 type Exec struct {

--- a/tools/go-cli/go-whisk/whisk/package.go
+++ b/tools/go-cli/go-whisk/whisk/package.go
@@ -21,7 +21,6 @@ import (
     "net/http"
     "net/url"
     "errors"
-    "reflect"
     "encoding/json"
 )
 
@@ -35,12 +34,12 @@ type PackageInterface interface {
 
 // Use this struct to create/update a package/binding with the Publish setting
 type SentPackagePublish struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
 }
 func (p *SentPackagePublish) GetName() string {
     return p.Name
@@ -48,12 +47,12 @@ func (p *SentPackagePublish) GetName() string {
 
 // Use this struct to update a package/binding with no change to the Publish setting
 type SentPackageNoPublish struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
 }
 func (p *SentPackageNoPublish) GetName() string {
     return p.Name
@@ -62,57 +61,30 @@ func (p *SentPackageNoPublish) GetName() string {
 // Use this struct to represent the package/binding sent from the Whisk server
 // Binding is a bool ???MWD20160602 now seeing Binding as a struct???
 type Package struct {
-    Namespace string    `json:"namespace,omitempty"`
-    Name      string    `json:"name,omitempty"`
-    Version   string    `json:"version,omitempty"`
-    Publish   bool      `json:"publish"`
-    Annotations 	    `json:"annotations,omitempty"`
-    Parameters  	    *json.RawMessage `json:"parameters,omitempty"`
-    Binding             `json:"binding,omitempty"`
-    Actions  []Action   `json:"actions,omitempty"`
-    Feeds    []Action   `json:"feeds,omitempty"`
+    Namespace   string              `json:"namespace,omitempty"`
+    Name        string              `json:"name,omitempty"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Binding                         `json:"binding,omitempty"`
+    Actions     []Action            `json:"actions,omitempty"`
+    Feeds       []Action            `json:"feeds,omitempty"`
 }
 func (p *Package) GetName() string {
     return p.Name
 }
 
-func (p *Package) GetAnnotationKeyValue(key string) string {
-    var val string = ""
-
-    Debug(DbgInfo, "Looking for annotation with key of '%s'\n", key)
-    if p.Annotations != nil {
-        for i,_ := range p.Annotations {
-            Debug(DbgInfo, "Examining annotation %+v\n", p.Annotations[i])
-            annotation := p.Annotations[i]
-            if k, ok := annotation["key"].(string); ok {
-                if k == key {
-                    if val, ok := annotation["value"].(string); ok {
-                        Debug(DbgInfo, "annotation[%s] = '%s'\n", key, val)
-                        if val != "" {
-                            return val
-                        }
-                    } else {
-                        Debug(DbgWarn, "Annotation 'value' is not a string type: %s", reflect.TypeOf(annotation["value"]).String())
-                    }
-                }
-            } else {
-                Debug(DbgWarn, "Annotation 'key' is not a string type: %s", reflect.TypeOf(annotation["key"]).String())
-            }
-        }
-    }
-    return val
-}
-
 // Use this struct when creating a binding
 // Publish is NOT optional; Binding is a namespace/name object, not a bool
 type BindingPackage struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
-    Binding          `json:"binding"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Binding                         `json:"binding"`
 }
 func (p *BindingPackage) GetName() string {
     return p.Name

--- a/tools/go-cli/go-whisk/whisk/trigger.go
+++ b/tools/go-cli/go-whisk/whisk/trigger.go
@@ -29,25 +29,25 @@ type TriggerService struct {
 }
 
 type Trigger struct {
-    Namespace string `json:"namespace,omitempty"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-    ActivationId string `json:"activationId,omitempty"`
-    Annotations `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    //Limits      `json:"limits,omitempty"`
+    Namespace string                `json:"namespace,omitempty"`
+    Name      string                `json:"-"`
+    Version   string                `json:"version,omitempty"`
+    Publish   bool                  `json:"publish,omitempty"`
+    ActivationId string             `json:"activationId,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    //Limits                        `json:"limits,omitempty"`
 }
 
 type TriggerFromServer struct {
-    Namespace string `json:"namespace"`
-    Name      string `json:"name"`
-    Version   string `json:"version"`
-    Publish   bool   `json:"publish"`
-    ActivationId string `json:"activationId,omitempty"`
-    Annotations `json:"annotations"`
-    Parameters  *json.RawMessage `json:"parameters"`
-    Limits      `json:"limits"`
+    Namespace string                `json:"namespace"`
+    Name      string                `json:"name"`
+    Version   string                `json:"version"`
+    Publish   bool                  `json:"publish"`
+    ActivationId string             `json:"activationId,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations"`
+    Parameters  *json.RawMessage    `json:"parameters"`
+    Limits                          `json:"limits"`
 }
 
 type TriggerListOptions struct {


### PR DESCRIPTION
- Update Go CLI to handle annotations as raw JSON instead of as strings
  - Use the same path that parameter parsing does
- Refactor printing of package summary
- Add tests to validate annotation, and parameter parsing
- Add negative tests to ensure arguments are passed to annotations, and parameters