### PR TITLE
Annotations Must be Parsed as Raw JSON

### DIFF
--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -601,8 +601,7 @@ class WskActivation(override val usePythonCLI: Boolean = false)
                 Try {
                     // strip first line and convert the rest to JsObject
                     assert(stdout.startsWith("ok: got activation"))
-                    val firstNewline = stdout.indexOf("\n")
-                    stdout.substring(firstNewline + 1).parseJson.asJsObject
+                    parseJsonString(stdout)
                 } map {
                     Right(_)
                 } getOrElse Left(s"cannot parse activation from '$stdout'")
@@ -788,6 +787,14 @@ sealed trait RunWskCmd {
         val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, args ++ params: _*)
         rr.validateExitCode(expectedExitCode)
         rr
+    }
+
+    /*
+     * Utility function to return a JSON object from the CLI output that returns
+     * an optional a status line following by the JSON data
+     */
+    def parseJsonString(jsonStr: String): JsObject = {
+        jsonStr.substring(jsonStr.indexOf("\n") + 1).parseJson.asJsObject  // Skip optional status line before parsing
     }
 }
 

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -30,6 +30,7 @@ import common.TestUtils
 import common.TestUtils.ANY_ERROR_EXIT
 import common.TestUtils.BAD_REQUEST
 import common.TestUtils.CONFLICT
+import common.TestUtils.ERROR_EXIT
 import common.TestUtils.FORBIDDEN
 import common.TestUtils.NOTALLOWED
 import common.TestUtils.NOT_FOUND
@@ -39,6 +40,7 @@ import common.TestUtils.UNAUTHORIZED
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
+import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import spray.json.pimpAny
@@ -332,6 +334,7 @@ class WskBasicTests
             }
     }
 
+
     behavior of "Wsk Rule CLI"
 
     it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) {
@@ -372,5 +375,4 @@ class WskBasicTests
         wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).
             stdout should include("default")
     }
-
 }

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -171,9 +171,9 @@ var actionInvokeCmd = &cobra.Command{
     if len(flags.common.param) > 0 {
       whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
 
-      parameters, err := parseParameters(flags.common.param)
+      parameters, err := getJSONFromArguments(flags.common.param, false)
       if err != nil {
-        whisk.Debug(whisk.DbgError, "parseParameters(%#v) failed: %s\n", flags.common.param, err)
+        whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, false) failed: %s\n", flags.common.param, err)
         errMsg := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -462,25 +462,25 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, bool, error)
     sharedSet = false
   }
 
-  whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-  parameters, err := parseParametersArray(flags.common.param)
-  if err != nil {
-    whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
-    errMsg := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
-    whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-      whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-    return nil, sharedSet, whiskErr
-  }
+    whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
+    parameters, err := getJSONFromArguments(flags.common.param, true)
+    if err != nil {
+        whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
+        errMsg := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
+        whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+        return nil, sharedSet, whiskErr
+    }
 
