### PR TITLE
add field level descriptions and doclink to github webhook (closes 1102)

### DIFF
--- a/catalog/installGit.sh
+++ b/catalog/installGit.sh
@@ -20,7 +20,7 @@ install "$CATALOG_HOME/github/webhook.js" \
     github/webhook \
     -a feed true \
     -a description 'Creates a webhook on GitHub to be notified on selected changes' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username or organization"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
     -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
 
 waitForAll

--- a/catalog/installGit.sh
+++ b/catalog/installGit.sh
@@ -20,7 +20,7 @@ install "$CATALOG_HOME/github/webhook.js" \
     github/webhook \
     -a feed true \
     -a description 'Creates a webhook on GitHub to be notified on selected changes' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username or organization"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
     -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
 
 waitForAll

--- a/catalog/installGit.sh
+++ b/catalog/installGit.sh
@@ -19,8 +19,8 @@ waitForAll
 install "$CATALOG_HOME/github/webhook.js" \
     github/webhook \
     -a feed true \
-    -a description 'Creates a webhook on github to be notified on selected changes' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true}, {"name":"repository", "required":true, "bindTime":true}, {"name":"accessToken", "required":true, "bindTime":true},{"name":"events", "required":true} ]' \
+    -a description 'Creates a webhook on GitHub to be notified on selected changes' \
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
     -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
 
 waitForAll

--- a/catalog/installGit.sh
+++ b/catalog/installGit.sh
@@ -20,8 +20,8 @@ install "$CATALOG_HOME/github/webhook.js" \
     github/webhook \
     -a feed true \
     -a description 'Creates a webhook on GitHub to be notified on selected changes' \
-    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of your GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "doclink": "https://developer.github.com/webhooks/#events"} ]' \
-    -a sampleInput '{"username":"whisk", "repository":"WhiskRepository", "accessToken":"123ABCXYZ", "events": "push,commit,delete"}'
+    -a parameters '[ {"name":"username", "required":true, "bindTime":true, "description": "Your GitHub username"}, {"name":"repository", "required":true, "bindTime":true, "description": "The name of a GitHub repository"}, {"name":"accessToken", "required":true, "bindTime":true, "description": "A webhook or personal token", "doclink": "https://github.com/settings/tokens/new"},{"name":"events", "required":true, "description": "A comma-separated list", "doclink": "https://developer.github.com/webhooks/#events"} ]' \
+    -a sampleInput '{"username":"myUserName", "repository":"myRepository or myOrganization/myRepository", "accessToken":"123ABCXYZ", "events": "push,delete,pull-request"}'
 
 waitForAll
 


### PR DESCRIPTION
This PR does the following:
1) fixes the main description to render the provider name more accurately as "GitHub", rather than the previous "github"
2) adds field-level descriptions to web hook
3) adds a `doclink` attribute to the accessToken and events fields

closes #1102
PG1 243 [clean]