### PR TITLE
Fix logging bits

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     compile 'io.spray:spray-io_2.11:1.3.3'
     compile 'io.spray:spray-routing_2.11:1.3.3'
 
-    compile 'com.typesafe.akka:akka-actor_2.11:2.4.7'
-    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.7'
-    compile 'com.typesafe.akka:akka-http-core_2.11:2.4.7'
-    compile 'com.typesafe.akka:akka-http-spray-json-experimental_2.11:2.4.7'
+    compile 'com.typesafe.akka:akka-actor_2.11:2.4.8'
+    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.8'
+    compile 'com.typesafe.akka:akka-http-core_2.11:2.4.8'
+    compile 'com.typesafe.akka:akka-http-spray-json-experimental_2.11:2.4.8'
 
     compile 'log4j:log4j:1.2.16'
     compile 'commons-codec:commons-codec:1.9'

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -29,18 +29,46 @@ import akka.event.Logging.{ DebugLevel, InfoLevel, WarningLevel, ErrorLevel }
  * A logging facility in which output is one line and fields are bracketed.
  */
 trait Logging extends PrintStreamEmitter {
+    /**
+     * Sets the loglevel for this implementor to log on. See
+     * {@link akka.event.Logging.LogLevel} for details.
+     */
     def setVerbosity(level: LogLevel) = this.level = level
     def getVerbosity() = level
 
+    /**
+     * Prints a message on DEBUG level
+     *
+     * @param from Reference, where the method was called from.
+     * @param message Message to write to the log
+     */
     def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
         if (level >= DebugLevel) emit(DebugLevel, id, from, message)
 
+    /**
+     * Prints a message on INFO level
+     *
+     * @param from Reference, where the method was called from.
+     * @param message Message to write to the log
+     */
     def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
         if (level >= InfoLevel) emit(InfoLevel, id, from, message)
 
+    /**
+     * Prints a message on WARN level
+     *
+     * @param from Reference, where the method was called from.
+     * @param message Message to write to the log
+     */
     def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
         if (level >= WarningLevel) emit(WarningLevel, id, from, message)
 
+    /**
+     * Prints a message on ERROR level
+     *
+     * @param from Reference, where the method was called from.
+     * @param message Message to write to the log
+     */
     def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
         if (level >= ErrorLevel) emit(ErrorLevel, id, from, message)
 
@@ -60,6 +88,15 @@ trait PrintStreamEmitter {
     private var componentName = "";
     def setComponentName(comp: String) = componentName = comp
 
+    /**
+     * Prints a message to the output stream
+     *
+     * @param loglevel The level to log on
+     * @param id <code>TransactionId</code> to include in the log
+     * @param from Reference, where the method was called from.
+     * @param message Message to write to the log
+     * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
+     */
     def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String, marker: Option[LogMarker] = None) = {
         val now = Instant.now(Clock.systemUTC)
         val time = Emitter.timeFormat.format(now)
@@ -119,6 +156,7 @@ case class LogMarkerToken(component: String, action: String, state: String) {
 }
 
 object LoggingMarkers {
+
     val start = "start"
     val finish = "finish"
     val error = "error"

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -85,9 +85,6 @@ trait PrintStreamEmitter {
      */
     var outputStream: PrintStream = Console.out
 
-    private var componentName = "";
-    def setComponentName(comp: String) = componentName = comp
-
     /**
      * Prints a message to the output stream
      *
@@ -102,8 +99,6 @@ trait PrintStreamEmitter {
         val time = Emitter.timeFormat.format(now)
         val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
 
-        val component = Option(componentName).filter(_.trim.nonEmpty).map("[" + _ + "]")
-
         val level = loglevel match {
             case DebugLevel   => "DEBUG"
             case InfoLevel    => "INFO"
@@ -113,7 +108,7 @@ trait PrintStreamEmitter {
 
         val logMessage = Seq(message).filter(_.trim.nonEmpty)
 
-        val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ component ++ Seq(s"[$name]") ++ logMessage ++ marker
+        val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage ++ marker
         outputStream.println(parts.mkString(" "))
     }
 }

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -106,7 +106,10 @@ trait PrintStreamEmitter {
             case ErrorLevel   => "ERROR"
         }
 
-        val logMessage = Seq(message).filter(_.trim.nonEmpty)
+        val logMessage = Seq(message).collect {
+            case msg if msg.nonEmpty =>
+                msg.split('\n').map(_.trim).mkString(" ")
+        }
 
         val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage ++ marker
         outputStream.println(parts.mkString(" "))

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStoreExceptions.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStoreExceptions.scala
@@ -20,3 +20,5 @@ sealed abstract class ArtifactStoreException(message: String) extends Exception(
 case class NoDocumentException(message: String) extends ArtifactStoreException(message)
 
 case class DocumentConflictException(message: String) extends ArtifactStoreException(message)
+
+case class DocumentTypeMismatchException(message: String) extends ArtifactStoreException(message)

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -124,6 +124,10 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](
                     // for compatibility
                     throw NoDocumentException("not found on 'delete'")
 
+                case Left(StatusCodes.Conflict) =>
+                    transid.finished(this, start, s"[DEL] '$dbName', document: '${doc}'; conflict.")
+                    throw DocumentConflictException("conflict on 'delete'")
+
                 case Left(code) =>
                     transid.failed(this, start, s"[DEL] '$dbName' failed to delete document: '${doc}'; http status: '${code}'", ErrorLevel)
                     throw new Exception("Unexpected http response code: " + code)

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -41,6 +41,7 @@ import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
 import spray.http.StatusCodes.Accepted
 import spray.http.StatusCodes.TooManyRequests
+import spray.http.StatusCodes.RequestEntityTooLarge
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import spray.json.DefaultJsonProtocol.StringJsonFormat
@@ -94,6 +95,7 @@ import whisk.core.entity.WhiskEntityQueries
 import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.{ terminate }
 import whisk.common.PrintStreamEmitter
+import org.apache.kafka.common.errors.RecordTooLargeException
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -281,6 +283,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                             case Failure(t: TooManyActivationException) =>
                                 info(this, s"[POST] max activation limit has exceeded")
                                 terminate(TooManyRequests)
+                            case Failure(t: RecordTooLargeException) =>
+                                info(this, s"[POST] action payload was too large")
+                                terminate(RequestEntityTooLarge)
                             case Failure(t: Throwable) =>
                                 error(this, s"[POST] action activation failed: ${t.getMessage}")
                                 terminate(InternalServerError, t.getMessage)

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -71,13 +71,13 @@ protected sealed trait Messages {
 }
 
 /** An exception to throw inside a Predicate future. */
-protected[controller] case class RejectRequest(code: ClientError, message: Option[ErrorResponse]) extends Throwable
+protected[core] case class RejectRequest(code: ClientError, message: Option[ErrorResponse]) extends Throwable
 
-protected[controller] object RejectRequest {
-    protected[controller] def apply(code: ClientError, m: String)(implicit transid: TransactionId): RejectRequest = {
+protected[core] object RejectRequest {
+    protected[core] def apply(code: ClientError, m: String)(implicit transid: TransactionId): RejectRequest = {
         RejectRequest(code, Some(ErrorResponse(m, transid)))
     }
-    protected[controller] def apply(code: ClientError, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
+    protected[core] def apply(code: ClientError, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
         val reason = t.getMessage
         RejectRequest(code, if (reason != null) reason else "Rejected")
     }

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -57,6 +57,7 @@ import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.{ terminate }
 import spray.http.StatusCodes
 import spray.json.JsBoolean
+import whisk.core.database.DocumentTypeMismatchException
 
 protected sealed trait Messages {
     /** Standard message for reporting resource conflicts */
@@ -174,8 +175,8 @@ trait ReadOps extends Directives with Messages with Logging {
             case Failure(t: NoDocumentException) =>
                 info(this, s"[GET] entity does not exist")
                 terminate(NotFound)
-            case Failure(t: IllegalArgumentException) =>
-                error(this, s"[GET] entity conformance check failed: ${t.getMessage}")
+            case Failure(t: DocumentTypeMismatchException) =>
+                info(this, s"[GET] entity conformance check failed: ${t.getMessage}")
                 terminate(Conflict, conformanceMessage)
             case Failure(t: Throwable) =>
                 error(this, s"[GET] entity failed: ${t.getMessage}")
@@ -211,7 +212,7 @@ trait ReadOps extends Directives with Messages with Logging {
             case Failure(t: NoDocumentException) =>
                 info(this, s"[PROJECT] entity does not exist")
                 terminate(NotFound)
-            case Failure(t: IllegalArgumentException) =>
+            case Failure(t: DocumentTypeMismatchException) =>
                 info(this, s"[PROJECT] entity conformance check failed: ${t.getMessage}")
                 terminate(Conflict, conformanceMessage)
             case Failure(t: Throwable) =>
@@ -299,7 +300,7 @@ trait WriteOps extends Directives with Messages with Logging {
             case Failure(RejectRequest(code, message)) =>
                 info(this, s"[PUT] entity rejected with code $code: $message")
                 terminate(code, message)
-            case Failure(t: IllegalArgumentException) =>
+            case Failure(t: DocumentTypeMismatchException) =>
                 info(this, s"[PUT] entity conformance check failed: ${t.getMessage}")
                 terminate(Conflict, conformanceMessage)
             case Failure(t: Throwable) =>
@@ -355,7 +356,7 @@ trait WriteOps extends Directives with Messages with Logging {
             case Failure(RejectRequest(code, message)) =>
                 info(this, s"[DEL] entity rejected with code $code: $message")
                 terminate(code, message)
-            case Failure(t: IllegalArgumentException) =>
+            case Failure(t: DocumentTypeMismatchException) =>
                 info(this, s"[DEL] entity conformance check failed: ${t.getMessage}")
                 terminate(Conflict, conformanceMessage)
             case Failure(t: Throwable) =>

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -85,8 +85,8 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         next: () => RequestContext => Unit)(
             implicit transid: TransactionId): RequestContext => Unit = {
         onComplete(entitlementService.check(user, right, resource)) {
-            case Success(entitment) =>
-                authorize(entitment) {
+            case Success(entitlement) =>
+                authorize(entitlement) {
                     next()
                 }
             case Failure(r: RejectRequest) =>

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -113,6 +113,9 @@ trait WhiskCollectionAPI
                         case Success(excludePrivate) =>
                             info(this, s"[LIST] exclude private entities: required == $excludePrivate")
                             list(resource.namespace, excludePrivate)
+                        case Failure(r: RejectRequest) =>
+                            info(this, s"[LIST] namespaces lookup failed: ${r.message}")
+                            terminate(r.code, r.message)
                         case Failure(t) =>
                             error(this, s"[LIST] namespaces lookup failed: ${t.getMessage}")
                             terminate(InternalServerError, t.getMessage)

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -122,6 +122,7 @@ trait WhiskNamespacesApi
      *
      * Responses are one of (Code, Message)
      * - 200 [ Namespaces (as String) ] as JSON
+     * - 401 Unauthorized
      * - 500 Internal Server Error
      */
     private def getNamespaces(user: Subject)(implicit transid: TransactionId) = {
@@ -129,6 +130,9 @@ trait WhiskNamespacesApi
             case Success(namespaces) =>
                 info(this, s"[GET] namespaces success: $namespaces")
                 complete(OK, namespaces)
+            case Failure(r: RejectRequest) =>
+                info(this, s"[GET] namespaces failed: ${r.message}")
+                terminate(r.code, r.message)
             case Failure(t) =>
                 error(this, s"[GET] namespaces failed: ${t.getMessage}")
                 terminate(InternalServerError, t.getMessage)

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -27,6 +27,7 @@ import spray.http.StatusCodes.BadRequest
 import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.InternalServerError
 import spray.http.StatusCodes.OK
+import spray.http.StatusCodes.NotFound
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
@@ -169,6 +170,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                             case IgnoredRuleActivation(ok) =>
                                 info(this, s"[POST] rule update ignored")
                                 if (ok) complete(OK) else terminate(Conflict)
+                            case _: NoDocumentException =>
+                                info(this, s"[POST] the trigger attached to the rule doesn't exist")
+                                terminate(NotFound, "Only rules with existing triggers can be activated")
                             case _: Throwable =>
                                 error(this, s"[POST] rule update failed: ${t.getMessage}")
                                 terminate(InternalServerError, t.getMessage)

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -43,6 +43,7 @@ import whisk.core.entity.Parameters
 import whisk.core.entity.Subject
 import whisk.http.ErrorResponse
 import akka.event.Logging.LogLevel
+import whisk.core.controller.RejectRequest
 
 package object types {
     type Entitlements = TrieMap[(Subject, String), Set[Privilege]]
@@ -194,6 +195,8 @@ protected[core] abstract class EntitlementService(config: WhiskConfig)(
                 case Success(r) =>
                     info(this, if (r) "authorized" else "not authorized")
                     promise success r
+                case Failure(r: RejectRequest) =>
+                    promise failure r
                 case Failure(t) =>
                     error(this, s"failed while checking entitlement: ${t.getMessage}")
                     promise success false

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -31,6 +31,7 @@ import whisk.core.entity.types.EntityStore
 import scala.concurrent.Promise
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.EntityName
+import whisk.core.database.NoDocumentException
 
 class PackageCollection(entityStore: EntityStore) extends Collection(Collection.PACKAGES) {
 
@@ -107,6 +108,9 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                     promise.success(false)
                 }
         } onFailure {
+            case t: NoDocumentException =>
+                info(this, s"the package does not exist")
+                promise.success(false)
             case t =>
                 error(this, s"entitlement check on package failed: ${t.getMessage}")
                 promise.success(false)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -59,7 +59,6 @@ class InvokerHealth(
 
     private implicit val executionContext = system.dispatcher
 
-    setComponentName("LoadBalancer");
     setVerbosity(InfoLevel);
 
     private val activationCountBeforeNextInvoker = 10

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -67,6 +67,7 @@ import whisk.core.entity.SequenceExec
 import whisk.core.entity.Pipecode
 import whisk.core.entity.NodeJSExec
 import akka.event.Logging.InfoLevel
+import whisk.core.entity.WhiskTrigger
 
 /**
  * Tests Actions API.
@@ -188,6 +189,15 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         implicit val tid = transid()
         Get(s"$collectionPath/xyz") ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
+        }
+    }
+
+    it should "report Conflict if the name was of a different type" in {
+        implicit val tid = transid()
+        val trigger = WhiskTrigger(namespace, aname)
+        put(entityStore, trigger)
+        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(Conflict)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -572,6 +572,18 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         }
     }
 
+    it should "reject rule activation, if the trigger is absent" in {
+        implicit val tid = transid()
+        val ruleName = aname
+        val ruleNameQualified = Namespace(WhiskEntity.qualifiedName(namespace, ruleName))
+        val triggerName = aname
+        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+        put(entityStore, rule)
+        Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
+            status should be(NotFound)
+        }
+    }
+
     it should "deactivate rule" in {
         implicit val tid = transid()
         val ruleName = aname

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -173,6 +173,15 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         }
     }
 
+    it should "report Conflict if the name was of a different type" in {
+        implicit val tid = transid()
+        val trigger = WhiskTrigger(namespace, aname)
+        put(entityStore, trigger)
+        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(Conflict)
+        }
+    }
+
     // DEL /rules/name
     it should "reject delete rule in state active" in {
         implicit val tid = transid()

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import spray.http.StatusCodes.BadRequest
+import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
 import spray.http.StatusCodes.RequestEntityTooLarge
@@ -50,6 +51,7 @@ import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.WhiskTriggerPut
 import whisk.core.entity.ReducedRule
 import whisk.core.entity.test.OldWhiskTrigger
+import whisk.core.entity.WhiskRule
 
 /**
  * Tests Trigger API.
@@ -117,6 +119,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
             status should be(OK)
             val response = responseAs[WhiskTrigger]
             response should be(trigger.withoutRules)
+        }
+    }
+
+    it should "report Conflict if the name was of a different type" in {
+        implicit val tid = transid()
+        val rule = WhiskRule(namespace, aname, aname, aname)
+        put(entityStore, rule)
+        Get(s"/$namespace/${collection.path}/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(Conflict)
         }
     }
 


### PR DESCRIPTION
- Adding documentation for Logging trait
- Removing unnecessary part of the log
- Getting rid of newlines in log messages
- Updating akka to get rid of an unnecessary log message on stdout
- Fix Package error message
- Surface proper message when rule update failed due to trigger absence
- Adding new exception type, fixing entity conformance logs
- Report invoke being too big properly, needs to be short-circuited
- Refactoring remote entitlement service
   - more dense code
   - adjust log levels related to entitlement
   - surface errors reported by the remote entitlement service
- Fix loglevel of conflicts on delete
- Fix loglevel for trigger fire iff action was deleted

Fixes #1045 
Fixes #1044

Every commit fixes exactly one thing for easier reviewability.