### PR TITLE
Change response code for non-existent package to not found from not allowed

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -49,7 +49,7 @@ import spray.json.JsBoolean
 import whisk.core.database.DocumentTypeMismatchException
 
 protected sealed trait Messages {
-    /** Standard message for reporting resource conflicts */
+    /** Standard message for reporting resource conflicts. */
     protected val conflictMessage = "Concurrent modification to resource detected"
 
     /**
@@ -63,9 +63,17 @@ protected sealed trait Messages {
 protected[core] case class RejectRequest(code: ClientError, message: Option[ErrorResponse]) extends Throwable
 
 protected[core] object RejectRequest {
+    /** Creates rejection with default message for status code. */
+    protected[core] def apply(code: ClientError)(implicit transid: TransactionId): RejectRequest = {
+        RejectRequest(code, Some(ErrorResponse.response(code)(transid)))
+    }
+
+    /** Creates rejection with custom message for status code. */
     protected[core] def apply(code: ClientError, m: String)(implicit transid: TransactionId): RejectRequest = {
         RejectRequest(code, Some(ErrorResponse(m, transid)))
     }
+
+    /** Creates rejection with custom message for status code derived from reason for throwable. */
     protected[core] def apply(code: ClientError, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
         val reason = t.getMessage
         RejectRequest(code, if (reason != null) reason else "Rejected")

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -34,10 +34,9 @@ import common.TestUtils.DONTCARE_EXIT
 import common.TestUtils.BAD_REQUEST
 import common.TestUtils.ERROR_EXIT
 import common.TestUtils.MISUSE_EXIT
+import common.TestUtils.NOT_FOUND
 import common.TestUtils.NOTALLOWED
 import common.TestUtils.SUCCESS_EXIT
-import common.TestUtils.FORBIDDEN
-import common.TestUtils.NOT_FOUND
 import common.WhiskProperties
 import common.Wsk
 import common.WskProps
@@ -647,7 +646,7 @@ class WskBasicCliUsageTests
                     trigger.get(name, expectedExitCode = NOT_FOUND)
 
                     trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).
-                        exitCode should { equal(FORBIDDEN) or equal(NOT_FOUND) } // response differs in the presence of entitlement service
+                        exitCode should equal(NOT_FOUND)
                     trigger.get(name, expectedExitCode = NOT_FOUND)
             }
     }

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -326,7 +326,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
         put(entityStore, action)
         Get(s"$collectionPath/${provider.name}/${action.name}") ~> sealRoute(routes(creds)) ~> check {
-            status should be(Forbidden) // do not leak that package does not exist
+            status should be(NotFound)
         }
     }
 
@@ -350,7 +350,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, provider)
         put(entityStore, action)
         Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
-            status should be(Forbidden) // do not leak that binding does not exist
+            status should be(NotFound)
         }
     }
 
@@ -485,7 +485,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val content = JsObject("xxx" -> "yyy".toJson)
         put(entityStore, action)
         Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(Forbidden) // do not leak that package does not exist
+            status should be(NotFound)
         }
     }
 
@@ -496,7 +496,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val content = JsObject("xxx" -> "yyy".toJson)
         put(entityStore, action)
         Post(s"$collectionPath/${provider.name}/${action.name}", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(Forbidden) // do not leak that package does not exist
+            status should be(NotFound)
         }
     }
 


### PR DESCRIPTION
The entitlement check for packages failed client requests with not authorized responses
when checking a package that does not exist. This served to neither confirm or deny the
existence of the package --- but has been confusing. Changed the response to not found should
the package in fact not exist. This removes an inconsistency as well between the local and
remote entitlement flows.

PG2-20 approved.