### PR TITLE
Increase maximumAllowedDelay for invokers from 5 to 20 seconds

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -117,7 +117,7 @@ class InvokerHealth(
         JsObject(health toMap)
     }
 
-    private val maximumAllowedDelay = 5 seconds
+    private val maximumAllowedDelay = 20 seconds
     def isFresh(lastDate: String) = {
         val lastDateMilli = DateUtil.parseToMilli(lastDate)
         val now = System.currentTimeMillis() // We fetch this repeatedly in case KV fetch is slow


### PR DESCRIPTION
Signed-off-by: Jeremias Werner <JEREWERN@de.ibm.com>

As discussed in blue-issue. PPG 957 is running.