### PR TITLE
More Go CLI parity with Python CLI

### DIFF
--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -149,9 +149,13 @@ trait ListOrGetFromCollection extends FullyQualifiedNames {
      */
     def get(
         name: String,
-        expectedExitCode: Int = SUCCESS_EXIT)(
+        expectedExitCode: Int = SUCCESS_EXIT,
+        summary: Boolean = false)(
             implicit wp: WskProps): RunResult = {
-        cli(wp.overrides ++ Seq(noun, "get", "--auth", wp.authKey, fqn(name)), expectedExitCode)
+        val params = Seq(noun, "get", "--auth", wp.authKey) ++
+          Seq(fqn(name)) ++
+          { if (summary) Seq("--summary") else Seq() }
+        cli(wp.overrides ++ params, expectedExitCode)
     }
 }
 

--- a/tools/go-cli/go-whisk-cli/commands/action.go
+++ b/tools/go-cli/go-whisk-cli/commands/action.go
@@ -32,6 +32,7 @@ import (
 
   "github.com/fatih/color"
   "github.com/spf13/cobra"
+  "github.com/mattn/go-colorable"
 )
 
 //////////////
@@ -188,7 +189,7 @@ var actionInvokeCmd = &cobra.Command{
       payload = (*json.RawMessage)(&data)
     }
 
-    outputStream := os.Stdout
+    outputStream := color.Output
 
     activation, _, err := client.Actions.Invoke(qName.entityName, payload, flags.common.blocking)
     if err != nil {
@@ -202,17 +203,17 @@ var actionInvokeCmd = &cobra.Command{
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
       } else {
-        outputStream = os.Stderr
+        outputStream = colorable.NewColorableStderr()
       }
     }
 
     if flags.common.blocking && flags.action.result {
-      printJsonNoColor(activation.Response.Result, outputStream)
+      printJSON(activation.Response.Result, outputStream)
     } else if flags.common.blocking {
       fmt.Fprintf(color.Output, "%s invoked /%s/%s with id %s\n", color.GreenString("ok:"),
         boldString(qName.namespace), boldString(qName.entityName),
         boldString(activation.ActivationID))
-      printJsonNoColor(activation, outputStream)
+      printJSON(activation, outputStream)
     } else {
       fmt.Fprintf(color.Output, "%s invoked /%s/%s with id %s\n", color.GreenString("ok:"),
         boldString(qName.namespace), boldString(qName.entityName),
@@ -269,7 +270,7 @@ var actionGetCmd = &cobra.Command{
       fmt.Fprintf(color.Output, "%s /%s/%s\n", boldString("action"), action.Namespace, action.Name)
     } else {
       fmt.Fprintf(color.Output, "%s got action %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-      printJsonNoColor(action)
+      printJSON(action)
     }
 
     return nil
@@ -692,7 +693,6 @@ func init() {
 
   actionListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "exclude the first `SKIP` number of actions from the result")
   actionListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return `LIMIT` number of actions from the collection")
-  actionListCmd.Flags().BoolVar(&flags.common.full, "full", false, "include full action description")
 
   actionCmd.AddCommand(
     actionCreateCmd,

--- a/tools/go-cli/go-whisk-cli/commands/activation.go
+++ b/tools/go-cli/go-whisk-cli/commands/activation.go
@@ -123,10 +123,10 @@ var activationGetCmd = &cobra.Command{
 
         if flags.common.summary {
             fmt.Printf("activation result for /%s/%s (%s at %s)\n", activation.Namespace, activation.Name, activation.Response.Status, time.Unix(activation.End/1000, 0))
-            printJsonNoColor(activation.Response.Result)
+            printJSON(activation.Response.Result)
         } else {
             fmt.Fprintf(color.Output, "%s got activation %s\n", color.GreenString("ok:"), boldString(id))
-            printJsonNoColor(activation)
+            printJSON(activation)
         }
 
         return nil
@@ -184,7 +184,7 @@ var activationResultCmd = &cobra.Command{
             return werr
         }
 
-        printJsonNoColor(result.Result)
+        printJSON(result.Result)
         return nil
     },
 }
@@ -288,7 +288,7 @@ var activationPollCmd = &cobra.Command{
                     continue
                 } else {
                     fmt.Printf("\nActivation: %s (%s)\n", activation.Name, activation.ActivationID)
-                    printJsonNoColor(activation.Logs)
+                    printJSON(activation.Logs)
                     reported[activation.ActivationID] = true
                 }
             }

--- a/tools/go-cli/go-whisk-cli/commands/flags.go
+++ b/tools/go-cli/go-whisk-cli/commands/flags.go
@@ -89,14 +89,16 @@ var flags struct {
         exit            int
     }
 
-    xPackage struct {
-        serviceGUID string
-    }
-
     // rule
     rule struct {
         enable  bool
         disable bool
+        summary bool
+    }
+
+    // trigger
+    trigger struct {
+        summary bool
     }
 }
 

--- a/tools/go-cli/go-whisk-cli/commands/package.go
+++ b/tools/go-cli/go-whisk-cli/commands/package.go
@@ -366,7 +366,7 @@ var packageGetCmd = &cobra.Command{
       printSummary(xPackage)
     } else {
       fmt.Fprintf(color.Output, "%s got package %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-      printJsonNoColor(xPackage)
+      printJSON(xPackage)
     }
 
     return nil
@@ -466,7 +466,6 @@ var packageListCmd = &cobra.Command{
       Skip:   flags.common.skip,
       Limit:  flags.common.limit,
       Public: shared,
-      Docs:   flags.common.full,
     }
 
     packages, _, err := client.Packages.List(options)
@@ -572,12 +571,10 @@ func init() {
 
   packageCreateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotation values in `KEY VALUE` format")
   packageCreateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameter values in `KEY VALUE` format")
-  packageCreateCmd.Flags().StringVarP(&flags.xPackage.serviceGUID, "service_guid", "s", "", "a unique identifier of the service")
   packageCreateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "package visibility `SCOPE`; yes = shared, no = private")
 
   packageUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotation values in `KEY VALUE` format")
   packageUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameter values in `KEY VALUE` format")
-  packageUpdateCmd.Flags().StringVarP(&flags.xPackage.serviceGUID, "service_guid", "s", "", "a unique identifier of the service")
   packageUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "package visibility `SCOPE`; yes = shared, no = private")
 
   packageGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, "summarize entity details")
