### PR TITLE
Make task print when its called

### DIFF
--- a/tools/go-cli/build.gradle
+++ b/tools/go-cli/build.gradle
@@ -18,7 +18,7 @@ task distBinary(dependsOn: [removeBinary, distDocker]) << {
     run(dockerBinary + ["rm", "-f", dockerContainerName])
 }
 
-task dumpOSInfo {
+task dumpOSInfo << {
     println "os.name = "+getOsName()
     println "os.arch = "+getOsArch()
     println "go.name = "+mapOsNameToGoName(getOsName())


### PR DESCRIPTION
omitting `<<` in a plain task causes the statements to be executed during gradles initialize phase as opposed to when its finally called