### PR TITLE
Refactor InvokerHealth to minimize KV store usage

### DIFF
--- a/common/scala/src/main/scala/whisk/common/ConsulClient.scala
+++ b/common/scala/src/main/scala/whisk/common/ConsulClient.scala
@@ -32,7 +32,6 @@ import java.util.NoSuchElementException
 import akka.stream.scaladsl._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import scala.util.Try
 
 /**
  * Client to access Consul's <a href="https://www.consul.io/docs/agent/http.html">
@@ -272,17 +271,6 @@ object ConsulKV {
         def instancePath(instance: Int) = s"${allInvokers}/${invokerKeyPrefix}${instance}"
         def instanceDataPath(instance: Int) = s"${allInvokersData}/${invokerKeyPrefix}${instance}"
 
-        // Invokers store the hostname they are running on here.
-        def hostname(instance: Int) = s"${instancePath(instance)}/hostname"
-
-        // Invokers store when they start here.
-        val startKey = "start"
-        def start(instance: Int) = s"${instancePath(instance)}/$startKey"
-
-        // Invokers store how many activations they have processed here.
-        val activationCountKey = "activationCount"
-        def activationCount(instance: Int) = s"${instancePath(instance)}/$activationCountKey"
-
         // Invokers store how many activations they have processed per user here.
         private val userActivationCountKey = "userActivationCount"
         def userActivationCount(instance: Int) = s"${instanceDataPath(instance)}/${userActivationCountKey}"
@@ -293,30 +281,12 @@ object ConsulKV {
 
         // Extract index from just the element of the path such as "invoker5"
         def extractInvokerIndex(key: String): Int = key.substring(invokerKeyPrefix.length).toInt
-
-        // Get the invoker index given a key somewhere in that invoker's KV sub-hierarchy
-        def getInvokerIndexFromAny(key: String): Option[Int] = {
-            val prefix = s"${allInvokers}/${invokerKeyPrefix}"
-            if (key.startsWith(prefix)) {
-                val middle = key.substring(prefix.length)
-                val slashIndex = middle.indexOf("/")
-                if (slashIndex > 0) {
-                    Try { middle.substring(0, slashIndex).toInt }.toOption
-                } else None
-            } else None
-        }
-
     }
 
     // All load balancer written information under here.
     object LoadBalancerKeys {
         val component = "loadBalancer"
-        val hostnameKey = s"${component}/hostname"
-        val startKey = s"${component}/start"
         val statusKey = s"${component}/status"
-        val activationCountKey = s"${component}/activationCount"
-        val overloadKey = s"${component}/overload"
-        val invokerHealth = s"${component}/invokerHealth"
         val userActivationCountKey = s"${component}/userActivationCount"
     }
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -37,7 +37,7 @@ import whisk.core.entity.Subject
  *
  * @param config containing the config information needed (consulServer)
  */
-class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
+class ActivationThrottler(consulServer: String, concurrencyLimit: Int, overloadLimit: Int)(
     implicit val system: ActorSystem) extends Logging {
 
     implicit private val executionContext = system.dispatcher
@@ -56,6 +56,11 @@ class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
      * Checks whether the operation should be allowed to proceed.
      */
     def check(subject: Subject): Boolean = userActivationCounter.getOrElse(subject(), 0L) < concurrencyLimit
+
+    /**
+     * Checks whether the system is overloaded
+     */
+    def isOverloaded: Boolean = userActivationCounter.values.sum > overloadLimit
 
     /**
      * Returns the per-namespace activation count as seen by the loadbalancer

--- a/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -35,7 +35,6 @@ import akka.actor.ActorSystem
 import akka.actor.actorRef2Scala
 import akka.japi.Creator
 import spray.json.DefaultJsonProtocol
-import spray.json.DefaultJsonProtocol.IntJsonFormat
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.JsArray
 import spray.json.JsNumber
@@ -537,13 +536,9 @@ class Invoker(
      */
     private val kv = new ConsulClient(config.consulServer)
     private val reporter = new ConsulKVReporter(kv, 3 seconds, 2 seconds,
-        InvokerKeys.hostname(instance),
-        InvokerKeys.start(instance),
         InvokerKeys.status(instance),
-        { index =>
-            (if (index % 5 == 0) getUserActivationCounts() else Map[String, JsValue]()) ++
-                Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson)
-        })
+        { index => (if (index % 5 == 0) getUserActivationCounts() else Map.empty[String, JsValue]) }
+    )
 
     // This is used for the getContainer endpoint used in perfContainer testing it is not real state
     private val activationIdMap = new TrieMap[ActivationId, String]


### PR DESCRIPTION
First round of minimizing Consul KV Store usage:

- removes unneeded fields in the KV store
- system overload status is read from activation throttler
- general refactoring of InvokerHealth