### PR TITLE
Add log helpers and assertions on logs and database dumps

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,6 +1,7 @@
 mode: deploy
 prompt_user: true
 openwhisk_home: "{{ lookup('env', 'OPENWHISK_HOME')|default(playbook_dir + '/..', true) }}"
+exclude_logs_from: []
 
 whisk:
   version:

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -1,0 +1,37 @@
+---
+# This playbook is used for utilities around logs
+
+- include: properties.yml
+
+- hosts: ansible
+  tasks:
+    - name: remove "logs" folder
+      file: path="{{ openwhisk_home }}/logs" state=absent
+    - name: create "logs" folder
+      file: path="{{ openwhisk_home }}/logs" state=directory
+    - name: dump databases
+      local_action: shell "{{ openwhisk_home }}/bin/wskadmin" db get whisks --docs --view whisks/{{ item }} > "{{ openwhisk_home }}/logs/db-{{ item }}.log"
+      with_items:
+        - activations
+        - actions
+        - triggers
+        - rules
+        - packages
+      when: "'db' not in exclude_logs_from"
+
+- hosts: shared,core,invokers
+  tasks:
+  - name: get all docker containers
+    local_action: shell docker --host tcp://{{inventory_hostname}}:{{docker.port}} ps -a --format="{% raw %}{{.Names}}{% endraw %}"
+    register: container_names
+  - name: get logs from all containers
+    local_action: shell docker --host tcp://{{inventory_hostname}}:{{docker.port}} logs {{ item }} > "{{ openwhisk_home }}/logs/{{ item }}.log"; exit 0
+    with_items: "{{ container_names.stdout_lines | difference('whisk_docker_registry') }}"
+    when: "'docker' not in exclude_logs_from"
+  - name: workaround to make synchronize work
+    set_fact:
+      ansible_ssh_private_key_file: "{{ ansible_ssh_private_key_file }}"
+    when: ansible_ssh_private_key_file is defined
+  - name: fetch logs from all machines
+    synchronize: src="{{ whisk_logs_dir }}/" dest="{{ openwhisk_home }}/logs" mode=pull
+    when: "'machine' not in exclude_logs_from"

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -10,7 +10,7 @@
     - name: create "logs" folder
       file: path="{{ openwhisk_home }}/logs" state=directory
     - name: dump databases
-      local_action: shell "{{ openwhisk_home }}/bin/wskadmin" db get whisks --docs --view whisks/{{ item }} > "{{ openwhisk_home }}/logs/db-{{ item }}.log"
+      local_action: shell "{{ openwhisk_home }}/bin/wskadmin" db get whisks --docs --view whisks/{{ item }} | tail -n +2 > "{{ openwhisk_home }}/logs/db-{{ item }}.log"
       with_items:
         - activations
         - actions

--- a/tools/build/checkLogs.py
+++ b/tools/build/checkLogs.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# CI/CD tool to assert that logs and databases are in certain bounds
+##
+
+import collections
+import fnmatch
+import itertools
+import os
+import platform
+import sys
+import json
+from functools import partial
+
+def file_has_at_most_x_bytes(x, file):
+    size = os.path.getsize(file)
+    if(size > x):
+        return [ (0, "file has %d bytes, expected %d bytes" % (size, x)) ]
+    else:
+        return [ ]
+
+# Checks that the database dump contains at most x entries
+def database_has_at_most_x_entries(x, file):
+    with open(file) as db_file:
+        data = json.load(db_file)
+        entries = len(data['rows'])
+        if(entries > x):
+            return [ (0, "found %d database entries, expected %d entries" % (entries, x)) ]
+        else:
+            return [ ]
+
+# Runs a series of file-by-file checks.
+def run_file_checks(file_path, checks):
+    errors = []
+
+    for check in checks:
+        errs = check(file_path)
+        if errs:
+            errors += errs
+
+    return errors
+
+# Helpers, rather than non-standard modules.
+def colors():
+    ansi = hasattr(sys.stderr, "isatty") and platform.system() != "Windows"
+
+    def colorize(code, string):
+        return "%s%s%s" % (code, string, '\033[0m') if ansi else string
+
+    blue  = lambda s: colorize('\033[94m', s)
+    green = lambda s: colorize('\033[92m', s)
+    red   = lambda s: colorize('\033[91m', s)
+
+    return collections.namedtuple("Colorizer", "blue green red")(blue, green, red)
+
+# Script entrypoint.
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stderr.write("Usage: %s logs_directory.\n" % sys.argv[0])
+        sys.exit(1)
+
+    root_dir = sys.argv[1]
+
+    col = colors()
+
+    if not os.path.isdir(root_dir):
+        sys.stderr.write("%s: %s is not a directory.\n" % (sys.argv[0], root_dir))
+
+    file_checks = [
+        ("db-rules.log", [ partial(database_has_at_most_x_entries, 0) ]),
+        ("db-triggers.log", [ partial(database_has_at_most_x_entries, 0) ]),
+        # Assert that stdout of the container is correctly piped and empty
+        ("controller.log", [ partial(file_has_at_most_x_bytes, 0) ]),
+        ("invoker0.log", [ partial(file_has_at_most_x_bytes, 0) ])
+    ]
+
+    all_errors = []
+
+    # Runs all relevant checks on all relevant files.
+    for file_name, checks in file_checks:
+        file_path = root_dir + "/" + file_name
+        errors = run_file_checks(file_path, checks)
+        all_errors += map(lambda p: (file_path, p[0], p[1]), errors)
+
+    sort_key = lambda p: p[0]
+
+    if all_errors:
+        files_with_errors = 0
+        for path, triples in itertools.groupby(sorted(all_errors, key=sort_key), key=sort_key):
+            files_with_errors += 1
+            sys.stderr.write("%s:\n" % col.blue(path))
+
+            pairs = sorted(map(lambda t: (t[1],t[2]), triples), key=lambda p: p[0])
+            for line, msg in pairs:
+                sys.stderr.write("    %4d: %s\n" % (line, msg))
+
+        # There's no reason not to pluralize properly.
+        if len(all_errors) == 1:
+            message = "There was an error."
+        else:
+            if files_with_errors == 1:
+                message = "There were %d errors in a file." % len(all_errors)
+            else:
+                message = "There were %d errors in %d files." % (len(all_errors), files_with_errors)
+
+        sys.stderr.write(col.red(message) + "\n")
+        sys.exit(1)
+    else:
+        print col.green("All checks passed.")
+        sys.exit(0)

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -31,3 +31,9 @@ $ANSIBLE_CMD postdeploy.yml
 cd $ROOTDIR
 cat whisk.properties
 ./gradlew :tests:test
+
+cd $ROOTDIR/ansible
+$ANSIBLE_CMD logs.yml
+
+cd $ROOTDIR
+tools/build/checkLogs.py logs


### PR DESCRIPTION
- Add playbook to collect logs and database dumps to a central location
- add `checkLogs.py` script to exercise checks on the logs and database dumps after tests have run, to assert there are no leaks.