@@ -588,7 +585,6 @@ func init() {
   packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", "include publicly shared entities in the result")
   packageListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "exclude the first `SKIP` number of packages from the result")
   packageListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return `LIMIT` number of packages from the collection")
-  packageListCmd.Flags().BoolVar(&flags.common.full, "full", false, "include full package description")
 
   packageCmd.AddCommand(
     packageBindCmd,

--- a/tools/go-cli/go-whisk-cli/commands/rule.go
+++ b/tools/go-cli/go-whisk-cli/commands/rule.go
@@ -349,8 +349,12 @@ var ruleGetCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Fprintf(color.Output, "%s got rule %s\n", color.GreenString("ok:"), boldString(ruleName))
-        printJsonNoColor(rule)
+        if (flags.rule.summary) {
+            fmt.Fprintf(color.Output, "rule /%s/%s\n", rule.Namespace, rule.Name)
+        } else {
+            fmt.Fprintf(color.Output, "%s got rule %s\n", color.GreenString("ok:"), boldString(ruleName))
+            printJSON(rule)
+        }
 
         return nil
     },
@@ -467,6 +471,8 @@ func init() {
     ruleUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "rule visibility `SCOPE`; yes = shared, no = private")
 
     ruleDeleteCmd.Flags().BoolVar(&flags.rule.disable, "disable", false, "automatically disable rule before deleting it")
+
+    ruleGetCmd.Flags().BoolVarP(&flags.rule.summary, "summary", "s", false, "summarize rule details")
 
     ruleListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, "exclude the first `SKIP` number of rules from the result")
     ruleListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, "only return `LIMIT` number of rules from the collection")

--- a/tools/go-cli/go-whisk-cli/commands/trigger.go
+++ b/tools/go-cli/go-whisk-cli/commands/trigger.go
@@ -362,7 +362,7 @@ var triggerUpdateCmd = &cobra.Command{
         }
 
         fmt.Fprintf(color.Output, "%s updated trigger %s\n", color.GreenString("ok:"), boldString(trigger.Name))
