### PR TITLE
Ignore reports generated when running tests.

### DIFF
--- a/tools/build/scanCode.py
+++ b/tools/build/scanCode.py
@@ -41,6 +41,7 @@ def exceptional_paths():
         "bin/wskadmin",
         "bin/wskdev",
         "bin/go-cli/wsk",
+        "tests/build/reports",
         "tests/src/com/google/code/tempusfugit/concurrency/ParallelRunner.java"
     ]
 


### PR DESCRIPTION
Gradle creates a report directory. Ignore all files in this directory when scanning project files. 