### PR TITLE
Allow JSON to be Input from a File

### DIFF
--- a/tests/dat/actions/invalidInput1.json
+++ b/tests/dat/actions/invalidInput1.json
@@ -1,0 +1,3 @@
+{
+  "invalidJSON":
+}

--- a/tests/dat/actions/invalidInput2.json
+++ b/tests/dat/actions/invalidInput2.json
@@ -1,0 +1,4 @@
+{
+  "invalid": "JS
+  ON"
+}

--- a/tests/dat/actions/invalidInput3.json
+++ b/tests/dat/actions/invalidInput3.json
@@ -1,0 +1,2 @@
+{
+  "invalid": "JSON"

--- a/tests/dat/actions/invalidInput4.json
+++ b/tests/dat/actions/invalidInput4.json
@@ -1,0 +1,3 @@
+{
+  "invalid": "JS"ON"
+}

--- a/tests/dat/actions/validInput1.json
+++ b/tests/dat/actions/validInput1.json
@@ -1,0 +1,11 @@
+{
+  "a key": "a value",
+  "a bool": true,
+  "objKey": {"b": "c"},
+  "objKey2": {"another object": {"some string": "1111"}},
+  "objKey3": {"json object": {"some int": 1111}},
+  "a number arr": [1,2,3],
+  "a string arr": ["1", "2", "3"],
+  "a bool arr": [true, false, true],
+  "strThatLooksLikeJSON": "{\"someKey\": \"someValue\"}"
+}

--- a/tests/dat/actions/validInput2.json
+++ b/tests/dat/actions/validInput2.json
@@ -1,0 +1,3 @@
+{
+  "payload": "test"
+}

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -225,6 +225,8 @@ class WskAction()
         kind: Option[String] = None, // one of docker, copy, sequence or none for autoselect else an explicit type
         parameters: Map[String, JsValue] = Map(),
         annotations: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
+        annotationFile: Option[String] = None,
         timeout: Option[Duration] = None,
         memory: Option[ByteSize] = None,
         logsize: Option[ByteSize] = None,
@@ -242,6 +244,8 @@ class WskAction()
             } ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
+            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
+            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
             { timeout map { t => Seq("-t", t.toMillis.toString) } getOrElse Seq() } ++
             { memory map { m => Seq("-m", m.toMB.toString) } getOrElse Seq() } ++
             { logsize map { l => Seq("-l", l.toMB.toString) } getOrElse Seq() } ++
@@ -259,12 +263,14 @@ class WskAction()
     def invoke(
         name: String,
         parameters: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
         blocking: Boolean = false,
         result: Boolean = false,
         expectedExitCode: Int = SUCCESS_EXIT)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, "invoke", "--auth", wp.authKey, fqn(name)) ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
             { if (blocking) Seq("--blocking") else Seq() } ++
             { if (result) Seq("--result") else Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
@@ -290,6 +296,8 @@ class WskTrigger()
         name: String,
         parameters: Map[String, JsValue] = Map(),
         annotations: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
+        annotationFile: Option[String] = None,
         feed: Option[String] = None,
         shared: Option[Boolean] = None,
         update: Boolean = false,
@@ -299,6 +307,8 @@ class WskTrigger()
             { feed map { f => Seq("--feed", fqn(f)) } getOrElse Seq() } ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
+            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
+            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }
@@ -313,10 +323,12 @@ class WskTrigger()
     def fire(
         name: String,
         parameters: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
         expectedExitCode: Int = SUCCESS_EXIT)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, "fire", "--auth", wp.authKey, fqn(name)) ++
-            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } }
+            { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
+            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }
 }
@@ -650,6 +662,8 @@ class WskPackage()
         name: String,
         parameters: Map[String, JsValue] = Map(),
         annotations: Map[String, JsValue] = Map(),
