### PR TITLE
Catch expections in ActivationFeed due to Kafka poll/commit failure and retry (Supersedes #990)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,6 @@ node_modules
 
 # Ansible
 ansible/environments/mac/hosts
-ansible/db_local.ini
+ansible/db_local.ini*
 ansible/tmp/*
 

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -18,12 +18,14 @@ package services
 
 import java.util.Calendar
 
-import scala.collection.JavaConversions.iterableAsScalaIterable
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 
+import org.apache.kafka.clients.consumer.CommitFailedException
 import org.junit.runner.RunWith
-import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Finders
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
@@ -35,44 +37,74 @@ import whisk.connector.kafka.KafkaProducerConnector
 import whisk.core.WhiskConfig
 import whisk.core.connector.Message
 import whisk.utils.ExecutionContextFactory
-import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
-class KafkaConnectorTests extends FlatSpec with Matchers with BeforeAndAfter {
+class KafkaConnectorTests extends FlatSpec with Matchers with BeforeAndAfterAll {
     implicit val transid = TransactionId.testing
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
+
+    val config = new WhiskConfig(WhiskConfig.kafkaHost)
+    assert(config.isValid)
+
+    val groupid = "kafkatest"
+    val topic = "Dinosaurs"
+    val sessionTimeout = 10 seconds
+    val producer = new KafkaProducerConnector(config.kafkaHost, ec)
+    val consumer = new KafkaConsumerConnector(config.kafkaHost, groupid, topic, sessionTimeout = sessionTimeout)
+
+    producer.setVerbosity(Verbosity.Debug)
+    consumer.setVerbosity(Verbosity.Debug)
+
+    override def afterAll() {
+        producer.close()
+        consumer.close()
+    }
 
     behavior of "Kafka connector"
 
     it should "send and receive a kafka message which sets up the topic" in {
+        for (i <- 0 until 5) {
+            val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
+            val start = java.lang.System.currentTimeMillis
+            val sent = Await.result(producer.send(topic, message), 10 seconds)
+            val received = consumer.peek(10 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
+            val end = java.lang.System.currentTimeMillis
+            val elapsed = end - start
+            println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
+            received.size should be >= 1
+            received.last should be(message.serialize)
+            consumer.commit()
+        }
+    }
 
-        val config = new WhiskConfig(WhiskConfig.kafkaHost)
-        assert(config.isValid)
+    it should "send and receive a kafka message even after session timeout" in {
+        for (i <- 0 until 4) {
+            val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
+            val start = java.lang.System.currentTimeMillis
+            val sent = Await.result(producer.send(topic, message), 1 seconds)
+            val received = consumer.peek(1 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
+            val end = java.lang.System.currentTimeMillis
+            val elapsed = end - start
+            println(s"($i) Received ${received.size}. Took $elapsed msec: $received\n")
 
-        val groupid = "kafkatest"
-        val topic = "Dinosaurs"
-        val producer = new KafkaProducerConnector(config.kafkaHost, ec)
-        val consumer = new KafkaConsumerConnector(config.kafkaHost, groupid, topic)
-
-        producer.setVerbosity(Verbosity.Debug)
-        consumer.setVerbosity(Verbosity.Debug)
-
-        try {
-            for (i <- 0 until 5) {
-                val message = new Message { override val serialize = Calendar.getInstance().getTime().toString }
-                val start = java.lang.System.currentTimeMillis
-                val sent = Await.result(producer.send(topic, message), 10 seconds)
-                val received = consumer.peek(10 seconds).map { case (_, _, _, msg) => new String(msg, "utf-8") }
-                val end = java.lang.System.currentTimeMillis
-                val elapsed = end - start
-                println(s"Took $elapsed msec: $received\n\n")
-                received.size should be >= 1
-                received.last should be(message.serialize)
-                consumer.commit()
+            // only the last iteration will have an updated cursor
+            // iteration 0: get whatever is on the topic (at least 1 but may be more if a previous test failed)
+            // iteration 1: get iteration 0 records + 1 more (since we intentionally failed the commit on previous iteration)
+            // iteration 2: get iteration 1 records + 1 more (since we intentionally failed the commit on previous iteration)
+            // iteration 3: get exactly 1 records since iteration 2 should have forwarded the cursor
+            if (i < 3) {
+                received.size should be >= i + 1
+            } else {
+                received.size should be(1)
             }
-        } finally {
-            producer.close()
-            consumer.close()
+            received.last should be(message.serialize)
+
+            if (i < 2) {
+                Thread.sleep((sessionTimeout + 1.second).toMillis)
+                an[CommitFailedException] should be thrownBy {
+                    consumer.commit() // sleep should cause commit to fail
+                }
+            } else consumer.commit()
         }
     }
 

--- a/tests/src/whisk/core/dispatcher/test/TestConnector.scala
+++ b/tests/src/whisk/core/dispatcher/test/TestConnector.scala
@@ -51,7 +51,11 @@ class TestConnector(
     }
 
     override def commit() = {
-        // nothing to do
+        if (throwCommitException) {
+            throw new Exception("commit failed")
+        } else {
+            // nothing to do
+        }
     }
 
     override def onMessage(process: (String, Int, Long, Array[Byte]) => Unit): Unit = {
@@ -91,6 +95,7 @@ class TestConnector(
         val counter = new Counter()
     }
 
+    protected[test] var throwCommitException = false
     private val queue = new LinkedBlockingQueue[Message]()
     @volatile private var closed = false
     private var offset = -1L


### PR DESCRIPTION
Modify activation feed so that we grab next batch of messages and commit offsets immediately, essentially marking the activation has having satisfied "at most once" semantics (this is the point at which the activation is considered started); if the commit fails, then messages peeked are peeked again on the next poll.

While the commit is synchronous and will block until it completes, at steady state with enough buffering (i.e., maxPipelineDepth > maxPeek), the latency of the commit should be masked.

Add kafka test where we intentionally fail the commit and then confirm recovery.

Supersedes #990.
PPG 960 approved.