### PR TITLE
Reduce frequency of posting user activation counts

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -129,7 +129,7 @@ class InvokerHealth(
         LoadBalancerKeys.hostnameKey,
         LoadBalancerKeys.startKey,
         LoadBalancerKeys.statusKey,
-        { () =>
+        { index =>
             Map(LoadBalancerKeys.invokerHealth -> getInvokerHealthJson(),
                 LoadBalancerKeys.activationCountKey -> getKafkaPostCount().toJson)
         })

--- a/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -41,6 +41,7 @@ import spray.json.JsArray
 import spray.json.JsNumber
 import spray.json.JsObject
 import spray.json.JsString
+import spray.json.JsValue
 import spray.json.pimpAny
 import spray.json.pimpString
 import whisk.common.ConsulClient
@@ -547,9 +548,9 @@ class Invoker(
         InvokerKeys.hostname(instance),
         InvokerKeys.start(instance),
         InvokerKeys.status(instance),
-        { () =>
-            getUserActivationCounts() ++
-                Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson)
+        { index =>
+            (if (index % 5 == 0) getUserActivationCounts() else Map[String,JsValue]()) ++
+            Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson)
         })
 
     // This is used for the getContainer endpoint used in perfContainer testing it is not real state


### PR DESCRIPTION
Change KVReporter's input thunk so that it accepts a count.  Use count to reduce the rate at which user activation counts are written out.  PG 970