### PR TITLE
Move to Go 1.7 to Reduce CLI  Executable Size by ~21%

### DIFF
--- a/tools/cli/Dockerfile
+++ b/tools/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 
 # Install zip
 RUN apt-get -y update && \


### PR DESCRIPTION
- Using the latest version of Go reduces the CLI file size by ~21%
- Ex: Mac executable size is reduced from 10.8MB to 8.5MB