### PR TITLE
Only Accept Key/Value Pairs for Parameters and Annotations

### DIFF
--- a/tools/go-cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/go-cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1062,5 +1062,17 @@
   {
     "id": "start polling for activations `DAYS` days ago",
     "translation": "start polling for activations `DAYS` days ago"
+  },
+  {
+    "id": "Arguments for '{{.arg}}' must be a key/value pair",
+    "translation": "Arguments for '{{.arg}}' must be a key/value pair"
+  },
+  {
+    "id": "The parameter arguments are invalid: {{.err}}",
+    "translation": "The parameter arguments are invalid: {{.err}}"
+  },
+  {
+    "id": "The annotation arguments are invalid: {{.err}}",
+    "translation": "The annotation arguments are invalid: {{.err}}"
   }
 ]


### PR DESCRIPTION
- Update argument parsing so that an error occurs if a key/value pair is not passed to -p or -a