### PR TITLE
Tweak citool.

### DIFF
--- a/tools/build/citool
+++ b/tools/build/citool
@@ -194,12 +194,19 @@ def validateResponse(res):
         return body
 
 def grepForFailingTests(args, body):
-    cmd = 'grep -E "^\w+\.*.*[&gt;|>] \w*.* FAILED%s"' % ("|PASSED" if args.all else "")
+    cmd = 'grep :tests:test'
+    # check that tests ran
     (time, output, error) = shell(cmd, body, args.verbose)
     if output == '':
-        print 'all tests passing'
+        print 'no tests detected'
+    # no tests: either build failure or task not yet reached, skip further check
     else:
-        print(output.replace('&gt;', '>')),
+        cmd = 'grep -E "^\w+\.*.*[&gt;|>] \w*.* FAILED%s"' % ("|PASSED" if args.all else "")
+        (time, output, error) = shell(cmd, body, args.verbose)
+        if output == '':
+            print 'all tests passing'
+        else:
+            print(output.replace('&gt;', '>')),
 
 def reportBuildStatus(args, body):
     cmd = 'tail -1'


### PR DESCRIPTION
Small tweak to citool: Detect if tests ran, if not, report message as such rather than a misleading all tests passed message.