-        printJsonNoColor(retTrigger)
+        printJSON(retTrigger)
         return nil
     },
 }
@@ -407,8 +407,13 @@ var triggerGetCmd = &cobra.Command{
             return werr
         }
 
-        fmt.Fprintf(color.Output, "%s got trigger %s\n", color.GreenString("ok:"), boldString(qName.entityName))
-        printJsonNoColor(retTrigger)
+        if (flags.trigger.summary) {
+            fmt.Fprintf(color.Output, "trigger /%s/%s\n", retTrigger.Namespace, retTrigger.Name)
+        } else {
+            fmt.Fprintf(color.Output, "%s got trigger %s\n", color.GreenString("ok:"), boldString(qName.entityName))
+            printJSON(retTrigger)
+        }
+
         return nil
     },
 }
@@ -593,6 +598,8 @@ func init() {
     triggerUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, "annotation values in `KEY VALUE` format")
     triggerUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "default parameter values in `KEY VALUE` format")
     triggerUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", "trigger visibility `SCOPE`; yes = shared, no = private")
+
+    triggerGetCmd.Flags().BoolVarP(&flags.trigger.summary, "summary", "s", false, "summarize trigger details")
 
     triggerFireCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, "parameter values in `KEY VALUE` format")
 

--- a/tools/go-cli/go-whisk-cli/commands/util.go
+++ b/tools/go-cli/go-whisk-cli/commands/util.go
@@ -343,7 +343,7 @@ func printActivationList(activations []whisk.Activation) {
 func printFullActivationList(activations []whisk.Activation) {
     fmt.Fprintf(color.Output, "%s\n", boldString("activations"))
     for _, activation := range activations {
-        printJsonNoColor(activation)
+        printJSON(activation)
     }
 }
 
@@ -438,9 +438,14 @@ func logoText() string {
     return logo
 }
 
-func printJSON(v interface{}) {
+func printJSON(v interface{}, stream ...io.Writer) {
     output, _ := prettyjson.Marshal(v)
-    fmt.Println(string(output))
+
+    if len(stream) > 0 {
+        fmt.Fprintf(stream[0], string(output))
+    } else {
+        fmt.Fprintf(color.Output, string(output))
+    }
 }
 
 // Same as printJSON, but with coloring disabled.

--- a/tools/go-cli/go-whisk/whisk/client.go
+++ b/tools/go-cli/go-whisk/whisk/client.go
@@ -202,7 +202,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
         if req.Body != nil {
             fmt.Println("Req Body")
             fmt.Println(req.Body)
-            Debug(DbgInfo, "Req Body (ASCII quoted string):\n%+q", req.Body)
+            Debug(DbgInfo, "Req Body (ASCII quoted string):\n%+q\n", req.Body)
         }
     }
 
@@ -226,7 +226,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
     }
     Verbose("Response body size is %d bytes\n", len(data))
     Verbose("Response body received:\n%s\n", string(data))
-    Debug(DbgInfo, "Response body received (ASCII quoted string):\n%+q", string(data))
+    Debug(DbgInfo, "Response body received (ASCII quoted string):\n%+q\n", string(data))
 
     // With the HTTP response status code and the HTTP body contents,
     // the possible response scenarios are:

--- a/tools/go-cli/go-whisk/whisk/util.go
+++ b/tools/go-cli/go-whisk/whisk/util.go
@@ -22,6 +22,7 @@ import (
     "net/url"
     "reflect"
 
+    "github.com/fatih/color"
     "github.com/google/go-querystring/query"
     "github.com/hokaccha/go-prettyjson"
 )
@@ -58,5 +59,5 @@ func addRouteOptions(route string, options interface{}) (*url.URL, error) {
 
 func printJSON(v interface{}) {
     output, _ := prettyjson.Marshal(v)
-    fmt.Println(string(output))
+    fmt.Fprintf(color.Output, string(output))
 }


### PR DESCRIPTION
Add colors for entity/JSON dumps to console (related to issue  #947 and PR #949)
Remove `--full` argument from `wsk action list` and `wsk package list`
Remove `--service_guid` argument from `wsk package create|update`
Add `--summary` argument to `wsk rule get` and `wsk trigger get` commands
Add `--summary` test cases