+        parameterFile: Option[String] = None,
+        annotationFile: Option[String] = None,
         shared: Option[Boolean] = None,
         update: Boolean = false,
         expectedExitCode: Int = SUCCESS_EXIT)(
@@ -657,6 +671,8 @@ class WskPackage()
         val params = Seq(noun, if (!update) "create" else "update", "--auth", wp.authKey, fqn(name)) ++
             { parameters flatMap { p => Seq("-p", p._1, p._2.compactPrint) } } ++
             { annotations flatMap { p => Seq("-a", p._1, p._2.compactPrint) } } ++
+            { parameterFile map { pf => Seq("-P", pf) } getOrElse Seq() } ++
+            { annotationFile map { af => Seq("-A", af) } getOrElse Seq() } ++
             { shared map { s => Seq("--shared", if (s) "yes" else "no") } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode)
     }

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -238,6 +238,26 @@ class WskBasicTests
             }
     }
 
+    it should "create, and invoke an action using a parameter file" in withAssetCleaner(wskprops) {
+        val name = "paramFileAction"
+        val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
+        val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
+
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, file)
+            }
+
+            val expectedOutput = JsObject(
+                "payload" -> JsString("test")
+            )
+            val run = wsk.action.invoke(name, parameterFile = argInput)
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.result shouldBe Some(expectedOutput)
+            }
+    }
+
     /**
      * Tests creating an action from a malformed js file. This should fail in
      * some way - preferably when trying to create the action. If not, then
@@ -392,6 +412,27 @@ class WskBasicTests
             }
 
             res.stdout should include regex(s"ok: created trigger $name")
+    }
+
+    it should "create, and fire a trigger using a parameter file" in withAssetCleaner(wskprops) {
+        val name = "paramFileTrigger"
+        val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
+        val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
+
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.trigger, name) {
+                (trigger, _) =>
+                    trigger.create(name)
+            }
+
+            val expectedOutput = JsObject(
+                    "payload" -> JsString("test")
+            )
+            val run = wsk.trigger.fire(name, parameterFile = argInput)
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.result shouldBe Some(expectedOutput)
+            }
     }
 
     behavior of "Wsk Rule CLI"

--- a/tests/src/whisk/core/cli/test/JsonArgsForTests.scala
+++ b/tests/src/whisk/core/cli/test/JsonArgsForTests.scala
@@ -24,41 +24,85 @@ import spray.json.JsBoolean
 
 object JsonArgsForTests {
 
-    def getEscapedJSONTestArgInput(parameters: Boolean = true) = Seq(
-        if (parameters) "-p" else "-a",
-        "\"key\"with\\escapes",                 // key:   key"with\escapes (will be converted to JSON string "key\"with\\escapes")
-        "{\"valid\": \"JSON\"}",                // value: {"valid":"JSON"}
-        if (parameters) "-p" else "-a",
-        "another\"escape\"",                    // key:   another"escape" (will be converted to JSON string "another\"escape\"")
-        "{\"valid\": \"\\nJ\\rO\\tS\\bN\\f\"}", // value: {"valid":"\nJ\rO\tS\bN\f"}  JSON strings can escape: \n, \r, \t, \b, \f
-        // NOTE: When uncommentting these tests, be sure to include the expected response in getEscapedJSONTestArgOutput()
-        //        if (parameters) "-p" else "-a",
-        //        "escape\\again",                        // key:   escape\again (will be converted to JSON string "escape\\again")
-        //        "{\"valid\": \"JS\\u2312ON\"}",         // value: {"valid":"JS\u2312ON"}   JSON strings can have escaped 4 digit unicode
-        //        if (parameters) "-p" else "-a",
-        //        "mykey",                                // key:   mykey  (will be converted to JSON string "key")
-        //        "{\"valid\": \"JS\\/ON\"}",             // value: {"valid":"JS\/ON"}   JSON strings can have escaped \/
-        if (parameters) "-p" else "-a",
-        "key1",                                 // key:   key  (will be converted to JSON string "key")
-        "{\"nonascii\": \"日本語\"}",           // value: {"nonascii":"日本語"}   JSON strings can have non-ascii
-        if (parameters) "-p" else "-a",
-        "key2",                                 // key:   key  (will be converted to JSON string "key")
-        "{\"valid\": \"J\\\\SO\\\"N\"}"         // value: {"valid":"J\\SO\"N"}   JSON strings can have escaped \\ and \"
+    def getInvalidJSONInput = Seq(
+        "{\"invalid1\": }",
+        "{\"invalid2\": bogus}",
+        "{\"invalid1\": \"aKey\"",
+        "invalid \"string\"",
+        "{\"invalid1\": [1, 2, \"invalid\"\"arr\"]}"
+    )
+
+    def getJSONFileOutput() = JsArray(
+        JsObject(
+            "key" -> JsString("a key"),
+            "value" -> JsString("a value")
+        ),
+        JsObject(
+            "key" -> JsString("a bool"),
+            "value" -> JsBoolean(true)
+        ),
+        JsObject(
+            "key" -> JsString("objKey"),
+            "value" -> JsObject(
+                "b" -> JsString("c")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("objKey2"),
+            "value" -> JsObject(
+                "another object" -> JsObject(
+                    "some string" -> JsString("1111")
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("objKey3"),
+            "value" -> JsObject(
+                "json object" -> JsObject(
+                    "some int" -> JsNumber(1111)
+                )
+            )
+        ),
+        JsObject(
+            "key" -> JsString("a number arr"),
+            "value" -> JsArray(
+                JsNumber(1), JsNumber(2), JsNumber(3)
+            )
+        ),
+        JsObject(
+            "key" -> JsString("a string arr"),
+            "value" -> JsArray(
+                JsString("1"), JsString("2"), JsString("3")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("a bool arr"),
+            "value" -> JsArray(
+                JsBoolean(true), JsBoolean(false), JsBoolean(true)
+            )
+        ),
+        JsObject(
+            "key" -> JsString("strThatLooksLikeJSON"),
+            "value" -> JsString("{\"someKey\": \"someValue\"}")
+        )
+    )
+
+    def getEscapedJSONTestArgInput() = Map(
+        "key1" -> JsObject(
+            "nonascii" -> JsString("日本語")
+        ),
+        "key2" -> JsObject(
+            "valid" -> JsString("J\\SO\"N")
+        ),
+        "\"key\"with\\escapes" -> JsObject(
+            "valid" -> JsString("JSON")
+        ),
+        "another\"escape\"" -> JsObject(
+            "valid" -> JsString("\\nJ\\rO\\tS\\bN\\f")
+        )
     )
 
     def getEscapedJSONTestArgOutput() = JsArray(
-        JsObject(
-            "key" -> JsString("\"key\"with\\escapes"),
-            "value" -> JsObject(
-                "valid" -> JsString("JSON")
-            )
-        ),
-        JsObject(
-            "key" -> JsString("another\"escape\""),
-            "value" -> JsObject(
-                "valid" -> JsString("\nJ\rO\tS\bN\f")
-            )
-        ),
         JsObject(
             "key" -> JsString("key1"),
             "value" -> JsObject(
@@ -69,6 +113,18 @@ object JsonArgsForTests {
             "key" -> JsString("key2"),
             "value" -> JsObject(
                 "valid" -> JsString("J\\SO\"N")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("\"key\"with\\escapes"),
+            "value" -> JsObject(
+                "valid" -> JsString("JSON")
+            )
+        ),
+        JsObject(
+            "key" -> JsString("another\"escape\""),
+            "value" -> JsObject(
+                "valid" -> JsString("\\nJ\\rO\\tS\\bN\\f")
             )
         )
     )

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -88,14 +88,34 @@ func init() {
 
 func getKeyValueArgs(args []string, argIndex int, parsedArgs []string) ([]string, []string, error) {
     var whiskErr error
+    var key string
+    var value string
 
     if len(args) - 1 >= argIndex + 2 {
-        parsedArgs = append(parsedArgs, args[argIndex + 1])
-        parsedArgs = append(parsedArgs, args[argIndex + 2])
+        key = args[argIndex + 1]
+        value = args[argIndex + 2]
+        parsedArgs = append(parsedArgs, getFormattedJSON(key, value))
         args = append(args[:argIndex], args[argIndex + 3:]...)
     } else {
         whisk.Debug(whisk.DbgError, "Arguments for '%s' must be a key/value pair; args: %s", args[argIndex], args)
         errMsg := wski18n.T("Arguments for '{{.arg}}' must be a key/value pair",
+            map[string]interface{}{"arg": args[argIndex]})
+        whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
+            whisk.DISPLAY_USAGE)
+    }
+
+    return parsedArgs, args, whiskErr
+}
+
+func getValueFromArgs(args []string, argIndex int, parsedArgs []string) ([]string, []string, error) {
+    var whiskErr error
+
+    if len(args) - 1 >= argIndex + 1 {
+        parsedArgs = append(parsedArgs, args[argIndex + 1])
+        args = append(args[:argIndex], args[argIndex + 2:]...)
+    } else {
+        whisk.Debug(whisk.DbgError, "An argument must be provided for '%s'; args: %s", args[argIndex], args)
+        errMsg := wski18n.T("An argument must be provided for '{{.arg}}'",
             map[string]interface{}{"arg": args[argIndex]})
         whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
             whisk.DISPLAY_USAGE)
@@ -112,7 +132,41 @@ func parseArgs(args []string) ([]string, []string, []string, error) {
     i := 0
 
     for i < len(args) {
-        if args[i] == "-p" || args[i] == "--param" {
+        if args[i] == "-P" || args[i] == "--param-file" {
+            paramArgs, args, whiskErr = getValueFromArgs(args, i, paramArgs)
+            if whiskErr != nil {
+                whisk.Debug(whisk.DbgError, "getValueFromArgs(%#v, %d) failed: %s\n", args, i, whiskErr)
+                errMsg := wski18n.T("The parameter arguments are invalid: {{.err}}",
+                    map[string]interface{}{"err": whiskErr})
+                whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
+                    whisk.DISPLAY_USAGE)
+                return nil, nil, nil, whiskErr
+            }
+
+            filename := paramArgs[len(paramArgs) - 1]
+            paramArgs[len(paramArgs) - 1], whiskErr = readFile(filename)
+            if whiskErr != nil {
+                whisk.Debug(whisk.DbgError, "readFile(%s) error: %s\n", filename, whiskErr)
+                return nil, nil, nil, whiskErr
+            }
+        } else if args[i] == "-A" || args[i] == "--annotation-file" {
+            annotArgs, args, whiskErr = getValueFromArgs(args, i, annotArgs)
+            if whiskErr != nil {
+                whisk.Debug(whisk.DbgError, "getValueFromArgs(%#v, %d) failed: %s\n", args, i, whiskErr)
+                errMsg := wski18n.T("The annotation arguments are invalid: {{.err}}",
+                    map[string]interface{}{"err": whiskErr})
+                whiskErr = whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
+                    whisk.DISPLAY_USAGE)
+                return nil, nil, nil, whiskErr
+            }
+
+            filename := annotArgs[len(annotArgs) - 1]
+            annotArgs[len(annotArgs) - 1], whiskErr = readFile(filename)
+            if whiskErr != nil {
+                whisk.Debug(whisk.DbgError, "readFile(%s) error: %s\n", filename, whiskErr)
+                return nil, nil, nil, whiskErr
+            }
+        } else if args[i] == "-p" || args[i] == "--param" {
             paramArgs, args, whiskErr = getKeyValueArgs(args, i, paramArgs)
             if whiskErr != nil {
                 whisk.Debug(whisk.DbgError, "getKeyValueArgs(%#v, %d) failed: %s\n", args, i, whiskErr)

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -40,7 +40,9 @@ var flags struct {
     common struct {
         blocking    bool
         annotation  []string
+        annotFile   string
         param       []string
+        paramFile   string
         shared      string // AKA "public" or "publish"
         skip        int  // skip first N records
         limit       int  // return max N records

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -78,10 +78,10 @@ var packageBindCmd = &cobra.Command{
     // e.g.   --p arg1,arg2 --p arg3,arg4   ->  [arg1, arg2, arg3, arg4]
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := getJSONFromArguments(flags.common.param, true)
+    parameters, err := getJSONFromStrings(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
           map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
@@ -93,10 +93,10 @@ var packageBindCmd = &cobra.Command{
     // The 1 or more --annotation arguments have all been combined into a single []string
     // e.g.   --a arg1,arg2 --a arg3,arg4   ->  [arg1, arg2, arg3, arg4]
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := getJSONFromArguments(flags.common.annotation, true)
+    annotations, err := getJSONFromStrings(flags.common.annotation, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
           map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
@@ -111,8 +111,8 @@ var packageBindCmd = &cobra.Command{
 
     p := &whisk.BindingPackage{
       Name:        bindQName.entityName,
-      Annotations: annotations,
-      Parameters:  parameters,
+      Annotations: annotations.(whisk.KeyValueArr),
+      Parameters:  parameters.(whisk.KeyValueArr),
       Binding:     binding,
     }
 
@@ -168,10 +168,10 @@ var packageCreateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := getJSONFromArguments(flags.common.param, true)
+    parameters, err := getJSONFromStrings(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
           map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
@@ -180,10 +180,10 @@ var packageCreateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := getJSONFromArguments(flags.common.annotation, true)
+    annotations, err := getJSONFromStrings(flags.common.annotation, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
           map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
@@ -197,16 +197,16 @@ var packageCreateCmd = &cobra.Command{
         Name:        qName.entityName,
         Namespace:   qName.namespace,
         Publish:     shared,
-        Annotations: annotations,
-        Parameters:  parameters,
+        Annotations: annotations.(whisk.KeyValueArr),
+        Parameters:  parameters.(whisk.KeyValueArr),
       }
     } else {
       p = &whisk.SentPackageNoPublish{
         Name:        qName.entityName,
         Namespace:   qName.namespace,
         Publish:     shared,
-        Annotations: annotations,
-        Parameters:  parameters,
+        Annotations: annotations.(whisk.KeyValueArr),
+        Parameters:  parameters.(whisk.KeyValueArr),
       }
     }
 
@@ -262,10 +262,10 @@ var packageUpdateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing parameters: %#v\n", flags.common.param)
-    parameters, err := getJSONFromArguments(flags.common.param, true)
+    parameters, err := getJSONFromStrings(flags.common.param, true)
 
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.param, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
           map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
@@ -274,9 +274,9 @@ var packageUpdateCmd = &cobra.Command{
     }
 
     whisk.Debug(whisk.DbgInfo, "Parsing annotations: %#v\n", flags.common.annotation)
-    annotations, err := getJSONFromArguments(flags.common.annotation, true)
+    annotations, err := getJSONFromStrings(flags.common.annotation, true)
     if err != nil {
-      whisk.Debug(whisk.DbgError, "getJSONFromArguments(%#v, true) failed: %s\n", flags.common.annotation, err)
+      whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
       errStr := fmt.Sprintf(
         wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
           map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
@@ -290,16 +290,16 @@ var packageUpdateCmd = &cobra.Command{
         Name:        qName.entityName,
         Namespace:   qName.namespace,
         Publish:     shared,
-        Annotations: annotations,
-        Parameters:  parameters,
+        Annotations: annotations.(whisk.KeyValueArr),
+        Parameters:  parameters.(whisk.KeyValueArr),
       }
     } else {
       p = &whisk.SentPackageNoPublish{
         Name:        qName.entityName,
         Namespace:   qName.namespace,
         Publish:     shared,
-        Annotations: annotations,
-        Parameters:  parameters,
+        Annotations: annotations.(whisk.KeyValueArr),
+        Parameters:  parameters.(whisk.KeyValueArr),
       }
     }
 
@@ -561,17 +561,23 @@ var packageRefreshCmd = &cobra.Command{
 
 func init() {
   packageCreateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, wski18n.T("annotation values in `KEY VALUE` format"))
-  packageCreateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("default parameter values in `KEY VALUE` format"))
+  packageCreateCmd.Flags().StringVarP(&flags.common.annotFile, "annotation-file", "A", "", wski18n.T("`FILE` containing annotation values in JSON format"))
+  packageCreateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
+  packageCreateCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
   packageCreateCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("package visibility `SCOPE`; yes = shared, no = private"))
 
   packageUpdateCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, wski18n.T("annotation values in `KEY VALUE` format"))
-  packageUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("default parameter values in `KEY VALUE` format"))
+  packageUpdateCmd.Flags().StringVarP(&flags.common.annotFile, "annotation-file", "A", "", wski18n.T("`FILE` containing annotation values in JSON format"))
+  packageUpdateCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
+  packageUpdateCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
   packageUpdateCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("package visibility `SCOPE`; yes = shared, no = private"))
 
   packageGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize package details"))
 
   packageBindCmd.Flags().StringSliceVarP(&flags.common.annotation, "annotation", "a", []string{}, wski18n.T("annotation values in `KEY VALUE` format"))
-  packageBindCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("default parameter values in `KEY VALUE` format"))
+  packageBindCmd.Flags().StringVarP(&flags.common.annotFile, "annotation-file", "A", "", wski18n.T("`FILE` containing annotation values in JSON format"))
+  packageBindCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
+  packageBindCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 
   packageListCmd.Flags().StringVar(&flags.common.shared, "shared", "", wski18n.T("include publicly shared entities in the result"))
   packageListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of packages from the result"))

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -56,13 +56,7 @@ var ruleEnableCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
 
@@ -106,13 +100,7 @@ var ruleDisableCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
 
@@ -156,13 +144,7 @@ var ruleStatusCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
 
@@ -214,13 +196,7 @@ var ruleCreateCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
         triggerName := args[1]
@@ -278,13 +254,7 @@ var ruleUpdateCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
         triggerName := args[1]  //MWD qualified name?
@@ -343,13 +313,7 @@ var ruleGetCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
 
@@ -399,13 +363,7 @@ var ruleDeleteCmd = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
+
         client.Namespace = qName.namespace
         ruleName := qName.entityName
 

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -216,8 +216,8 @@
     "translation": "annotation values in `KEY VALUE` format"
   },
   {
-    "id": "default parameter values in `KEY VALUE` format",
-    "translation": "default parameter values in `KEY VALUE` format"
+    "id": "`FILE` containing annotation values in JSON format",
+    "translation": "`FILE` containing annotation values in JSON format"
   },
   {
     "note-to-translators": "DO NOT TRANSLATE THE 'yes' AND 'no'.  THOSE ARE FIXED CLI ARGUMENT VALUES",
@@ -680,6 +680,10 @@
     "translation": "parameter values in `KEY VALUE` format"
   },
   {
+    "id": "`FILE` containing parameter values in JSON format",
+    "translation": "`FILE` containing parameter values in JSON format"
+  },
+  {
     "id": "Arguments must be comma separated, and must be quoted if they contain spaces.",
     "translation": "Arguments must be comma separated, and must be quoted if they contain spaces."
   },
@@ -1110,5 +1114,9 @@
   {
     "id": "default",
     "translation": "default"
+  },
+  {
+    "id": "An argument must be provided for '{{.arg}}'",
+    "translation": "An argument must be provided for '{{.arg}}'"
   }
 ]

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -20,7 +20,6 @@ import (
     "fmt"
     "net/http"
     "errors"
-    "encoding/json"
     "net/url"
     "../wski18n"
 )
@@ -35,8 +34,8 @@ type Action struct {
     Version     string              `json:"version,omitempty"`
     Publish     bool                `json:"publish"`
     Exec        *Exec               `json:"exec,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
     Limits      *Limits             `json:"limits,omitempty"`
 }
 
@@ -44,9 +43,9 @@ type SentActionPublish struct {
     Namespace   string              `json:"-"`
     Version     string              `json:"-"`
     Publish     bool                `json:"publish"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
+    Annotations KeyValueArr        `json:"annotations,omitempty"`
     Exec        *Exec               `json:"exec,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
     Limits      *Limits             `json:"limits,omitempty"`
     Error       string              `json:"error,omitempty"`
     Code        int                 `json:"code,omitempty"`
@@ -56,9 +55,9 @@ type SentActionNoPublish struct {
     Namespace   string              `json:"-"`
     Version     string              `json:"-"`
     Publish     bool                `json:"publish,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
     Exec        *Exec               `json:"exec,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
     Limits      *Limits             `json:"limits,omitempty"`
     Error       string              `json:"error,omitempty"`
     Code        int                 `json:"code,omitempty"`
@@ -226,7 +225,7 @@ func (s *ActionService) Delete(actionName string) (*http.Response, error) {
     return resp, nil
 }
 
-func (s *ActionService) Invoke(actionName string, payload *json.RawMessage, blocking bool) (*Activation, *http.Response, error) {
+func (s *ActionService) Invoke(actionName string, payload interface{}, blocking bool) (*Activation, *http.Response, error) {
     // Encode resource name as a path (with no query params) before inserting it into the URI
     // This way any '?' chars in the name won't be treated as the beginning of the query params
     actionName = (&url.URL{Path: actionName}).String()

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -20,7 +20,6 @@ import (
     "fmt"
     "net/http"
     "errors"
-    "encoding/json"
     "net/url"
     "../wski18n"
 )
@@ -34,15 +33,14 @@ type Activation struct {
     Name      string `json:"name"`
     Version   string `json:"version"`
     Publish   bool   `json:"publish"`
-
-    Subject      string `json:"subject"`
-    ActivationID string `json:"activationId"`
-    Cause        string `json:"cause,omitempty"`
-    Start        int64  `json:"start"`        // When action started (in milliseconds since January 1, 1970 UTC)
-    End          int64  `json:"end"`                    // Since a 0 is a valid value from server, don't omit
-    Response     `json:"response"`
-    Logs         []string `json:"logs"`
-    Annotations *json.RawMessage `json:"annotations"`
+    Subject         string `json:"subject"`
+    ActivationID    string `json:"activationId"`
+    Cause           string `json:"cause,omitempty"`
+    Start           int64  `json:"start"`        // When action started (in milliseconds since January 1, 1970 UTC)
+    End             int64  `json:"end"`                    // Since a 0 is a valid value from server, don't omit
+    Response        `json:"response"`
+    Logs            []string `json:"logs"`
+    Annotations     KeyValueArr `json:"annotations"`
 }
 
 type Response struct {

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -67,7 +67,7 @@ func NewClient(httpClient *http.Client, config *Config) (*Client, error) {
 
     // Disable certificate checking in the dev environment if in insecure mode
     if config.Insecure {
-        Debug(DbgInfo, "Disabling certificate checking.")
+        Debug(DbgInfo, "Disabling certificate checking.\n")
 
         tlsConfig := &tls.Config{
             InsecureSkipVerify: true,
@@ -86,7 +86,7 @@ func NewClient(httpClient *http.Client, config *Config) (*Client, error) {
     if config.BaseURL == nil {
         config.BaseURL, err = url.Parse(defaultBaseURL)
         if err != nil {
-            Debug(DbgError, "url.Parse(%s) error: %s", defaultBaseURL, err)
+            Debug(DbgError, "url.Parse(%s) error: %s\n", defaultBaseURL, err)
             errStr := wski18n.T("Unable to create request URL '{{.url}}': {{.err}}",
                 map[string]interface{}{"url": defaultBaseURL, "err": err})
             werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)

--- a/tools/cli/go-whisk/whisk/package.go
+++ b/tools/cli/go-whisk/whisk/package.go
@@ -21,7 +21,6 @@ import (
     "net/http"
     "net/url"
     "errors"
-    "encoding/json"
     "../wski18n"
 )
 
@@ -39,8 +38,8 @@ type SentPackagePublish struct {
     Name        string              `json:"-"`
     Version     string              `json:"version,omitempty"`
     Publish     bool                `json:"publish"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
 }
 func (p *SentPackagePublish) GetName() string {
     return p.Name
@@ -52,8 +51,8 @@ type SentPackageNoPublish struct {
     Name        string              `json:"-"`
     Version     string              `json:"version,omitempty"`
     Publish     bool                `json:"publish,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
 }
 func (p *SentPackageNoPublish) GetName() string {
     return p.Name
@@ -66,8 +65,8 @@ type Package struct {
     Name        string              `json:"name,omitempty"`
     Version     string              `json:"version,omitempty"`
     Publish     bool                `json:"publish"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
     Binding                         `json:"binding,omitempty"`
     Actions     []Action            `json:"actions,omitempty"`
     Feeds       []Action            `json:"feeds,omitempty"`
@@ -83,8 +82,8 @@ type BindingPackage struct {
     Name        string              `json:"-"`
     Version     string              `json:"version,omitempty"`
     Publish     bool                `json:"publish"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
     Binding                         `json:"binding"`
 }
 func (p *BindingPackage) GetName() string {
@@ -97,9 +96,6 @@ type Binding struct {
 }
 
 type BindingUpdates struct {
-    //Added   []Binding `json:"added,omitempty"`
-    //Updated []Binding `json:"updated,omitempty"`
-    //Deleted []Binding `json:"deleted,omitempty"`
     Added   []string `json:"added,omitempty"`
     Updated []string `json:"updated,omitempty"`
     Deleted []string `json:"deleted,omitempty"`

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -30,14 +30,13 @@ type RuleService struct {
 }
 
 type Rule struct {
-    Namespace string `json:"namespace,omitempty"`
-    Name      string `json:"name,omitempty"`
-    Version   string `json:"version,omitempty"`
-    Publish   bool   `json:"publish,omitempty"`
-
-    Status  string `json:"status"`
-    Trigger string `json:"trigger"`
-    Action  string `json:"action"`
+    Namespace string    `json:"namespace,omitempty"`
+    Name      string    `json:"name,omitempty"`
+    Version   string    `json:"version,omitempty"`
+    Publish   bool      `json:"publish,omitempty"`
+    Status  string      `json:"status"`
+    Trigger string      `json:"trigger"`
+    Action  string      `json:"action"`
 }
 
 type RuleListOptions struct {

--- a/tools/cli/go-whisk/whisk/shared.go
+++ b/tools/cli/go-whisk/whisk/shared.go
@@ -19,20 +19,14 @@ package whisk
 import "encoding/json"
 
 type KeyValue struct {
-    Key   string        `json:"key,omitempty"`
-    Value interface{}   `json:"value"`     // Whisk permits empty values, do not add 'omitempty'
+    Key  string         `json:"key"`
+    Value interface{}   `json:"value"`
 }
 
-type KeyValues struct {
-    Key     string `json:"key,omitempty"`
-    Values  []string `json:"value,omitempty"`
-}
+type KeyValueArr []KeyValue
 
 type Annotations []map[string]interface{}
 
-type ActionSequence []KeyValues
-
-//type Parameters []KeyValue
 type Parameters *json.RawMessage
 
 type Limits struct {

--- a/tools/cli/go-whisk/whisk/trigger.go
+++ b/tools/cli/go-whisk/whisk/trigger.go
@@ -20,7 +20,6 @@ import (
     "fmt"
     "net/http"
     "errors"
-    "encoding/json"
     "net/url"
     "../wski18n"
 )
@@ -35,8 +34,8 @@ type Trigger struct {
     Version   string                `json:"version,omitempty"`
     Publish   bool                  `json:"publish,omitempty"`
     ActivationId string             `json:"activationId,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations,omitempty"`
-    Parameters  *json.RawMessage    `json:"parameters,omitempty"`
+    Annotations KeyValueArr         `json:"annotations,omitempty"`
+    Parameters  KeyValueArr         `json:"parameters,omitempty"`
     //Limits                        `json:"limits,omitempty"`
 }
 
@@ -46,8 +45,8 @@ type TriggerFromServer struct {
     Version   string                `json:"version"`
     Publish   bool                  `json:"publish"`
     ActivationId string             `json:"activationId,omitempty"`
-    Annotations *json.RawMessage    `json:"annotations"`
-    Parameters  *json.RawMessage    `json:"parameters"`
+    Annotations KeyValueArr         `json:"annotations"`
+    Parameters  KeyValueArr         `json:"parameters"`
     Limits                          `json:"limits"`
 }
 
@@ -174,7 +173,7 @@ func (s *TriggerService) Delete(triggerName string) (*TriggerFromServer, *http.R
     return t, resp, nil
 }
 
-func (s *TriggerService) Fire(triggerName string, payload *json.RawMessage) (*TriggerFromServer, *http.Response, error) {
+func (s *TriggerService) Fire(triggerName string, payload interface{}) (*TriggerFromServer, *http.Response, error) {
     // Encode resource name as a path (with no query params) before inserting it into the URI
     // This way any '?' chars in the name won't be treated as the beginning of the query params
     triggerName = (&url.URL{Path: triggerName}).String()


### PR DESCRIPTION
- Pass JSON files to parameters and annotations
  - Add tests to ensure file input works as desired
- Refactor parameter and annotation handling
  - Use KeyValueArr data type to store annotations and parameters
- Refactor summaries for get commands
  - Use KeyValueArr data type to get annotations and parameters
- Refactor parameter and annotation tests
  - Order of params and annots are not guaranteed in Go map data structures
- Fixes: #426

