### PR TITLE
Move note about not sharing sensitive information inside the comment block

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,20 @@
 <!--
-If you are reporting a new issue, make sure that we do not have any duplicates
-already open. If there is a duplicate, please close your issue and add a comment
-to the existing issue.
+Do NOT share passwords, credentials or other confidential information.
 
-If you suspect your issue is a bug, please edit your issue description to
-include the information shown below.
+Before creating a new issue, please check if there is one already open that
+fits the defect you are reporting.
+If you open an issue and realize later it is a duplicate of a pre-existing
+open issue, please close yours and add a comment to the other.
+
+If you are reporting a defect, please edit the issue description to include the
+information shown below.
 
 For more information about reporting issues, see
 https://github.com/openwhisk/openwhisk/blob/master/CONTRIBUTING.md#raising-issues
 
-
 Use the commands below to provide key information from your environment:
-You do NOT have to include this information if this is a feature request
+You do not have to include this information if this is a feature request.
 -->
-> note: obfuscate all passwords, credentials or other confidential information
 
 ## Environment details:
 


### PR DESCRIPTION
when opening new issues, this line would appear outside the comment block.

> note: obfuscate all passwords, credentials or other confidential information

and hence appear in the issue description. Move it instead inside the template comment block and put it right at the top.