### PR TITLE
Make logsize settable for each action

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Limits.scala
@@ -68,9 +68,6 @@ protected[core] object ActionLimits
     /** Creates a ActionLimits instance with default duration, memory and log limits. */
     protected[core] def apply(): ActionLimits = ActionLimits(TimeLimit(), MemoryLimit(), LogLimit())
 
-    /** Creates a ActionLimits instance with given duration and memory and default log limit. */
-    protected[core] def apply(timeout: TimeLimit, memory: MemoryLimit): ActionLimits = ActionLimits(timeout, memory, LogLimit())
-
     override protected[core] implicit val serdes = new RootJsonFormat[ActionLimits] {
         val helper = jsonFormat3(ActionLimits.apply)
 

--- a/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
@@ -42,6 +42,8 @@ protected[core] class LogLimit private (val megabytes: Int) extends AnyVal {
 }
 
 protected[core] object LogLimit extends ArgNormalizer[LogLimit] {
+    protected[entity] val MAX_LOGSIZE = 10 // MB
+    protected[entity] val MIN_LOGSIZE = 0 // MB
     protected[core] val STD_LOGSIZE = 10 // MB
 
     /** Gets LogLimit with default log limit */
@@ -55,8 +57,9 @@ protected[core] object LogLimit extends ArgNormalizer[LogLimit] {
      * @throws IllegalArgumentException if limit does not conform to requirements
      */
     @throws[IllegalArgumentException]
-    private def apply(megabytes: Int): LogLimit = {
-        require(megabytes == STD_LOGSIZE, s"only standard log limit of '$STD_LOGSIZE' (megabytes) allowed")
+    protected[core] def apply(megabytes: Int): LogLimit = {
+        require(megabytes >= MIN_LOGSIZE, s"log size $megabytes (megabytes) below allowed threshold of $MIN_LOGSIZE (megabytes)")
+        require(megabytes <= MAX_LOGSIZE, s"log size $megabytes (megabytes) exceeds allowed threshold of $MAX_LOGSIZE (megabytes)")
         new LogLimit(megabytes);
     }
 

--- a/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/MemoryLimit.scala
@@ -56,8 +56,8 @@ protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
      */
     @throws[IllegalArgumentException]
     protected[core] def apply(megabytes: Int): MemoryLimit = {
-        require(megabytes >= MIN_MEMORY, s"memory $megabytes below allowed threshold")
-        require(megabytes <= MAX_MEMORY, s"memory $megabytes exceeds allowed threshold")
+        require(megabytes >= MIN_MEMORY, s"memory $megabytes (megabytes) below allowed threshold of $MIN_MEMORY (megabytes)")
+        require(megabytes <= MAX_MEMORY, s"memory $megabytes (megabytes) exceeds allowed threshold of $MAX_MEMORY (megabytes)")
         new MemoryLimit(megabytes);
     }
 

--- a/common/scala/src/main/scala/whisk/core/entity/TimeLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/TimeLimit.scala
@@ -62,8 +62,8 @@ protected[core] object TimeLimit extends ArgNormalizer[TimeLimit] {
      */
     @throws[IllegalArgumentException]
     protected[core] def apply(duration: Int): TimeLimit = {
-        require(duration >= MIN_DURATION.toMillis.toInt, s"duration $duration below allowed threshold")
-        require(duration <= MAX_DURATION.toMillis.toInt, s"duration $duration exceeds allowed threshold")
+        require(duration >= MIN_DURATION.toMillis.toInt, s"duration $duration (milliseconds) below allowed threshold of $MIN_DURATION (milliseconds)")
+        require(duration <= MAX_DURATION.toMillis.toInt, s"duration $duration (milliseconds) exceeds allowed threshold of $MAX_DURATION (milliseconds)")
         new TimeLimit(Duration(duration, MILLISECONDS))
     }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -38,7 +38,7 @@ import whisk.core.database.DocumentFactory
  * ActionLimitsOption mirrors ActionLimits but makes both the timeout and memory
  * limit optional so that it is convenient to override just one limit at a time.
  */
-case class ActionLimitsOption(timeout: Option[TimeLimit], memory: Option[MemoryLimit])
+case class ActionLimitsOption(timeout: Option[TimeLimit], memory: Option[MemoryLimit], logs: Option[LogLimit])
 
 /**
  * WhiskActionPut is a restricted WhiskAction view that eschews properties
@@ -173,7 +173,7 @@ object WhiskAction
 }
 
 object ActionLimitsOption extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat2(ActionLimitsOption.apply)
+    implicit val serdes = jsonFormat3(ActionLimitsOption.apply)
 }
 
 object WhiskActionPut extends DefaultJsonProtocol {

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -69,6 +69,7 @@ import whisk.core.entity.Namespace
 import whisk.core.entity.{ Parameters, ParameterName, ParameterValue }
 import whisk.core.entity.SemVer
 import whisk.core.entity.TimeLimit
+import whisk.core.entity.LogLimit
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskActionPut
 import whisk.core.entity.WhiskActivation
@@ -355,7 +356,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
             val limits = content.limits map { l =>
                 ActionLimits(
                     l.timeout getOrElse TimeLimit(),
-                    l.memory getOrElse MemoryLimit())
+                    l.memory getOrElse MemoryLimit(),
+                    l.logs getOrElse LogLimit())
             } getOrElse ActionLimits()
 
             // This is temporary while we are making sequencing directly supported in the controller.
@@ -382,7 +384,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
     /** Updates a WhiskAction from PUT content, merging old action where necessary. */
     private def update(content: WhiskActionPut)(action: WhiskAction) = Future successful {
         val limits = content.limits map { l =>
-            ActionLimits(l.timeout getOrElse action.limits.timeout, l.memory getOrElse action.limits.memory)
+            ActionLimits(l.timeout getOrElse action.limits.timeout, l.memory getOrElse action.limits.memory, l.logs getOrElse action.limits.logs)
         } getOrElse action.limits
 
         // This is temporary while we are making sequencing directly supported in the controller.

--- a/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -38,6 +38,7 @@ import whisk.core.WhiskConfig.invokerContainerPolicy
 import whisk.core.WhiskConfig.selfDockerEndpoint
 import whisk.core.entity.ActionLimits
 import whisk.core.entity.MemoryLimit
+import whisk.core.entity.LogLimit
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.NodeJSExec
 import whisk.core.entity.WhiskAction
@@ -409,7 +410,7 @@ class ContainerPool(
 
     private def makeWarmNodejsContainer()(implicit transid: TransactionId): WhiskContainer = {
         val imageName = WhiskAction.containerImageName(nodejsExec, config.dockerRegistry, config.dockerImageTag)
-        val limits = ActionLimits(TimeLimit(), defaultMemoryLimit)
+        val limits = ActionLimits(TimeLimit(), defaultMemoryLimit, LogLimit())
         val containerName = makeContainerName("warmJsContainer")
         val con = makeGeneralContainer(warmNodejsKey, containerName, imageName, limits)
         this.synchronized {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -406,7 +406,7 @@ OpenWhisk has a few system limits, including how much memory an action uses and 
 | ----- | ----------- | ------------ | -----| ------- |
 | timeout | a container is not allowed to run longer than N milliseconds | per action |  milliseconds | 60000 |
 | memory | a container is not allowed to allocate more than N MB of memory | per action | MB | 256 |
-| logs | a container is not allowed to write mor than N MB to stdout | per action | MB | 10 |
+| logs | a container is not allowed to write more than N MB to stdout | per action | MB | 10 |
 | concurrent | it's not allowed to have more than N concurrent activations per namespace | per namespace | number | 100 |
 | minuteRate | a user cannot invoke more than this many actions per minute | per user | number | 120 |
 | hourRate | a user cannot invoke more than this many actions per hour | per user | number | 3600 |
@@ -422,9 +422,9 @@ OpenWhisk has a few system limits, including how much memory an action uses and 
 * A container cannot have more memory allocated than the limit.
 
 ### Per action logs (MB) (Default: 10MB)
-* The log limit M is in the range from [0MB..10MB] and is set per action in MB.
-* A user can change the limit when creating the action.
-* If a container writes more logs than the limit, the activation will contain the logs until that limit and truncated afterwards. The last logline will contain warning.
+* The log limit N is in the range [0MB..10MB] and is set per action.
+* A user can change the limit when creating or updating the action.
+* Logs that exceed the set limit are truncated and a warning is added as the last output of the activation to indicate that the activation exceeded the set log limit.
 
 ### Per action artifact (MB) (Fixed: 1MB)
 * The maximum code size for the action is 1MB.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -406,6 +406,7 @@ OpenWhisk has a few system limits, including how much memory an action uses and 
 | ----- | ----------- | ------------ | -----| ------- |
 | timeout | a container is not allowed to run longer than N milliseconds | per action |  milliseconds | 60000 |
 | memory | a container is not allowed to allocate more than N MB of memory | per action | MB | 256 |
+| logs | a container is not allowed to write mor than N MB to stdout | per action | MB | 10 |
 | concurrent | it's not allowed to have more than N concurrent activations per namespace | per namespace | number | 100 |
 | minuteRate | a user cannot invoke more than this many actions per minute | per user | number | 120 |
 | hourRate | a user cannot invoke more than this many actions per hour | per user | number | 3600 |
@@ -419,6 +420,11 @@ OpenWhisk has a few system limits, including how much memory an action uses and 
 * The memory limit M is in the range from [128MB..512MB] and is set per action in MB.
 * A user can change the limit when creating the action.
 * A container cannot have more memory allocated than the limit.
+
+### Per action logs (MB) (Default: 10MB)
+* The log limit M is in the range from [0MB..10MB] and is set per action in MB.
+* A user can change the limit when creating the action.
+* If a container writes more logs than the limit, the activation will contain the logs until that limit and truncated afterwards. The last logline will contain warning.
 
 ### Per action artifact (MB) (Fixed: 1MB)
 * The maximum code size for the action is 1MB.

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -41,6 +41,7 @@ import spray.json.JsValue
 import spray.json.pimpString
 import whisk.utils.retry
 import java.time.Instant
+import whisk.core.entity.ByteSize
 
 /**
  * Provide Scala bindings for the whisk CLI.
@@ -225,7 +226,7 @@ class WskAction(override val usePythonCLI: Boolean = false)
         annotations: Map[String, JsValue] = Map(),
         timeout: Option[Duration] = None,
         memory: Option[Int] = None,
-        logsize: Option[Int] = None,
+        logsize: Option[ByteSize] = None,
         shared: Option[Boolean] = None,
         update: Boolean = false,
         expectedExitCode: Int = SUCCESS_EXIT)(
@@ -242,7 +243,7 @@ class WskAction(override val usePythonCLI: Boolean = false)
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { timeout map { t => Seq("-t", t.toMillis.toString) } getOrElse Seq() } ++
             { memory map { m => Seq("-m", m.toString) } getOrElse Seq() } ++
-            { logsize map { l => Seq("-l", l.toString) } getOrElse Seq() } ++
+            { logsize map { l => Seq("-l", l.toMB.toString) } getOrElse Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -68,7 +68,6 @@ import java.time.Instant
  * a local property file if it exists.
  */
 
-
 case class WskProps(
     authKey: String = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting),
     namespace: String = "_",
@@ -226,6 +225,7 @@ class WskAction(override val usePythonCLI: Boolean = false)
         annotations: Map[String, JsValue] = Map(),
         timeout: Option[Duration] = None,
         memory: Option[Int] = None,
+        logsize: Option[Int] = None,
         shared: Option[Boolean] = None,
         update: Boolean = false,
         expectedExitCode: Int = SUCCESS_EXIT)(
@@ -242,6 +242,7 @@ class WskAction(override val usePythonCLI: Boolean = false)
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
             { timeout map { t => Seq("-t", t.toMillis.toString) } getOrElse Seq() } ++
             { memory map { m => Seq("-m", m.toString) } getOrElse Seq() } ++
+            { logsize map { l => Seq("-l", l.toString) } getOrElse Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }

--- a/tests/src/limits/ActionLimitsTests.scala
+++ b/tests/src/limits/ActionLimitsTests.scala
@@ -98,20 +98,20 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
 
     it should "succeed but truncate logs, if log size exceeds its limit" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
+            val allowedSize = 0 megabytes
             val name = "TestActionCausingExceededLogs"
             assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
                 val actionName = TestUtils.getTestActionFilename("dosLogs.js")
-                (action, _) => action.create(name, Some(actionName))
+                (action, _) => action.create(name, Some(actionName), logsize = Some(allowedSize.toMB.toInt))
             }
 
-            val allowedSize = 10 megabytes
-            val writing = allowedSize + 2.megabytes
+            val writing = allowedSize + 1.megabytes
             val characters = writing.toBytes / 2 // a character takes 2 bytes
 
             val run = wsk.action.invoke(name, Map("payload" -> characters.toJson))
             withActivation(wsk.activation, run) { response =>
                 val lines = response.fields("logs").convertTo[List[String]]
-                lines.last should be("Logs have been truncated because they exceeded the limit of 10 megabytes")
+                lines.last should be(s"Logs have been truncated because they exceeded the limit of ${allowedSize.toMB} megabytes")
                 // dropping 39 characters (timestamp + streamname)
                 lines.dropRight(1).map(_.drop(39)).mkString.sizeInBytes should be <= allowedSize
             }

--- a/tests/src/limits/ActionLimitsTests.scala
+++ b/tests/src/limits/ActionLimitsTests.scala
@@ -102,7 +102,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
             val name = "TestActionCausingExceededLogs"
             assetHelper.withCleaner(wsk.action, name, confirmDelete = true) {
                 val actionName = TestUtils.getTestActionFilename("dosLogs.js")
-                (action, _) => action.create(name, Some(actionName), logsize = Some(allowedSize.toMB.toInt))
+                (action, _) => action.create(name, Some(actionName), logsize = Some(allowedSize))
             }
 
             val writing = allowedSize + 1.megabytes

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -50,6 +50,7 @@ import whisk.core.entity.ActivationLogs
 import whisk.core.entity.AuthKey
 import whisk.core.entity.Exec
 import whisk.core.entity.MemoryLimit
+import whisk.core.entity.LogLimit
 import whisk.core.entity.Namespace
 import whisk.core.entity.Parameters
 import whisk.core.entity.SemVer
@@ -457,7 +458,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "put should accept request with limits property" in {
         implicit val tid = transid()
         val action = WhiskAction(namespace, aname, Exec.js("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory))))
+        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
         Put(s"$collectionPath/${action.name}", content) ~> sealRoute(routes(creds)) ~> check {
             deleteAction(action.docid)
             status should be(OK)
@@ -468,7 +469,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "put and then get action from cache" in {
         val action = WhiskAction(namespace, aname, Exec.js("??"), Parameters("x", "b"))
-        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory))))
+        val content = WhiskActionPut(Some(action.exec), Some(action.parameters), Some(ActionLimitsOption(Some(action.limits.timeout), Some(action.limits.memory), Some(action.limits.logs))))
         val name = action.name
 
         val stream = new ByteArrayOutputStream
@@ -590,7 +591,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "invoke an action, blocking with timeout" in {
         implicit val tid = transid()
-        val action = WhiskAction(namespace, aname, Exec.js("??"), limits = ActionLimits(TimeLimit(1000), MemoryLimit()))
+        val action = WhiskAction(namespace, aname, Exec.js("??"), limits = ActionLimits(TimeLimit(1000), MemoryLimit(), LogLimit()))
         put(entityStore, action)
         Post(s"$collectionPath/${action.name}?blocking=true") ~> sealRoute(routes(creds)) ~> check {
             status should be(Accepted)

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -364,12 +364,13 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
     }
 
     it should "reject bad limit values" in {
-        intercept[IllegalArgumentException] {
-            ActionLimits(TimeLimit(TimeLimit.MIN_DURATION.toMillis.toInt - 1), MemoryLimit(MemoryLimit.MIN_MEMORY - 1))
-        }
-        intercept[IllegalArgumentException] {
-            ActionLimits(TimeLimit(TimeLimit.MAX_DURATION.toMillis.toInt + 1), MemoryLimit(MemoryLimit.MAX_MEMORY + 1))
-        }
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(TimeLimit.MIN_DURATION.toMillis.toInt - 1), MemoryLimit(), LogLimit())
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(MemoryLimit.MIN_MEMORY - 1), LogLimit())
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(), LogLimit(LogLimit.MIN_LOGSIZE - 1))
+
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(TimeLimit.MAX_DURATION.toMillis.toInt + 1), MemoryLimit(), LogLimit())
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(MemoryLimit.MAX_MEMORY + 1), LogLimit())
+        an[IllegalArgumentException] should be thrownBy ActionLimits(TimeLimit(), MemoryLimit(), LogLimit(LogLimit.MAX_LOGSIZE + 1))
     }
 
     it should "parse activation id as uuid" in {

--- a/tools/cli/wskaction.py
+++ b/tools/cli/wskaction.py
@@ -97,8 +97,7 @@ class Action(Item):
             if args.param:
                 payload['parameters'] = getParams(args)
             # API will accept limits == {} as limits not specified on an update
-            print args.logsize
-            if args.timeout or args.memory or not args.logsize is None:
+            if not args.timeout is None or not args.memory is None or not args.logsize is None:
                 payload['limits'] = self.getLimits(args)
             if validExe:
                 payload['exec'] = exe
@@ -152,9 +151,9 @@ class Action(Item):
     # creates { timeout: msecs, memory: megabytes } action timeout/memory limits
     def getLimits(self, args):
         limits = {}
-        if args.timeout:
+        if not args.timeout is None:
             limits['timeout'] = args.timeout
-        if args.memory :
+        if not args.memory is None:
             limits['memory'] = args.memory
         if not args.logsize is None:
             limits['logs'] = args.logsize

--- a/tools/cli/wskaction.py
+++ b/tools/cli/wskaction.py
@@ -48,6 +48,7 @@ class Action(Item):
         subcmd.add_argument('-p', '--param', help='default parameters', nargs=2, action='append')
         subcmd.add_argument('-t', '--timeout', help='the timeout limit in milliseconds when the action will be terminated', type=int)
         subcmd.add_argument('-m', '--memory', help='the memory limit in MB of the container that runs the action', type=int)
+        subcmd.add_argument('-l', '--logsize', help='the logsize limit in MB of the container that runs the action', type=int)
 
         subcmd = parser.add_parser('update', help='update an existing action')
         subcmd.add_argument('--kind', help='the kind of the action runtime (example: swift:3)', type=str)
@@ -63,6 +64,7 @@ class Action(Item):
         subcmd.add_argument('-p', '--param', help='default parameters', nargs=2, action='append')
         subcmd.add_argument('-t', '--timeout', help='the timeout limit in milliseconds when the action will be terminated', type=int)
         subcmd.add_argument('-m', '--memory', help='the memory limit in MB of the container that runs the action', type=int)
+        subcmd.add_argument('-l', '--logsize', help='the logsize limit in MB of the container that runs the action', type=int)
 
         subcmd = parser.add_parser('invoke', help='invoke action')
         subcmd.add_argument('name', help='the name of the action to invoke')
@@ -95,7 +97,8 @@ class Action(Item):
             if args.param:
                 payload['parameters'] = getParams(args)
             # API will accept limits == {} as limits not specified on an update
-            if args.timeout or args.memory:
+            print args.logsize
+            if args.timeout or args.memory or not args.logsize is None:
                 payload['limits'] = self.getLimits(args)
             if validExe:
                 payload['exec'] = exe
@@ -153,6 +156,8 @@ class Action(Item):
             limits['timeout'] = args.timeout
         if args.memory :
             limits['memory'] = args.memory
+        if not args.logsize is None:
+            limits['logs'] = args.logsize
         return limits
 
     # creates one of:

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -506,13 +506,16 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
     }
 
     // Only include the memory and timeout limit if set
-    if flags.action.memory > 0 || flags.action.timeout > 0 {
+    if flags.action.memory > -1 || flags.action.timeout > -1 || flags.action.logsize > -1 {
         limits = new(whisk.Limits)
-        if flags.action.memory > 0 {
+        if flags.action.memory > -1 {
             limits.Memory = flags.action.memory
         }
-        if flags.action.timeout > 0 {
+        if flags.action.timeout > -1 {
             limits.Timeout = flags.action.timeout
+        }
+        if flags.action.logsize > -1 {
+            limits.Logsize = flags.action.logsize
         }
         whisk.Debug(whisk.DbgInfo, "Action limits: %+v\n", limits)
     }
@@ -677,8 +680,9 @@ func init() {
     actionCreateCmd.Flags().StringVar(&flags.action.kind, "kind", "", "the kind of the action runtime (example: swift:3, nodejs:6)")
     actionCreateCmd.Flags().StringVar(&flags.action.shared, "shared", "", "shared action (default: private)")
     actionCreateCmd.Flags().StringVar(&flags.action.xPackage, "package", "", "package")
-    actionCreateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", 0, "the timeout limit in miliseconds when the action will be terminated")
-    actionCreateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", 0, "the memory limit in MB of the container that runs the action")
+    actionCreateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in miliseconds when the action will be terminated")
+    actionCreateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", -1, "the memory limit in MB of the container that runs the action")
+    actionCreateCmd.Flags().IntVarP(&flags.action.logsize, "logsize", "l", -1, "the logsize limit in MB of the container that runs the action")
     actionCreateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")
     actionCreateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
 
@@ -688,8 +692,9 @@ func init() {
     actionUpdateCmd.Flags().StringVar(&flags.action.kind, "kind", "", "the kind of the action runtime (example: swift:3, nodejs:6)")
     actionUpdateCmd.Flags().StringVar(&flags.action.shared, "shared", "", "shared action (default: private)")
     actionUpdateCmd.Flags().StringVar(&flags.action.xPackage, "package", "", "package")
-    actionUpdateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", 0, "the timeout limit in miliseconds when the action will be terminated")
-    actionUpdateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", 0, "the memory limit in MB of the container that runs the action")
+    actionUpdateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in miliseconds when the action will be terminated")
+    actionUpdateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", -1, "the memory limit in MB of the container that runs the action")
+    actionUpdateCmd.Flags().IntVarP(&flags.action.logsize, "logsize", "l", -1, "the logsize limit in MB of the container that runs the action")
     actionUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")
     actionUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameters")
 

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -509,13 +509,19 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
     if flags.action.memory > -1 || flags.action.timeout > -1 || flags.action.logsize > -1 {
         limits = new(whisk.Limits)
         if flags.action.memory > -1 {
-            limits.Memory = flags.action.memory
+            limits.Memory = &flags.action.memory
+        } else {
+            limits.Memory = nil
         }
         if flags.action.timeout > -1 {
-            limits.Timeout = flags.action.timeout
+            limits.Timeout = &flags.action.timeout
+        } else {
+            limits.Timeout = nil
         }
         if flags.action.logsize > -1 {
-            limits.Logsize = flags.action.logsize
+            limits.Logsize = &flags.action.logsize
+        } else {
+            limits.Logsize = nil
         }
         whisk.Debug(whisk.DbgInfo, "Action limits: %+v\n", limits)
     }

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -510,18 +510,12 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
         limits = new(whisk.Limits)
         if flags.action.memory > -1 {
             limits.Memory = &flags.action.memory
-        } else {
-            limits.Memory = nil
         }
         if flags.action.timeout > -1 {
             limits.Timeout = &flags.action.timeout
-        } else {
-            limits.Timeout = nil
         }
         if flags.action.logsize > -1 {
             limits.Logsize = &flags.action.logsize
-        } else {
-            limits.Logsize = nil
         }
         whisk.Debug(whisk.DbgInfo, "Action limits: %+v\n", limits)
     }
@@ -686,7 +680,7 @@ func init() {
     actionCreateCmd.Flags().StringVar(&flags.action.kind, "kind", "", "the kind of the action runtime (example: swift:3, nodejs:6)")
     actionCreateCmd.Flags().StringVar(&flags.action.shared, "shared", "", "shared action (default: private)")
     actionCreateCmd.Flags().StringVar(&flags.action.xPackage, "package", "", "package")
-    actionCreateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in miliseconds when the action will be terminated")
+    actionCreateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in milliseconds when the action will be terminated")
     actionCreateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", -1, "the memory limit in MB of the container that runs the action")
     actionCreateCmd.Flags().IntVarP(&flags.action.logsize, "logsize", "l", -1, "the logsize limit in MB of the container that runs the action")
     actionCreateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")
@@ -698,7 +692,7 @@ func init() {
     actionUpdateCmd.Flags().StringVar(&flags.action.kind, "kind", "", "the kind of the action runtime (example: swift:3, nodejs:6)")
     actionUpdateCmd.Flags().StringVar(&flags.action.shared, "shared", "", "shared action (default: private)")
     actionUpdateCmd.Flags().StringVar(&flags.action.xPackage, "package", "", "package")
-    actionUpdateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in miliseconds when the action will be terminated")
+    actionUpdateCmd.Flags().IntVarP(&flags.action.timeout, "timeout", "t", -1, "the timeout limit in milliseconds when the action will be terminated")
     actionUpdateCmd.Flags().IntVarP(&flags.action.memory, "memory", "m", -1, "the memory limit in MB of the container that runs the action")
     actionUpdateCmd.Flags().IntVarP(&flags.action.logsize, "logsize", "l", -1, "the logsize limit in MB of the container that runs the action")
     actionUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotations")

--- a/tools/go-cli/go-whisk-cli/commands/flags.go
+++ b/tools/go-cli/go-whisk-cli/commands/flags.go
@@ -72,6 +72,7 @@ var flags struct {
         sequence    bool
         timeout     int
         memory      int
+        logsize     int
         result      bool
         xPackage    string
         kind        string

--- a/tools/go-cli/go-whisk/whisk/shared.go
+++ b/tools/go-cli/go-whisk/whisk/shared.go
@@ -36,7 +36,7 @@ type ActionSequence []KeyValues
 type Parameters *json.RawMessage
 
 type Limits struct {
-    Timeout int `json:"timeout,omitempty"`
-    Memory  int `json:"memory,omitempty"`
-    Logsize int `json:"logs"`
+    Timeout *int `json:"timeout,omitempty"`
+    Memory  *int `json:"memory,omitempty"`
+    Logsize *int `json:"logs,omitempty"`
 }

--- a/tools/go-cli/go-whisk/whisk/shared.go
+++ b/tools/go-cli/go-whisk/whisk/shared.go
@@ -38,4 +38,5 @@ type Parameters *json.RawMessage
 type Limits struct {
     Timeout int `json:"timeout,omitempty"`
     Memory  int `json:"memory,omitempty"`
+    Logsize int `json:"logs"`
 }


### PR DESCRIPTION
Adds the logsize as a limit that is settable per action and thus included in the quota for each action.

@mdeuser please review the go-cli parts

Signed-off-by: Christian Bickel <cbickel@de.ibm.com>