### PR TITLE
Supercedes #950 - fixes unsafe parameter passing in python action and issue #493

### DIFF
--- a/core/pythonAction/pythonaction.py
+++ b/core/pythonAction/pythonaction.py
@@ -61,7 +61,7 @@ def run():
     result = None
     try:
         exec(flask.g, namespace)
-        exec("param = " + json.dumps(value), namespace)
+        namespace["param"] = value
         exec("fun = main(param)", namespace)
         result = namespace['fun']
     except Exception:

--- a/tests/dat/actions/malformed.py
+++ b/tests/dat/actions/malformed.py
@@ -1,0 +1,2 @@
+// invalid python comment
+

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -56,7 +56,6 @@ class PythonActionContainerTests extends FlatSpec
             """.stripMargin
 
             val (initCode, _) = c.init(initPayload(code))
-
             initCode should be(200)
 
             val argss = List(
@@ -65,7 +64,29 @@ class PythonActionContainerTests extends FlatSpec
 
             for (args <- argss) {
                 val (runCode, out) = c.run(runPayload(args))
-                println(out)
+                runCode should be(200)
+                out should be(Some(args))
+            }
+        }
+        err.trim shouldBe empty
+    }
+
+    it should "support valid json" in {
+        val (out, err) = withPythonContainer { c =>
+            val code = """
+                |def main(dict):
+                |    return dict
+            """.stripMargin
+
+            val (initCode, _) = c.init(initPayload(code))
+            initCode should be(200)
+
+            val argss = List(
+                JsObject("user" -> JsNull),
+                JsObject("user" -> JsString("Momo")))
+
+            for (args <- argss) {
+                val (runCode, out) = c.run(runPayload(args))
                 runCode should be(200)
                 out should be(Some(args))
             }
@@ -101,14 +122,13 @@ class PythonActionContainerTests extends FlatSpec
               | 20 GOTO 10
             """.stripMargin
 
-            val (initCode, _) = c.init(initPayload(code))
-            // init code does not check anything about the code, so it should return 200
-            initCode should be(200)
+            val (initCode, res) = c.init(initPayload(code))
+            // init checks whether compilation was successful, so return 502
+            initCode should be(502)
 
             val (runCode, runRes) = c.run(runPayload(JsObject("basic" -> JsString("forever"))))
             runCode should be(502)
         }
-        err.toLowerCase should include("error")
     }
 
 
@@ -123,7 +143,6 @@ class PythonActionContainerTests extends FlatSpec
             initCode should be(200)
 
             val (runCode, runRes) = c.run(runPayload(JsObject()))
-            println(runRes)
             runCode should be(200) // action writer returning an error is OK
 
             runRes shouldBe defined
@@ -134,8 +153,8 @@ class PythonActionContainerTests extends FlatSpec
     it should "enforce that the user returns an object" in {
         withPythonContainer { c =>
             val code = """
-                | def main(args):
-                |     return "rebel, rebel"
+                |def main(args):
+                |    return "rebel, rebel"
             """.stripMargin
 
             val (initCode, _) = c.init(initPayload(code))

--- a/tests/src/system/basic/CLIJavaTests.scala
+++ b/tests/src/system/basic/CLIJavaTests.scala
@@ -39,8 +39,7 @@ class CLIJavaTests
     with Matchers {
 
     implicit val wskprops = WskProps()
-    var usePythonCLI = false
-    val wsk = new Wsk(usePythonCLI)
+    val wsk = new Wsk(usePythonCLI = false)
     val expectedDuration = 120 seconds
     val activationPollDuration = 60 seconds
 


### PR DESCRIPTION
I addressed the comments I made on #950, and made some additional tweaks to limit the stack trace reported to the end user (i.e., exclude 'init' and 'flask') and added a CLI test for bad python code that won't compile (fixing #493).

IPG 390 and PPG 946 approved.