### PR TITLE
Remove services:registrator in gradle setting

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,6 @@ include 'core:javaAction'
 
 include 'services:consul'
 include 'services:kafka'
-include 'services:registrator'
 include 'services:zookeeper'
 
 include 'tools:cli'


### PR DESCRIPTION
Since services:registrator is removed, we need to remove from the
gradle setting. If it is still there, import openwhisk project
as a gradle project will raise an error in eclipse.