### PR TITLE
update slack.post to support token-based auth

### DIFF
--- a/catalog/installSlack.sh
+++ b/catalog/installSlack.sh
@@ -12,15 +12,16 @@ source "$CATALOG_HOME/util.sh"
 echo Installing Slack package.
 
 createPackage slack \
-    -a description "Package which contains actions to interact with the Slack messaging service"
+    -a description "This package interacts with the Slack messaging service" \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your Slack username"}, {"name":"url", "required":true, "bindTime":true, "description": "Your webhook URL", "doclink": "https://api.slack.com/incoming-webhooks"},{"name":"channel", "required":true, "bindTime":true, "description": "The name of a Slack channel"}, {"name": "token", "description": "Your Slack oauth token", "doclink": "https://api.slack.com/docs/oauth"} ]'
 
 waitForAll
 
 install "$CATALOG_HOME/slack/post.js" \
     slack/post \
-    -a description 'Posts a message to Slack' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"text", "required":true}, {"name":"url", "required":true, "bindTime":true},{"name":"channel", "required":true, "bindTime":true} ]' \
-    -a sampleInput '{"username":"whisk", "text":"Hello whisk!", "channel":"myChannel", "url": "https://hooks.slack.com/services/XYZ/ABCDEFG/12345678"}'
+    -a description 'Post a message to Slack' \
+    -a parameters '[ {"name":"text", "required":true, "description": "The message you wish to post"} ]' \
+    -a sampleInput '{"username":"openwhisk", "text":"Hello OpenWhisk!", "channel":"myChannel", "url": "https://hooks.slack.com/services/XYZ/ABCDEFG/12345678"}'
 
 waitForAll
 

