### PR TITLE
Wrap consul read of configuration with Try 

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -19,11 +19,11 @@ package whisk.core
 import java.io.File
 
 import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.duration.DurationInt
 import scala.io.Source
+import scala.util.Try
 
 import akka.actor.ActorSystem
-
 import whisk.common.Config
 import whisk.common.Config.Settings
 import whisk.common.ConsulClient
@@ -141,12 +141,12 @@ object WhiskConfig extends Logging {
     def readPropertiesFromConsul(properties: Settings)(implicit system: ActorSystem) = {
         //try to get consulServer prop
         val consulString = for {
-            server <- properties.get("consulserver.host")
-            port <- properties.get("consul.host.port4")
+            server <- properties.get(consulServerHost)
+            port <- properties.get(consulPort)
         } yield server + ":" + port
 
         consulString match {
-            case Some(consulServer) => {
+            case Some(consulServer) => Try {
                 info(this, s"reading properties from consul at $consulServer")
                 val consul = new ConsulClient(consulServer)
 

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -40,9 +40,7 @@ object WhiskServices {
 
     type LoadBalancerReq = (String, ActivationMessage, TransactionId)
 
-    def requiredProperties = WhiskConfig.loadbalancerHost ++
-        WhiskConfig.consulServer ++
-        WhiskConfig.entitlementHost
+    def requiredProperties = WhiskConfig.loadbalancerHost ++ WhiskConfig.consulServer ++ EntitlementService.requiredProperties
 
     def consulServer(config: WhiskConfig) = config.consulServer
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -68,12 +68,13 @@ protected[core] case class Resource(
 }
 
 protected[core] object EntitlementService {
-    val requiredProperties = WhiskConfig.consulServer ++ Map(
+    val requiredProperties = WhiskConfig.consulServer ++ WhiskConfig.entitlementHost ++ Map(
         WhiskConfig.actionInvokePerMinuteLimit -> null,
         WhiskConfig.actionInvokePerHourLimit -> null,
-        WhiskConfig.triggerFirePerMinuteLimit -> null,
         WhiskConfig.actionInvokeConcurrentLimit -> null,
+        WhiskConfig.triggerFirePerMinuteLimit -> null,
         WhiskConfig.triggerFirePerHourLimit -> null)
+
     /**
      * The default list of namespaces for a subject.
      */
@@ -89,6 +90,7 @@ protected[core] abstract class EntitlementService(config: WhiskConfig)(
     private implicit val executionContext = actorSystem.dispatcher
 
     private var loadbalancerOverload: Option[Boolean] = None
+
     private val invokeRateThrottler = new RateThrottler(config.actionInvokePerMinuteLimit.toInt, config.actionInvokePerHourLimit.toInt)
     private val triggerRateThrottler = new RateThrottler(config.triggerFirePerMinuteLimit.toInt, config.triggerFirePerHourLimit.toInt)
     private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, config.actionInvokeConcurrentLimit.toInt)


### PR DESCRIPTION
Allows API unit tests to run once again without a deployment by allowing consul read to fail during configuration - the invariant that all required properties must be defined for config to be valid is not changed.