### PR TITLE
Remove sleeps

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
@@ -16,11 +16,16 @@
 
 package whisk.core.entity
 
+import scala.util.Try
+
 import spray.json.DefaultJsonProtocol
 import spray.json.JsBoolean
-import spray.json.JsValue
 import spray.json.JsObject
 import spray.json.JsString
+import spray.json.JsValue
+import spray.json.pimpString
+import whisk.common.Logging
+import scala.concurrent.duration.Duration
 
 protected[core] case class ActivationResponse private (
     val statusCode: Int, val result: Option[JsValue]) {
@@ -54,7 +59,7 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
     val ContainerError   = 2
     val WhiskError       = 3
 
-    private def messageForCode(code: Int) = {
+    protected[core] def messageForCode(code: Int) = {
         require(code >= 0 && code <= 3)
         code match {
             case 0 => "success"
@@ -78,5 +83,94 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
     protected[core] def whiskError(errorValue: JsValue)       = error(WhiskError, errorValue)
     protected[core] def whiskError(errorMsg: String)          = error(WhiskError, JsString(errorMsg))
 
+    protected[core] def abnormalInitialization = JsString("The action did not initialize and exited unexpectedly.")
+    protected[core] def abnormalRun = JsString("The action did not produce a valid response and exited unexpectedly.")
+    protected[core] def invalidInitResponse(actualResponse: String) = {
+        JsString("The action failed during initialization" + {
+            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
+        })
+    }
+    protected[core] def invalidRunResponse(actualResponse: String) = {
+        JsString("The action did not produce a valid JSON response" + {
+            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
+        })
+    }
+    protected[core] def timedoutActivation(timeout: Duration, init: Boolean) = {
+        JsString(s"The action exceeded its time limits of ${timeout.toMillis} milliseconds" + {
+            if (!init) "." else "during initialization."
+        })
+    }
+
+    /**
+     * Interprets response from container after initialization. This method is only called when the initialization failed.
+     *
+     * @param response an Option (HTTP Status Code, HTTP response bytes as String)
+     * @return appropriate ActivationResponse representing initialization error
+     */
+    protected[core] def processInitResponseContent(response: Option[(Int, String)], logger: Logging): ActivationResponse = {
+        require(response map { _._1 != 200 } getOrElse true, s"should not interpret init response when status code is 200")
+
+        response map {
+            case (code, contents) =>
+                logger.debug(this, s"init response: '$contents'")
+                Try { contents.parseJson.asJsObject } match {
+                    case scala.util.Success(result @ JsObject(fields)) =>
+                        // If the response is a JSON object container an error field, accept it as the response error.
+                        val errorOpt = fields.get(ERROR_FIELD)
+                        val errorContent = errorOpt getOrElse invalidInitResponse(contents)
+                        containerError(errorContent)
+                    case _ =>
+                        containerError(invalidInitResponse(contents))
+                }
+        } getOrElse {
+            // This indicates a terminal failure in the container (it exited prematurely).
+            containerError(abnormalInitialization)
+        }
+    }
+
+    /**
+     * Interprets response from container after running the action. This method is only called when the initialization succeeded.
+     *
+     * @param response an Option (HTTP Status Code, HTTP response bytes as String)
+     * @return appropriate ActivationResponse representing run result
+     */
+    protected[core] def processRunResponseContent(response: Option[(Int, String)], logger: Logging): ActivationResponse = {
+        response map {
+            case (code, contents) =>
+                logger.debug(this, s"response: '$contents'")
+                print(code, contents)
+                Try { contents.parseJson.asJsObject } match {
+                    case scala.util.Success(result @ JsObject(fields)) =>
+                        // If the response is a JSON object container an error field, accept it as the response error.
+                        val errorOpt = fields.get(ERROR_FIELD)
+
+                        if (code == 200) {
+                            errorOpt map { error =>
+                                applicationError(error)
+                            } getOrElse {
+                                // The happy path.
+                                success(Some(result))
+                            }
+                        } else {
+                            // Any non-200 code is treated as a container failure. We still need to check whether
+                            // there was a useful error message in there.
+                            val errorContent = errorOpt getOrElse invalidRunResponse(contents)
+                            containerError(errorContent)
+                        }
+
+                    case scala.util.Success(notAnObj) =>
+                        // This should affect only blackbox containers, since our own containers should already test for that.
+                        containerError(invalidRunResponse(contents))
+
+                    case scala.util.Failure(t) =>
+                        // This should affect only blackbox containers, since our own containers should already test for that.
+                        logger.warn(this, s"response did not json parse: '$contents' led to $t")
+                        containerError(invalidRunResponse(contents))
+                }
+        } getOrElse {
+            // This indicates a terminal failure in the container (it exited prematurely).
+            containerError(abnormalRun)
+        }
+    }
     protected[core] implicit val serdes = jsonFormat2(ActivationResponse.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
@@ -41,6 +41,8 @@ import whisk.core.entity.size.SizeInt
  */
 protected[core] class LogLimit private (val megabytes: Int) extends AnyVal {
     protected[core] def apply() = megabytes
+    protected[core] def truncatedLogMessage = s"Logs were truncated because they exceeded the limit of $megabytes megabytes."
+
 }
 
 protected[core] object LogLimit extends ArgNormalizer[LogLimit] {

--- a/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -527,7 +527,7 @@ class ContainerPool(
         if (con.containerId.isDefined) {
             // Then send it the init payload which is code for now
             val initArg = action.containerInitializer
-            val initResult = con.init(initArg)
+            val initResult = con.init(initArg, action.limits.timeout.duration)
             Success(con, Some(initResult))
         } else Error("failed to get id for container")
     }

--- a/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -499,7 +499,7 @@ class ContainerPool(
         val key = ActionContainerId(auth.uuid, action.fullyQualifiedName, action.rev)
         val warmedContainer = if (limits.memory == defaultMemoryLimit && imageName == nodeImageName) getWarmNodejsContainer(key) else None
         val containerName = makeContainerName(action)
-        val con = warmedContainer getOrElse makeGeneralContainer(key, containerName, imageName, limits, action.exec.isInstanceOf[BlackBoxExec])
+        val con = warmedContainer getOrElse makeGeneralContainer(key, containerName, imageName, limits, action.exec.kind == BlackBoxExec)
         initWhiskContainer(action, con)
     }
 

--- a/core/dispatcher/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -143,7 +143,6 @@ trait ContainerUtils extends Logging {
                 val read = channel.read(buffer)
                 if (read > 0)
                     remain = read - read.toInt
-                Thread.sleep(50) // TODO What is this for?
             }
             buffer.array
         } catch {

--- a/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -79,8 +79,6 @@ class WhiskContainer(
      * Sends initialization payload to container.
      */
     def init(args: JsObject)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
-        // this shouldn't be needed but leave it for now
-        if (isBlackbox) Thread.sleep(3000)
         info(this, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
         val timeout = initTimeoutMilli min limits.timeout.duration

--- a/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -21,7 +21,6 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration.DurationInt
-import scala.language.postfixOps
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -64,7 +63,6 @@ class WhiskContainer(
 
     var boundParams = JsObject() // Mutable to support pre-alloc containers
     var lastLogSize = 0L
-    private val initTimeoutMilli = 60 seconds
     private implicit val emitter: PrintStreamEmitter = this
 
     /**
@@ -81,8 +79,8 @@ class WhiskContainer(
     def init(args: JsObject)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         info(this, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
-        val timeout = initTimeoutMilli min limits.timeout.duration
-        val result = sendPayload("/init", JsObject("value" -> args), timeout) // This will retry.
+        val timeout = limits.timeout.duration
+        val result = sendPayload("/init", JsObject("value" -> args), timeout) // this will retry
         info(this, s"initialization result: ${result}")
         result
     }

--- a/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -76,10 +76,9 @@ class WhiskContainer(
     /**
      * Sends initialization payload to container.
      */
-    def init(args: JsObject)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
+    def init(args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         info(this, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
-        val timeout = limits.timeout.duration
         val result = sendPayload("/init", JsObject("value" -> args), timeout) // this will retry
         info(this, s"initialization result: ${result}")
         result

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,10 +19,10 @@ include 'tools:cli'
 include 'tools:go-cli'
 
 include 'sdk:docker'
-include 'tests:dat:blackbox:badaction'
-include 'tests:dat:blackbox:badproxy'
 
 include 'tests'
+include 'tests:dat:blackbox:badaction'
+include 'tests:dat:blackbox:badproxy'
 
 rootProject.name = 'openwhisk'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,8 @@ include 'tools:cli'
 include 'tools:go-cli'
 
 include 'sdk:docker'
+include 'tests:dat:blackbox:badaction'
+include 'tests:dat:blackbox:badproxy'
 
 include 'tests'
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -37,8 +37,8 @@ test.dependsOn([
     ':core:swiftAction:distDocker',
     ':core:swift3Action:distDocker',
     ':sdk:docker:distDocker',
-    'tests:dat:blackbox:badaction',
-    'tests:dat:blackbox:badproxy'
+    ':tests:dat:blackbox:badaction:distDocker',
+    ':tests:dat:blackbox:badproxy:distDocker'
 ])
 
 dependencies {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -36,7 +36,9 @@ test.dependsOn([
     ':core:javaAction:distDocker',
     ':core:swiftAction:distDocker',
     ':core:swift3Action:distDocker',
-    ':sdk:docker:distDocker'
+    ':sdk:docker:distDocker',
+    'tests:dat:blackbox:badaction',
+    'tests:dat:blackbox:badproxy'
 ])
 
 dependencies {

--- a/tests/dat/actions/initexit.js
+++ b/tests/dat/actions/initexit.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/tests/dat/actions/initforever.js
+++ b/tests/dat/actions/initforever.js
@@ -1,0 +1,1 @@
+while (true) {}

--- a/tests/dat/actions/runexit.js
+++ b/tests/dat/actions/runexit.js
@@ -1,0 +1,3 @@
+function main() {
+    process.exit(1);
+}

--- a/tests/dat/blackbox/badaction/Dockerfile
+++ b/tests/dat/blackbox/badaction/Dockerfile
@@ -1,0 +1,8 @@
+# Dockerfile for example whisk docker action
+FROM dockerskeleton
+ 
+ENV FLASK_PROXY_PORT 8080
+
+ADD runner.py /actionProxy/
+
+CMD ["/bin/bash", "-c", "cd actionProxy && python -u runner.py"]

--- a/tests/dat/blackbox/badaction/README.md
+++ b/tests/dat/blackbox/badaction/README.md
@@ -1,0 +1,6 @@
+A docker action that can manipulates `/init` and `/run` in different ways including
+- not responding
+- aborting and terminating the container
+
+The action overrides the [common action proxy runner](../../../core/actionProxy/actionproxy.py) with programmable `init` and `run` methods.
+These containers are used in [Docker container tests](../../src/actionContainers/DockerExampleContainerTests.scala).

--- a/tests/dat/blackbox/badaction/build.gradle
+++ b/tests/dat/blackbox/badaction/build.gradle
@@ -1,0 +1,4 @@
+ext.dockerImageName = 'badaction'
+
+apply from: '../../../../gradle/docker.gradle'
+distDocker.dependsOn ':core:actionProxy:distDocker'

--- a/tests/dat/blackbox/badaction/runner.py
+++ b/tests/dat/blackbox/badaction/runner.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+sys.path.append('../actionProxy')
+from actionproxy import ActionRunner, main, setRunner
+import time
+
+class Runner(ActionRunner):
+
+    def __init__(self):
+        ActionRunner.__init__(self)
+
+    def init(self, message):
+        if 'code' in message and message['code'] == 'sleep':
+            # sleep forever/never respond
+            while True:
+                print("sleeping")
+                time.sleep(60)
+        elif 'code' in message and message['code'] == 'exit':
+            print("exiting")
+            sys.exit(1)
+        else:
+            return ActionRunner.init(self, message)
+
+    def run(self, args, env):
+        if 'sleep' in args:
+            # sleep forever/never respond
+            while True:
+                print("sleeping")
+                time.sleep(60)
+        elif 'exit' in args:
+            print("exiting")
+            sys.exit(1)
+        else:
+            return ActionRunner.run(self, args, env)
+
+if __name__ == "__main__":
+    setRunner(Runner())
+    main()

--- a/tests/dat/blackbox/badproxy/Dockerfile
+++ b/tests/dat/blackbox/badproxy/Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile for example whisk docker action
+FROM dockerskeleton
+ 
+ENV FLASK_PROXY_PORT 8080
+
+CMD ["/bin/bash", "-c", "tail -f /dev/null"]

--- a/tests/dat/blackbox/badproxy/README.md
+++ b/tests/dat/blackbox/badproxy/README.md
@@ -1,0 +1,1 @@
+A docker action that does not implement a proper proxy. Runs a shell commands that never terminates.

--- a/tests/dat/blackbox/badproxy/build.gradle
+++ b/tests/dat/blackbox/badproxy/build.gradle
@@ -1,0 +1,4 @@
+ext.dockerImageName = 'badproxy'
+
+apply from: '../../../../gradle/docker.gradle'
+distDocker.dependsOn ':core:actionProxy:distDocker'

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -102,7 +102,7 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
 
             if (i < 2) {
                 Thread.sleep((sessionTimeout + 1.second).toMillis)
-                an[CommitFailedException] should be thrownBy {
+                a[CommitFailedException] should be thrownBy {
                     consumer.commit() // sleep should cause commit to fail
                 }
             } else consumer.commit()

--- a/tests/src/whisk/core/cli/test/JsonArgsForTests.scala
+++ b/tests/src/whisk/core/cli/test/JsonArgsForTests.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.cli.test
+
+import spray.json.JsObject
+import spray.json.JsArray
+import spray.json.JsString
+import spray.json.JsNumber
+import spray.json.JsBoolean
+
+object JsonArgsForTests {
+
+    def getEscapedJSONTestArgInput(parameters: Boolean = true) = Seq(
+        if (parameters) "-p" else "-a",
+        "\"key\"with\\escapes",                 // key:   key"with\escapes (will be converted to JSON string "key\"with\\escapes")
+        "{\"valid\": \"JSON\"}",                // value: {"valid":"JSON"}
+        if (parameters) "-p" else "-a",
+        "another\"escape\"",                    // key:   another"escape" (will be converted to JSON string "another\"escape\"")
+        "{\"valid\": \"\\nJ\\rO\\tS\\bN\\f\"}", // value: {"valid":"\nJ\rO\tS\bN\f"}  JSON strings can escape: \n, \r, \t, \b, \f
+        // NOTE: When uncommentting these tests, be sure to include the expected response in getEscapedJSONTestArgOutput()
+        //        if (parameters) "-p" else "-a",
+        //        "escape\\again",                        // key:   escape\again (will be converted to JSON string "escape\\again")
+        //        "{\"valid\": \"JS\\u2312ON\"}",         // value: {"valid":"JS\u2312ON"}   JSON strings can have escaped 4 digit unicode
+        //        if (parameters) "-p" else "-a",
+        //        "mykey",                                // key:   mykey  (will be converted to JSON string "key")
+        //        "{\"valid\": \"JS\\/ON\"}",             // value: {"valid":"JS\/ON"}   JSON strings can have escaped \/
+        if (parameters) "-p" else "-a",
+        "key1",                                 // key:   key  (will be converted to JSON string "key")
+        "{\"nonascii\": \"日本語\"}",           // value: {"nonascii":"日本語"}   JSON strings can have non-ascii
+        if (parameters) "-p" else "-a",
+        "key2",                                 // key:   key  (will be converted to JSON string "key")
+        "{\"valid\": \"J\\\\SO\\\"N\"}"         // value: {"valid":"J\\SO\"N"}   JSON strings can have escaped \\ and \"
+    )
+
+    def getEscapedJSONTestArgOutput() = JsArray(
+        JsObject(
+            "key" -> JsString("\"key\"with\\escapes"),
+            "value" -> JsObject(
+                "valid" -> JsString("JSON")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("another\"escape\""),
+            "value" -> JsObject(
+                "valid" -> JsString("\nJ\rO\tS\bN\f")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("key1"),
+            "value" -> JsObject(
+                "nonascii" -> JsString("日本語")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("key2"),
+            "value" -> JsObject(
+                "valid" -> JsString("J\\SO\"N")
+            )
+        )
+    )
+
+    def getValidJSONTestArgOutput() = JsArray(
+        JsObject(
+            "key" -> JsString("number"),
+            "value" -> JsNumber(8)
+        ),
+        JsObject(
+            "key" -> JsString("objArr"),
+            "value" -> JsArray(
+                JsObject(
+                    "name" -> JsString("someName"),
+                    "required" -> JsBoolean(true)
+                ),
+                JsObject(
+                    "name" -> JsString("events"),
+                    "count" -> JsNumber(10)
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("strArr"),
+            "value" -> JsArray(
+                JsString("44"),
+                JsString("55")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("string"),
+            "value" -> JsString("This is a string")
+        ),
+        JsObject(
+            "key" -> JsString("numArr"),
+            "value" -> JsArray(
+                JsNumber(44),
+                JsNumber(55)
+            )
+        ),
+        JsObject(
+            "key" -> JsString("object"),
+            "value" -> JsObject(
+                "objString" -> JsString("aString"),
+                "objStrNum" -> JsString("123"),
+                "objNum" -> JsNumber(300),
+                "objBool" -> JsBoolean(false),
+                "objNumArr" -> JsArray(
+                    JsNumber(1),
+                    JsNumber(2)
+                ),
+                "objStrArr" -> JsArray(
+                    JsString("1"),
+                    JsString("2")
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("strNum"),
+            "value" -> JsString("9")
+        )
+    )
+
+    def getValidJSONTestArgInput() = Map(
+        "string" -> JsString("This is a string"),
+        "strNum" -> JsString("9"),
+        "number" -> JsNumber(8),
+        "numArr" -> JsArray(
+            JsNumber(44),
+            JsNumber(55)
+        ),
+        "strArr" -> JsArray(
+            JsString("44"),
+            JsString("55")
+        ),
+        "objArr" -> JsArray(
+            JsObject(
+                "name" -> JsString("someName"),
+                "required" -> JsBoolean(true)
+            ),
+            JsObject(
+                "name" -> JsString("events"),
+                "count" -> JsNumber(10)
+            )
+        ),
+        "object" -> JsObject(
+            "objString" -> JsString("aString"),
+            "objStrNum" -> JsString("123"),
+            "objNum" -> JsNumber(300),
+            "objBool" -> JsBoolean(false),
+            "objNumArr" -> JsArray(
+                JsNumber(1),
+                JsNumber(2)
+            ),
+            "objStrArr" -> JsArray(
+                JsString("1"),
+                JsString("2")
+            )
+        )
+    )
+}

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -51,13 +51,15 @@ import whisk.core.entity.LogLimit._
 import whisk.core.entity.MemoryLimit._
 import whisk.core.entity.TimeLimit._
 import whisk.core.entity.size.SizeInt
+import whisk.core.entity.ActivationResponse
 import whisk.utils.retry
+import JsonArgsForTests._
 
 /**
  * Tests for basic CLI usage. Some of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class WskBasicCliUsageTests
+class WskBasicUsageTests
     extends TestHelpers
     with WskTestHelpers {
 
@@ -339,8 +341,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("action", "create", wsk.action.fqn(name), file, "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput()
-                    )
+                        getEscapedJSONTestArgInput())
             }
 
             val stdout = wsk.action.get(name).stdout
@@ -356,8 +357,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("action", "create", wsk.action.fqn(name), file, "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput(false)
-                    )
+                        getEscapedJSONTestArgInput(false))
             }
 
             val stdout = wsk.action.get(name).stdout
@@ -366,18 +366,52 @@ class WskBasicCliUsageTests
             wsk.parseJsonString(stdout).fields("annotations") shouldBe getEscapedJSONTestArgOutput
     }
 
-    it should "invoke an action that exits and get appropriate error" in withAssetCleaner(wskprops) {
+    it should "invoke an action that exits during init and get appropriate error" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val name = "abort"
+            val name = "abort init"
             assetHelper.withCleaner(wsk.action, name) {
-                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("exit.py")))
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
             }
 
             withActivation(wsk.activation, wsk.action.invoke(name)) {
                 activation =>
-                    val response = activation.fields("response").asJsObject
-                    response.fields("result") shouldBe JsObject("error" -> "the action did not produce a valid JSON response".toJson)
-                    response.fields("status") shouldBe "action developer error".toJson
+                    val response = activation.response
+                    response.result.get.fields("error") shouldBe ActivationResponse.abnormalInitialization
+                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
+            }
+    }
+
+    it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "hang init"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(
+                        name,
+                        Some(TestUtils.getTestActionFilename("initforever.js")),
+                        timeout = Some(3 seconds))
+            }
+
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                activation =>
+                    val response = activation.response
+                    response.result.get.fields("error") shouldBe ActivationResponse.timedoutActivation(3 seconds, true)
+                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
+            }
+    }
+
+    it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "abort run"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
+            }
+
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                activation =>
+                    val response = activation.response
+                    response.result.get.fields("error") shouldBe ActivationResponse.abnormalRun
+                    response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
             }
     }
 
@@ -524,8 +558,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.pkg, name) {
                 (pkg, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("package", "create", wsk.pkg.fqn(name), "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput()
-                    )
+                        getEscapedJSONTestArgInput())
             }
 
             val stdout = wsk.pkg.get(name).stdout
@@ -540,8 +573,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.pkg, name) {
                 (pkg, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("package", "create", wsk.pkg.fqn(name), "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput(false)
-                    )
+                        getEscapedJSONTestArgInput(false))
             }
 
             val stdout = wsk.pkg.get(name).stdout
@@ -625,8 +657,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.trigger, name) {
                 (trigger, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("trigger", "create", wsk.trigger.fqn(name), "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput()
-                    )
+                        getEscapedJSONTestArgInput())
             }
 
             val stdout = wsk.trigger.get(name).stdout
@@ -641,8 +672,7 @@ class WskBasicCliUsageTests
             assetHelper.withCleaner(wsk.trigger, name) {
                 (trigger, _) =>
                     wsk.cli(wskprops.overrides ++ Seq("trigger", "create", wsk.trigger.fqn(name), "--auth", wp.authKey) ++
-                      getEscapedJSONTestArgInput(false)
-                    )
+                        getEscapedJSONTestArgInput(false))
             }
 
             val stdout = wsk.trigger.get(name).stdout
@@ -782,150 +812,4 @@ class WskBasicCliUsageTests
             }
             tmpProps.delete()
     }
-
-    def getEscapedJSONTestArgInput(parameters: Boolean = true) = Seq(
-        if (parameters) "-p" else "-a",
-        "\"key\"with\\escapes",                 // key:   key"with\escapes (will be converted to JSON string "key\"with\\escapes")
-        "{\"valid\": \"JSON\"}",                // value: {"valid":"JSON"}
-        if (parameters) "-p" else "-a",
-        "another\"escape\"",                    // key:   another"escape" (will be converted to JSON string "another\"escape\"")
-        "{\"valid\": \"\\nJ\\rO\\tS\\bN\\f\"}", // value: {"valid":"\nJ\rO\tS\bN\f"}  JSON strings can escape: \n, \r, \t, \b, \f
-        // NOTE: When uncommentting these tests, be sure to include the expected response in getEscapedJSONTestArgOutput()
-        //        if (parameters) "-p" else "-a",
-        //        "escape\\again",                        // key:   escape\again (will be converted to JSON string "escape\\again")
-        //        "{\"valid\": \"JS\\u2312ON\"}",         // value: {"valid":"JS\u2312ON"}   JSON strings can have escaped 4 digit unicode
-        //        if (parameters) "-p" else "-a",
-        //        "mykey",                                // key:   mykey  (will be converted to JSON string "key")
-        //        "{\"valid\": \"JS\\/ON\"}",             // value: {"valid":"JS\/ON"}   JSON strings can have escaped \/
-        if (parameters) "-p" else "-a",
-        "key1",                                 // key:   key  (will be converted to JSON string "key")
-        "{\"nonascii\": \"日本語\"}",           // value: {"nonascii":"日本語"}   JSON strings can have non-ascii
-        if (parameters) "-p" else "-a",
-        "key2",                                 // key:   key  (will be converted to JSON string "key")
-        "{\"valid\": \"J\\\\SO\\\"N\"}"         // value: {"valid":"J\\SO\"N"}   JSON strings can have escaped \\ and \"
-    )
-
-    def getEscapedJSONTestArgOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("\"key\"with\\escapes"),
-            "value" -> JsObject(
-                "valid" -> JsString("JSON")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("another\"escape\""),
-            "value" -> JsObject(
-                "valid" -> JsString("\nJ\rO\tS\bN\f")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("key1"),
-            "value" -> JsObject(
-                "nonascii" -> JsString("日本語")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("key2"),
-            "value" -> JsObject(
-                "valid" -> JsString("J\\SO\"N")
-            )
-        )
-    )
-
-    def getValidJSONTestArgOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("number"),
-            "value" -> JsNumber(8)
-        ),
-        JsObject(
-            "key" -> JsString("objArr"),
-            "value" -> JsArray(
-                JsObject(
-                    "name" -> JsString("someName"),
-                    "required" -> JsBoolean(true)
-                ),
-                JsObject(
-                    "name" -> JsString("events"),
-                    "count" -> JsNumber(10)
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("strArr"),
-            "value" -> JsArray(
-                JsString("44"),
-                JsString("55")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("string"),
-            "value" -> JsString("This is a string")
-        ),
-        JsObject(
-            "key" -> JsString("numArr"),
-            "value" -> JsArray(
-                JsNumber(44),
-                JsNumber(55)
-            )
-        ),
-        JsObject(
-            "key" -> JsString("object"),
-            "value" -> JsObject(
-                "objString" -> JsString("aString"),
-                "objStrNum" -> JsString("123"),
-                "objNum" -> JsNumber(300),
-                "objBool" -> JsBoolean(false),
-                "objNumArr" -> JsArray(
-                    JsNumber(1),
-                    JsNumber(2)
-                ),
-                "objStrArr" -> JsArray(
-                    JsString("1"),
-                    JsString("2")
-                )
-            )
-        ),
-        JsObject(
-            "key" -> JsString("strNum"),
-            "value" -> JsString("9")
-        )
-    )
-
-    def getValidJSONTestArgInput() = Map(
-        "string" -> JsString("This is a string"),
-        "strNum" -> JsString("9"),
-        "number" -> JsNumber(8),
-        "numArr" -> JsArray(
-            JsNumber(44),
-            JsNumber(55)
-        ),
-        "strArr" -> JsArray(
-            JsString("44"),
-            JsString("55")
-        ),
-        "objArr" -> JsArray(
-            JsObject(
-                "name" -> JsString("someName"),
-                "required" -> JsBoolean(true)
-            ),
-            JsObject(
-                "name" -> JsString("events"),
-                "count" -> JsNumber(10)
-            )
-        ),
-        "object" -> JsObject(
-            "objString" -> JsString("aString"),
-            "objStrNum" -> JsString("123"),
-            "objNum" -> JsNumber(300),
-            "objBool" -> JsBoolean(false),
-            "objNumArr" -> JsArray(
-                JsNumber(1),
-                JsNumber(2)
-            ),
-            "objStrArr" -> JsArray(
-                JsString("1"),
-                JsString("2")
-            )
-        )
-    )
 }

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -41,8 +41,7 @@ import common.WhiskProperties
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.DefaultJsonProtocol.IntJsonFormat
-import spray.json.DefaultJsonProtocol.LongJsonFormat
+import spray.json.DefaultJsonProtocol._
 import spray.json._
 import spray.json.JsObject
 import spray.json.pimpAny
@@ -365,6 +364,21 @@ class WskBasicCliUsageTests
             assert(stdout.startsWith(s"ok: got action $name\n"))
 
             wsk.parseJsonString(stdout).fields("annotations") shouldBe getEscapedJSONTestArgOutput
+    }
+
+    it should "invoke an action that exits and get appropriate error" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "abort"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("exit.py")))
+            }
+
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                activation =>
+                    val response = activation.fields("response").asJsObject
+                    response.fields("result") shouldBe JsObject("error" -> "the action did not produce a valid JSON response".toJson)
+                    response.fields("status") shouldBe "action developer error".toJson
+            }
     }
 
     behavior of "Wsk packages"

--- a/tests/src/whisk/core/controller/test/AuthorizeTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthorizeTests.scala
@@ -127,7 +127,7 @@ class AuthorizeTests extends ControllerTestCommon with Authenticate {
         val collections = Seq(PACKAGES)
         val resources = collections map { Resource(someUser.namespace, _, Some("xyz")) }
         resources foreach { r =>
-            an[RejectRequest] should be thrownBy {
+            a[RejectRequest] should be thrownBy {
                 // read should fail because the lookup for the package will fail
                 Await.result(entitlementService.check(someUser, READ, r), requestTimeout)
             }

--- a/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.dispatcher.test
+
+import scala.Vector
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import spray.json.pimpAny
+import spray.json.pimpString
+import whisk.common.Logging
+import whisk.core.entity.ActivationResponse._
+
+@RunWith(classOf[JUnitRunner])
+class ActivationResponseTests extends FlatSpec with Matchers {
+
+    behavior of "ActivationResponse"
+
+    val logger = new Logging {}
+
+    it should "interpret failed init that does not response" in {
+        val ar = processInitResponseContent(None, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalInitialization
+    }
+
+    it should "interpret failed init that responds with null string" in {
+        val response = Some(500, null)
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.toString should not include regex("null")
+    }
+
+    it should "interpret failed init that responds with empty string" in {
+        val response = Some(500, "")
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
+    }
+
+    it should "interpret failed init that responds with non-empty string" in {
+        val response = Some(500, "true")
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.toString should include(response.get._2)
+    }
+
+    it should "interpret failed init that responds with JSON string not object" in {
+        val response = Some(500, Vector(1).toJson.compactPrint)
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.toString should include(response.get._2)
+    }
+
+    it should "interpret failed init that responds with JSON object containing error" in {
+        val response = Some(500, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get shouldBe response.get._2.parseJson
+    }
+
+    it should "interpret failed init that responds with JSON object" in {
+        val response = Some(500, Map("foobar" -> "baz").toJson.compactPrint)
+        val ar = processInitResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.toString should include("baz")
+    }
+
+    it should "not interpret successful init" in {
+        val response = Some(200, "")
+        an[IllegalArgumentException] should be thrownBy {
+            processInitResponseContent(response, logger)
+        }
+    }
+
+    it should "interpret failed run that does not response" in {
+        val ar = processRunResponseContent(None, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalRun
+    }
+
+    it should "interpret failed run that responds with null string" in {
+        val response = Some(500, null)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.toString should not include regex("null")
+    }
+
+    it should "interpret failed run that responds with empty string" in {
+        val response = Some(500, "")
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
+    }
+
+    it should "interpret failed run that responds with non-empty string" in {
+        val response = Some(500, "true")
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.toString should include(response.get._2)
+    }
+
+    it should "interpret failed run that responds with JSON string not object" in {
+        val response = Some(500, Vector(1).toJson.compactPrint)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.toString should include(response.get._2)
+    }
+
+    it should "interpret failed run that responds with JSON object containing error" in {
+        val response = Some(500, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get shouldBe response.get._2.parseJson
+    }
+
+    it should "interpret failed run that responds with JSON object" in {
+        val response = Some(500, Map("foobar" -> "baz").toJson.compactPrint)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ContainerError
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.toString should include("baz")
+    }
+
+    it should "interpret successful run that responds with JSON object containing error" in {
+        val response = Some(200, Map(ERROR_FIELD -> "foobar").toJson.compactPrint)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe ApplicationError
+        ar.result.get shouldBe response.get._2.parseJson
+    }
+
+    it should "interpret successful run that responds with JSON object" in {
+        val response = Some(200, Map("foobar" -> "baz").toJson.compactPrint)
+        val ar = processRunResponseContent(response, logger)
+        ar.statusCode shouldBe Success
+        ar.result.get shouldBe response.get._2.parseJson
+    }
+
+}


### PR DESCRIPTION
Remove unnecessary sleeps in invoker:
- a 3s sleep before calling /init for black box containers is not necessary since the HTTP call will retry.
- slack sleeps after init also not necessary since if container respond to inits, it's ready to run.
- sleep during nio channel draining should not be necessary.

And adds tests using blackbox actions for containers that misbehave to confirm they will timeout with expected exception. Three cases are tested:

1. blackbox that doesn't implement a proper proxy (doesn't run a proxy at all)
2. blackbox that doesn't respond to init (implements /init but does not respond)
3. blackbox that doesn't respond to run (implements /run but does not respond)

 