-  whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-  annotations, err := parseAnnotations(flags.common.annotation)
-  if err != nil {
-    whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
-    errMsg := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
-    whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-      whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-    return nil, sharedSet, whiskErr
-  }
+    whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
+    annotations, err := getJSONFromArguments(flags.common.annotation, true)
+    if err != nil {
+        whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
+        errMsg := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
+        whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+        return nil, sharedSet, whiskErr
+    }
 
   // Only include the memory and timeout limit if set
   if flags.action.memory > -1 || flags.action.timeout > -1 || flags.action.logsize > -1 {

--- a/tools/go-cli/go-whisk-cli/commands/commands.go
+++ b/tools/go-cli/go-whisk-cli/commands/commands.go
@@ -124,9 +124,9 @@ func parseArgs(args []string) ([]string, []string, []string, error) {
                 annotArgs = append(annotArgs, "")
                 args = append(args[:i], args[i + 2:]...)
             } else {
-                whisk.Debug(whisk.DbgError, "Parameter arguments must be a key value pair; args: %s", args)
+                whisk.Debug(whisk.DbgError, "Annotation arguments must be a key value pair; args: %s", args)
 
-                errMsg = fmt.Sprintf("Parameter arguments must be a key value pair: %s", args)
+                errMsg = fmt.Sprintf("Annotation arguments must be a key value pair: %s", args)
                 whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
                     whisk.DISPLAY_USAGE)
 

--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -83,10 +83,10 @@ var packageBindCmd = &cobra.Command{
     // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := parseParametersArray(flags.common.param)
+    parameters, err := getJSONFromArguments(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
@@ -96,10 +96,10 @@ var packageBindCmd = &cobra.Command{
     // The 1 or more --annotation arguments have all been combined into a single []string
     // e.g.   --a arg1,arg2 --a arg3,arg4   ->  [arg1, arg2, arg3, arg4]
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := parseAnnotations(flags.common.annotation)
+    annotations, err := getJSONFromArguments(flags.common.annotation, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
@@ -175,20 +175,20 @@ var packageCreateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := parseParametersArray(flags.common.param)
+    parameters, err := getJSONFromArguments(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := parseAnnotations(flags.common.annotation)
+    annotations, err := getJSONFromArguments(flags.common.annotation, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
@@ -271,19 +271,19 @@ var packageUpdateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := parseParametersArray(flags.common.param)
+    parameters, err := getJSONFromArguments(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseParametersArray(%#v) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf("Invalid parameter argument '%#v': %s", flags.common.param, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := parseAnnotations(flags.common.annotation)
+    annotations, err := getJSONFromArguments(flags.common.annotation, true)
     if err != nil {
-      whisk.Debug(whisk.DbgError, "parseAnnotations(%#v) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf("Invalid annotation argument '%#v': %s", flags.common.annotation, err)
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr

--- a/tools/go-cli/go-whisk/whisk/action.go
+++ b/tools/go-cli/go-whisk/whisk/action.go
@@ -20,7 +20,6 @@ import (
     "fmt"
     "net/http"
     "errors"
-    "reflect"
     "encoding/json"
     "net/url"
 )
@@ -30,65 +29,38 @@ type ActionService struct {
 }
 
 type Action struct {
-    Namespace   string      `json:"namespace,omitempty"`
-    Name        string      `json:"name,omitempty"`
-    Version     string      `json:"version,omitempty"`
-    Publish     bool        `json:"publish"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`   // Can be either []KeyValue or []KeyValues (action seq)
-    Limits      *Limits     `json:"limits,omitempty"`
-}
-
-func (p *Action) GetAnnotationKeyValue(key string) string {
-    var val string = ""
-
-    Debug(DbgInfo, "Looking for annotation with key of '%s'\n", key)
-    if p.Annotations != nil {
-        for i,_ := range p.Annotations {
-            Debug(DbgInfo, "Examining annotation %+v\n", p.Annotations[i])
-            annotation := p.Annotations[i]
-            if k, ok := annotation["key"].(string); ok {
-                if k == key {
-                    if val, ok := annotation["value"].(string); ok {
-                        Debug(DbgInfo, "annotation[%s] = '%s'\n", key, val)
-                        if val != "" {
-                            return val
-                        }
-                    } else {
-                        Debug(DbgWarn, "Annotation 'value' is not a string type: %s", reflect.TypeOf(annotation["value"]).String())
-                    }
-                }
-            } else {
-                Debug(DbgWarn, "Annotation 'key' is not a string type: %s", reflect.TypeOf(annotation["key"]).String())
-            }
-        }
-    }
-    return val
+    Namespace   string              `json:"namespace,omitempty"`
+    Name        string              `json:"name,omitempty"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
 }
 
 type SentActionPublish struct {
-    Namespace   string      `json:"-"`
-    Version     string      `json:"-"`
-    Publish     bool        `json:"publish"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Limits      *Limits     `json:"limits,omitempty"`
-    Error       string      `json:"error,omitempty"`
-    Code        int         `json:"code,omitempty"`
+    Namespace   string              `json:"-"`
+    Version     string              `json:"-"`
+    Publish     bool                `json:"publish"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
+    Error       string              `json:"error,omitempty"`
+    Code        int                 `json:"code,omitempty"`
 }
 
 type SentActionNoPublish struct {
-    Namespace   string      `json:"-"`
-    Version     string      `json:"-"`
-    Publish     bool        `json:"publish,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    Exec        *Exec       `json:"exec,omitempty"`
-    Annotations             `json:"annotations,omitempty"`
-    Limits      *Limits     `json:"limits,omitempty"`
-    Error       string      `json:"error,omitempty"`
-    Code        int         `json:"code,omitempty"`
+    Namespace   string              `json:"-"`
+    Version     string              `json:"-"`
+    Publish     bool                `json:"publish,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Exec        *Exec               `json:"exec,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Limits      *Limits             `json:"limits,omitempty"`
+    Error       string              `json:"error,omitempty"`
+    Code        int                 `json:"code,omitempty"`
 }
 
 type Exec struct {

--- a/tools/go-cli/go-whisk/whisk/client.go
+++ b/tools/go-cli/go-whisk/whisk/client.go
@@ -202,6 +202,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
         if req.Body != nil {
             fmt.Println("Req Body")
             fmt.Println(req.Body)
+            Debug(DbgInfo, "Req Body (ASCII quoted string):\n%+q", req.Body)
         }
     }
 
@@ -225,6 +226,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
     }
     Verbose("Response body size is %d bytes\n", len(data))
     Verbose("Response body received:\n%s\n", string(data))
+    Debug(DbgInfo, "Response body received (ASCII quoted string):\n%+q", string(data))
 
     // With the HTTP response status code and the HTTP body contents,
     // the possible response scenarios are:

--- a/tools/go-cli/go-whisk/whisk/package.go
+++ b/tools/go-cli/go-whisk/whisk/package.go
@@ -21,7 +21,6 @@ import (
     "net/http"
     "net/url"
     "errors"
-    "reflect"
     "encoding/json"
 )
 
@@ -35,12 +34,12 @@ type PackageInterface interface {
 
 // Use this struct to create/update a package/binding with the Publish setting
 type SentPackagePublish struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
 }
 func (p *SentPackagePublish) GetName() string {
     return p.Name
@@ -48,12 +47,12 @@ func (p *SentPackagePublish) GetName() string {
 
 // Use this struct to update a package/binding with no change to the Publish setting
 type SentPackageNoPublish struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
 }
 func (p *SentPackageNoPublish) GetName() string {
     return p.Name
@@ -62,57 +61,30 @@ func (p *SentPackageNoPublish) GetName() string {
 // Use this struct to represent the package/binding sent from the Whisk server
 // Binding is a bool ???MWD20160602 now seeing Binding as a struct???
 type Package struct {
-    Namespace string    `json:"namespace,omitempty"`
-    Name      string    `json:"name,omitempty"`
-    Version   string    `json:"version,omitempty"`
-    Publish   bool      `json:"publish"`
-    Annotations 	    `json:"annotations,omitempty"`
-    Parameters  	    *json.RawMessage `json:"parameters,omitempty"`
-    Binding             `json:"binding,omitempty"`
-    Actions  []Action   `json:"actions,omitempty"`
-    Feeds    []Action   `json:"feeds,omitempty"`
+    Namespace   string              `json:"namespace,omitempty"`
+    Name        string              `json:"name,omitempty"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Binding                         `json:"binding,omitempty"`
+    Actions     []Action            `json:"actions,omitempty"`
+    Feeds       []Action            `json:"feeds,omitempty"`
 }
 func (p *Package) GetName() string {
     return p.Name
 }
 
-func (p *Package) GetAnnotationKeyValue(key string) string {
-    var val string = ""
-
-    Debug(DbgInfo, "Looking for annotation with key of '%s'\n", key)
-    if p.Annotations != nil {
-        for i,_ := range p.Annotations {
-            Debug(DbgInfo, "Examining annotation %+v\n", p.Annotations[i])
-            annotation := p.Annotations[i]
-            if k, ok := annotation["key"].(string); ok {
-                if k == key {
-                    if val, ok := annotation["value"].(string); ok {
-                        Debug(DbgInfo, "annotation[%s] = '%s'\n", key, val)
-                        if val != "" {
-                            return val
-                        }
-                    } else {
-                        Debug(DbgWarn, "Annotation 'value' is not a string type: %s", reflect.TypeOf(annotation["value"]).String())
-                    }
-                }
-            } else {
-                Debug(DbgWarn, "Annotation 'key' is not a string type: %s", reflect.TypeOf(annotation["key"]).String())
-            }
-        }
-    }
-    return val
-}
-
 // Use this struct when creating a binding
 // Publish is NOT optional; Binding is a namespace/name object, not a bool
 type BindingPackage struct {
-    Namespace string `json:"-"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish"`
-    Annotations 	 `json:"annotations,omitempty"`
-    Parameters  	 *json.RawMessage `json:"parameters,omitempty"`
-    Binding          `json:"binding"`
+    Namespace   string              `json:"-"`
+    Name        string              `json:"-"`
+    Version     string              `json:"version,omitempty"`
+    Publish     bool                `json:"publish"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Binding                         `json:"binding"`
 }
 func (p *BindingPackage) GetName() string {
     return p.Name

--- a/tools/go-cli/go-whisk/whisk/trigger.go
+++ b/tools/go-cli/go-whisk/whisk/trigger.go
@@ -29,25 +29,25 @@ type TriggerService struct {
 }
 
 type Trigger struct {
-    Namespace string `json:"namespace,omitempty"`
-    Name      string `json:"-"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-    ActivationId string `json:"activationId,omitempty"`
-    Annotations `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage `json:"parameters,omitempty"`
-    //Limits      `json:"limits,omitempty"`
+    Namespace string                `json:"namespace,omitempty"`
+    Name      string                `json:"-"`
+    Version   string                `json:"version,omitempty"`
+    Publish   bool                  `json:"publish,omitempty"`
+    ActivationId string             `json:"activationId,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    //Limits                        `json:"limits,omitempty"`
 }
 
 type TriggerFromServer struct {
-    Namespace string `json:"namespace"`
-    Name      string `json:"name"`
-    Version   string `json:"version"`
-    Publish   bool   `json:"publish"`
-    ActivationId string `json:"activationId,omitempty"`
-    Annotations `json:"annotations"`
-    Parameters  *json.RawMessage `json:"parameters"`
-    Limits      `json:"limits"`
+    Namespace string                `json:"namespace"`
+    Name      string                `json:"name"`
+    Version   string                `json:"version"`
+    Publish   bool                  `json:"publish"`
+    ActivationId string             `json:"activationId,omitempty"`
+    Annotations *json.RawMessage    `json:"annotations"`
+    Parameters  *json.RawMessage    `json:"parameters"`
+    Limits                          `json:"limits"`
 }
 
 type TriggerListOptions struct {


### PR DESCRIPTION
Annotations Must be Parsed as Raw JSON

parameter/annotation `key` input value is a string.  It will be converted into a JSON string doing
`\` and `"` escaping.  If it's not a valid JSON string after that, an error is returned.

parameter/annotation `value` input value is expected to be valid JSON.  If it is not valid JSON,
and it is NOT surrounded by either {} or [], it will be surrounded with double quotes making it a JSON
string.  In all cases, if the final value is still not valid JSON, an error is returned.

Replaces PR #953 
Fixes #952 
Fixes #717 
Fixes #718 
