### PR TITLE
Allow invoker to run pull concurrently with other docker ops

### DIFF
--- a/core/dispatcher/src/main/scala/whisk/core/container/Container.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/Container.scala
@@ -34,7 +34,6 @@ class Container(
     val image: String,
     network: String,
     policy: Option[String],
-    pull: Boolean = false,
     val limits: ActionLimits = ActionLimits(),
     env: Map[String, String] = Map(),
     args: Array[String] = Array())
@@ -47,8 +46,6 @@ class Container(
     val id = Container.idCounter.next()
     val name = containerName.getOrElse("anon")
     val dockerhost = pool.dockerhost
-
-    if (pull) pullImage(image)
 
     val (containerId, containerIP) = bringup(containerName, image, network, env, args, limits, policy)
 

--- a/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -40,11 +40,10 @@ class WhiskContainer(
     image: String,
     network: String,
     policy: Option[String],
-    pull: Boolean,
     env: Map[String, String],
     limits: ActionLimits,
     args: Array[String] = Array())
-    extends Container(originalId, pool, key, Some(containerName), image, network, policy, pull, limits, env, args) {
+    extends Container(originalId, pool, key, Some(containerName), image, network, policy, limits, env, args) {
 
     var boundParams = JsObject() // Mutable to support pre-alloc containers
     var lastLogSize = 0L


### PR DESCRIPTION
Lift the pull operation from the Container ctor chain into the container pool.

Send docker pull operation to a different guard so that pull operations are serialized
among themselves but can run concurrently with non-pull operations.  (PPG 920)