### PR TITLE
add option to print verbose CLI output to stdout during tests.

### DIFF
--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -328,7 +328,9 @@ public class TestUtils {
 
         int exitCode = bl.launch(timeoutMilli);
         RunResult rr = new RunResult(exitCode, new String(bl.getStdout()), new String(bl.getStderr()));
-        logger.info("RunResult: " + rr);
+        if (logger != null) {
+            logger.info("RunResult: " + rr);
+        }
         rr.validateExitCode(expectedExitCode);
         return rr;
     }

--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -72,7 +72,7 @@ public class TestUtils {
 
 
     static {
-        logger.setLevel(Level.WARNING);
+        logger.setLevel(Level.INFO);
         System.out.println("JUnit version is: " + Version.id());
     }
 
@@ -328,6 +328,7 @@ public class TestUtils {
 
         int exitCode = bl.launch(timeoutMilli);
         RunResult rr = new RunResult(exitCode, new String(bl.getStdout()), new String(bl.getStderr()));
+        logger.info("RunResult: " + rr);
         rr.validateExitCode(expectedExitCode);
         return rr;
     }


### PR DESCRIPTION
this will greatly increase verbosity of CLI tests if needed. currently applied to CLIRuleTests only for debugging. can be turned on for other tests as well. we could also pass it in as a gradle property on demand.