--- a/catalog/slack/post.js
+++ b/catalog/slack/post.js
@@ -14,9 +14,32 @@ function main(params) {
   var body = {
     channel: params.channel,
     username: params.username || 'Simple Message Bot',
-    text: params.text,
-    icon_emoji: params.icon_emoji
+    text: params.text
   };
+
+  if (params.icon_emoji) {
+    // guard against sending icon_emoji: undefined
+    body.icon_emoji = params.icon_emoji;
+  }
+
+  if (params.token) {
+    //
+    // this allows us to support /api/chat.postMessage
+    // e.g. users can pass params.url = https://slack.com/api/chat.postMessage
+    //                 and params.token = <their auth token>
+    //
+    body.token = params.token;
+  } else {
+    //
+    // the webhook api expects a nested payload
+    //
+    // notice that we need to stringify; this is due to limitations
+    // of the formData npm: it does not handle nested objects
+    //
+    body = {
+      payload: JSON.stringify(body)
+    };
+  }
 
   if (params.attachments) {
     body.attachments = params.attachments;
@@ -27,9 +50,7 @@ function main(params) {
 
   request.post({
     url: params.url,
-    formData: {
-      payload: JSON.stringify(body)
-    }
+    formData: body
   }, function(err, res, body) {
     if (err) {
       console.log('error: ', err, body);

--- a/catalog/slack/post.js
+++ b/catalog/slack/post.js
@@ -36,6 +36,9 @@ function main(params) {
     // notice that we need to stringify; this is due to limitations
     // of the formData npm: it does not handle nested objects
     //
+    console.log(body);
+    console.log("to: " + params.url);
+
     body = {
       payload: JSON.stringify(body)
     };
@@ -44,9 +47,6 @@ function main(params) {
   if (params.attachments) {
     body.attachments = params.attachments;
   }
-
-  console.log(body);
-  console.log("to: " + params.url);
 
   request.post({
     url: params.url,

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -474,6 +474,7 @@ The `/whisk.system/slack/post` action posts a message to a specified Slack chann
 - `channel`: The Slack channel to post the message to.
 - `username`: The name to post the message as.
 - `text`: A message to post.
+- `token`: (optional) A Slack [access token](https://api.slack.com/tokens). See [below](#slack-token-based-api) for more detail on the use of the Slack access tokens.
 
 The following is an example of configuring Slack, creating a package binding, and posting a message to a channel.
 
@@ -493,7 +494,7 @@ The following is an example of configuring Slack, creating a package binding, an
   $ wsk action invoke mySlack/post --blocking --result --param text 'Hello from OpenWhisk!'
   ```
 
-### Using the Slack token-based API
+### <a name="slack-token-based-api"></a>Using the Slack token-based API
 
 If you prefer, you may optionally choose to use Slack's token-based API, rather than the webhook API. If you so choose, then pass in a `token` parameter that contains your Slack [access token](https://api.slack.com/tokens). You may then use any of the [Slack API methods](https://api.slack.com/methods) as your `url` parameter. For example, to post a message, you would use a `url` parameter value of [slack.postMessage](https://api.slack.com/methods/chat.postMessage).
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -493,6 +493,9 @@ The following is an example of configuring Slack, creating a package binding, an
   $ wsk action invoke mySlack/post --blocking --result --param text 'Hello from OpenWhisk!'
   ```
 
+### Using the Slack token-based API
+
+If you prefer, you may optionally choose to use Slack's token-based API, rather than the webhook API. If you so choose, then pass in a `token` parameter that contains your Slack [access token](https://api.slack.com/tokens). You may then use any of the [Slack API methods](https://api.slack.com/methods) as your `url` parameter. For example, to post a message, you would use a `url` parameter value of [slack.postMessage](https://api.slack.com/methods/chat.postMessage).
 
 ## Using the GitHub package
 

--- a/tests/src/packages/SlackTests.java
+++ b/tests/src/packages/SlackTests.java
@@ -52,12 +52,10 @@ public class SlackTests {
     String expectedChannel = "channel: '" + channel + "'";
     String expectedUsername = "username: '" + username + "'";
     String expectedText = "text: '" + text + "'";
-    String expectedIcon = "icon_emoji: undefined";
 
     assertTrue("Expected message not found: " + expectedChannel, wsk.logsForActivationContain(activationId, expectedChannel, DEFAULT_WAIT));
     assertTrue("Expected message not found: " + expectedUsername, wsk.logsForActivationContain(activationId, expectedUsername, DEFAULT_WAIT));
     assertTrue("Expected message not found: " + expectedText, wsk.logsForActivationContain(activationId, expectedText, DEFAULT_WAIT));
-    assertTrue("Expected message not found: " + expectedIcon, wsk.logsForActivationContain(activationId, expectedIcon, DEFAULT_WAIT));
     assertTrue("Expected message not found: " + url, wsk.logsForActivationContain(activationId, url, DEFAULT_WAIT));
   }
 


### PR DESCRIPTION
This PR updates slack.post to support slack's oauth token style of authentication. If `params.token` is defined, the post assumes it is using token style authentication.

The only minor complexity here lies in the format of the body that slack expects, combined with some limitations of the formData npm that the request npm uses. The (preexisting) webhook-style API expects the formData to have the form `{ payload: body }`, whereas the slack API expects it to be of the form `body`, i.e. no payload wrapper. On top of this, the formData npm cannot tolerate nested objects -- this is why the slack.post code has always called `JSON.stringify` on the body. This is not needed (and causes harm) for the slack API-style of invocation.

Next, I removed the icon_emoji from the body if it is not defined by params. formData also barfs on `undefined`. This required updating the test to remove the expectation of seeing icon_emoji in the output.

The last change to the post.js code: I pulled the `console.log` calls so that they'd only execute in the webhook code path, in order to avoid leaking an unredacted auth token to the logs.

I also updated the docs/catalog.md to describe the new token-based auth support.

Finally, I updated installSlack  to add description and doclink fields. Here, I hoisted the bindTime parameters from the action annotation to the level of a package annotation. This has been a long-standing issue with the slack metadata that forced the Bluemix UI code to have some hacks: i.e. when prompting the user for a package binding, we had to hackishly look at the action annotations, even though the user had requested to make a package binding -- an operation independent of any action.


closes #1091 
PG1 229 [clean]