### PR TITLE
Controller publishes digested user activation concurrency

### DIFF
--- a/common/scala/src/main/scala/whisk/common/ConsulClient.scala
+++ b/common/scala/src/main/scala/whisk/common/ConsulClient.scala
@@ -308,6 +308,12 @@ object ConsulKV {
 
     }
 
+    // All keys for information written from the controller are here.
+    object ControllerKeys {
+        val component = "controller"
+        val userActivationCountKey = s"${component}/userActivationCount"
+    }
+
     // All load balancer written information under here.
     object LoadBalancerKeys {
         val component = "loadBalancer"


### PR DESCRIPTION
This PR causes the controller to publish its notion of activation concurrency level per user.