### PR TITLE
Rebase action proxy (dockerskeleton) on alpine image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ node_modules
 ansible/environments/mac/hosts
 ansible/db_local.ini*
 ansible/tmp/*
+
+# Action proxies copied during build
+core/swiftAction/actionproxy.py
+core/swift3Action/actionproxy.py

--- a/.project
+++ b/.project
@@ -16,7 +16,7 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1470885991026</id>
+			<id>1472286169084</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
@@ -46,11 +46,19 @@
 						<id>org.eclipse.ui.ide.multiFilter</id>
 						<arguments>1.0-projectRelativePath-matches-false-false-bin</arguments>
 					</matcher>
+					<matcher>
+						<id>org.eclipse.ui.ide.multiFilter</id>
+						<arguments>1.0-projectRelativePath-matches-false-true-core/swiftAction/actionproxy.py</arguments>
+					</matcher>
+					<matcher>
+						<id>org.eclipse.ui.ide.multiFilter</id>
+						<arguments>1.0-projectRelativePath-matches-false-false-core/swift3Action/actionproxy.py</arguments>
+					</matcher>
 				</arguments>
 			</matcher>
 		</filter>
 		<filter>
-			<id>1470885991027</id>
+			<id>1472286169086</id>
 			<name></name>
 			<type>10</type>
 			<matcher>

--- a/core/actionProxy/Dockerfile
+++ b/core/actionProxy/Dockerfile
@@ -1,16 +1,14 @@
 # Dockerfile for docker skeleton (useful for running blackbox binaries, scripts, or python actions).
-FROM buildpack-deps:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
+FROM python:2.7.12-alpine
 
 # Upgrade and install basic Python dependencies
-RUN apt-get -y purge && \
-    apt-get -y update && \
-    apt-get -y install --fix-missing python2.7 python-distribute python-pip
-
-# Install Python proxy support
-RUN apt-get -y install --fix-missing python2.7-dev python-gevent python-flask
-RUN apt-get clean
+RUN apk add --no-cache bash \
+ && apk add --no-cache --virtual .build-deps \
+        bzip2-dev \
+        gcc \
+        libc-dev \
+  && pip install --no-cache-dir gevent flask \
+  && apk del .build-deps
 
 ENV FLASK_PROXY_PORT 8080
 

--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for python actions, overrides and extends ActionRunner from actionProxy
 FROM dockerskeleton
 
-ENV DEBIAN_FRONTEND noninteractive
- 
+RUN apk add --no-cache python-dev
+
 ENV FLASK_PROXY_PORT 8080
 
 RUN mkdir -p /pythonAction

--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -1,15 +1,23 @@
 # Dockerfile for swift actions, overrides and extends ActionRunner from actionProxy
 # This Dockerfile is partially based on: https://github.com/swiftdocker/docker-swift/
-FROM dockerskeleton
+FROM buildpack-deps:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Upgrade and install basic Python dependencies
+RUN apt-get -y purge \
+ && apt-get -y update \
+ && apt-get -y install --fix-missing python2.7 python-gevent python-flask \
+\
 # Upgrade and install Swift dependencies
-RUN apt-get -y install --fix-missing build-essential wget clang libedit-dev libicu52 libxml2-dev
+ && apt-get -y install --fix-missing build-essential wget clang libedit-dev libicu52 libxml2-dev \
+\
+# Clean up
+ && apt-get clean
 
- # Kitura dependencies
-RUN apt-get -y install autoconf libtool libkqueue-dev libkqueue0 libdispatch-dev libdispatch0 libcurl4-openssl-dev libbsd-dev
-RUN apt-get clean
+# Kitura dependencies
+RUN apt-get -y install autoconf libtool libkqueue-dev libkqueue0 libdispatch-dev libdispatch0 libcurl4-openssl-dev libbsd-dev \
+ && apt-get clean
 
 # Install Swift keys
 RUN wget --no-verbose -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
@@ -31,7 +39,11 @@ RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
 RUN git clone -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git
 RUN cd swift-corelibs-libdispatch && git submodule init && git submodule update && sh ./autogen.sh && ./configure --with-swift-toolchain=/usr --prefix=/usr && make && make install
 
-# Copy the Flask proxy.
+# Add the action proxy
+RUN mkdir -p /actionProxy
+ADD actionproxy.py /actionProxy
+
+# Add swift3 action runner
 RUN mkdir -p /swift3Action
 ADD epilogue.swift /swift3Action
 ADD swift3runner.py /swift3Action

--- a/core/swift3Action/build.gradle
+++ b/core/swift3Action/build.gradle
@@ -1,3 +1,13 @@
 ext.dockerImageName = 'swift3action'
 apply from: '../../gradle/docker.gradle'
-distDocker.dependsOn ':core:actionProxy:distDocker'
+distDocker.dependsOn 'copyProxy'
+distDocker.finalizedBy('rmProxy')
+
+task copyProxy(type: Copy) {
+    from '../actionProxy/actionproxy.py'
+    into './actionproxy.py'
+}
+
+task rmProxy(type: Delete) {
+    delete 'actionproxy.py'
+}

--- a/core/swiftAction/Dockerfile
+++ b/core/swiftAction/Dockerfile
@@ -1,12 +1,19 @@
 # Dockerfile for swift3 actions, overrides and extends ActionRunner from actionProxy
 # This Dockerfile is partially based on: https://github.com/swiftdocker/docker-swift/
-FROM dockerskeleton
+FROM buildpack-deps:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Upgrade and install basic Python dependencies
+RUN apt-get -y purge \
+ && apt-get -y update \
+ && apt-get -y install --fix-missing python2.7 python-gevent python-flask \
+\
 # Upgrade and install Swift dependencies
-RUN apt-get -y install --fix-missing build-essential wget clang libedit-dev libicu52 libxml2-dev
-RUN apt-get clean
+ && apt-get -y install --fix-missing build-essential wget clang libedit-dev libicu52 libxml2-dev \
+\
+# Clean up
+ && apt-get clean
 
 # Install Swift keys
 RUN wget --no-verbose -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
@@ -24,7 +31,11 @@ RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
     tar -xzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
     rm -rf $SWIFT_ARCHIVE_NAME* /tmp/* /var/tmp/*
 
-# Copy the Flask proxy.
+# Add the action proxy
+RUN mkdir -p /actionProxy
+ADD actionproxy.py /actionProxy
+
+# Add swift action runner
 RUN mkdir -p /swiftAction
 RUN touch /swiftAction/action.swift
 ADD epilogue.swift /swiftAction

--- a/core/swiftAction/build.gradle
+++ b/core/swiftAction/build.gradle
@@ -1,3 +1,13 @@
 ext.dockerImageName = 'swiftaction'
 apply from: '../../gradle/docker.gradle'
-distDocker.dependsOn ':core:actionProxy:distDocker'
+distDocker.dependsOn 'copyProxy'
+distDocker.finalizedBy('rmProxy')
+
+task copyProxy(type: Copy) {
+    from '../actionProxy/actionproxy.py'
+    into './actionproxy.py'
+}
+
+task rmProxy(type: Delete) {
+    delete 'actionproxy.py'
+}

--- a/sdk/docker/Dockerfile
+++ b/sdk/docker/Dockerfile
@@ -1,11 +1,17 @@
 # Dockerfile for example whisk docker action
 FROM dockerskeleton
-
-ENV DEBIAN_FRONTEND noninteractive
  
 ENV FLASK_PROXY_PORT 8080
 
+### Add source file(s)
 ADD example.c /action/example.c
-RUN cd /action; gcc -o exec example.c
+
+RUN apk add --no-cache --virtual .build-deps \
+        bzip2-dev \
+        gcc \
+        libc-dev \
+### Compile source file(s)
+ && cd /action; gcc -o exec example.c \
+ && apk del .build-deps
 
 CMD ["/bin/bash", "-c", "cd actionProxy && python -u actionproxy.py"]

--- a/sdk/docker/README.md
+++ b/sdk/docker/README.md
@@ -31,4 +31,4 @@ wsk action invoke dockerSkeletonExample --blocking
 The executable file must be located in the `/action` folder.
 The name of the executable must be `/action/exec` and can be any file with executable permissions.
 The sample docker action runs `example.c` by copying and building the source inside the container
-as `/action/exec` (see `Dockerfile` lines 8-9).
+as `/action/exec` (see `Dockerfile` lines 7 and 14).

--- a/tests/src/actionContainers/ActionProxyContainerTests.scala
+++ b/tests/src/actionContainers/ActionProxyContainerTests.scala
@@ -68,7 +68,8 @@ class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSyst
                 |print $ARGV[0];
             """.stripMargin.trim
 
-        Seq(("bash", bash), ("python", python), ("perl", perl))
+        // excluding perl as it not installed in alpine based image
+        Seq(("bash", bash), ("python", python))
     }
 
     /** Standard code samples, should print 'hello' to stdout and echo the input args. */
@@ -91,7 +92,8 @@ class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSyst
                 |print "{ \"auth\": \"$a\", \"edge\": \"$e\" }";
             """.stripMargin.trim
 
-        Seq(("bash", bash), ("python", python), ("perl", perl))
+        // excluding perl as it not installed in alpine based image
+        Seq(("bash", bash), ("python", python))
     }
 
     behavior of "openwhisk/dockerskeleton"


### PR DESCRIPTION
Reduce image size for docker actions skeleton from 619.8MB to 86.78MB.
This makes the example docker image size equally smaller.
Use the base image for python actions but not Swift since the latter not yet ready for a diet.

PG1-321 approved (node failing test is due to #1142 and not this pr).