### PR TITLE
Add string for go-cli error when host is not set

### DIFF
--- a/tools/go-cli/go-whisk-cli/commands/commands.go
+++ b/tools/go-cli/go-whisk-cli/commands/commands.go
@@ -30,6 +30,11 @@ import (
 var client *whisk.Client
 
 func setupClientConfig(cmd *cobra.Command, args []string) (error){
+    if(Properties.APIHost == "") {
+        errStr := "Cannot perform operation because an API host is not set"
+        werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+        return werr
+    }
     var apiHostBaseUrl = fmt.Sprintf("https://%s/api/", Properties.APIHost)
 
     baseURL, err := url.Parse(apiHostBaseUrl)

--- a/tools/go-cli/go-whisk-cli/commands/property.go
+++ b/tools/go-cli/go-whisk-cli/commands/property.go
@@ -63,7 +63,6 @@ var propertySetCmd = &cobra.Command{
     Short:          "set property",
     SilenceUsage:   true,
     SilenceErrors:  true,
-    PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
         var okMsg string = ""
         var werr *whisk.WskError = nil
@@ -76,7 +75,12 @@ var propertySetCmd = &cobra.Command{
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-
+        if client == nil {
+            whisk.Debug(whisk.DbgError,"client not initialized",nil)
+            errStr := "client not initialized"
+            werr :=whisk.MakeWskError(errors.New(errStr),whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,whisk.NO_DISPLAY_USAGE)
+            return werr
+        }
         // read in each flag, update if necessary
 
         if auth := flags.global.auth; len(auth) > 0 {


### PR DESCRIPTION
Remove detail error to console,
since they can obtain in debug mode.

Fixes #979 