### PR TITLE
update reference on docker skeleton to use alpine image

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -265,6 +265,7 @@ This example invokes a Yahoo Weather service to get the current conditions at a 
 
   This example also shows the need for asynchronous actions. The action returns a Promise to indicate that the result of this action is not available yet when the function returns. Instead, the result is available in the `request` callback after the HTTP call completes, and is passed as an argument to the `resolve()` function.
 
+
 2. Run the following commands to create the action and invoke it:
   ```
   $ wsk action create weather weather.js
@@ -480,6 +481,7 @@ $ wsk action invoke --blocking --result helloJava --param name World
 
 **Note:** If the JAR file has more than one class with a main method matching required signature, the CLI tool uses the first one reported by `jar -tf`.
 
+
 ## Creating Docker actions
 
 With OpenWhisk Docker actions, you can write your actions in any language.
@@ -546,14 +548,15 @@ For the instructions that follow, assume that the Docker user ID is `janesmith` 
   Notice that part of the example.c file is compiled as part of the Docker image build process, so you do not need C compiled on your machine.
   In fact, unless you are compiling the binary on a compatible host machine, it may not run inside the container since formats will not match.
 
-Your Docker container may now be used as an OpenWhisk action.
+  Your Docker container may now be used as an OpenWhisk action.
+
 
   ```
   $ wsk action create --docker example janesmith/blackboxdemo
   ```
 
-Notice the use of `--docker` when creating an action. Currently all Docker images are assumed to be hosted on Docker Hub.
-The action may be invoked as any other OpenWhisk action.
+  Notice the use of `--docker` when creating an action. Currently all Docker images are assumed to be hosted on Docker Hub.
+  The action may be invoked as any other OpenWhisk action.
 
   ```
   $ wsk action invoke --blocking --result example --param payload Rey
@@ -567,7 +570,9 @@ The action may be invoked as any other OpenWhisk action.
   }
   ```
 
-If you update the Docker image, run `buildAndPush.sh` to refresh the image on Docker Hub, then run `wsk action update` to make the system to fetch the new image. New invocations will start using the new image and not a warm image with the old code.
+  To update the Docker action, run buildAndPush.sh to refresh the image on Docker Hub, this will allow the next time the system pulls your Docker image to run the new code for your action. 
+  If there are no warm containers any new invocations will use the new Docker image. 
+  Take into account that if there is a warm container using a previous version of your Docker image, any new invocations will continue to use this image unless you run wsk action update, this will indicate to the system that for any new invocations force a docekr pull resulting on pulling your new Docker image.
 
   ```
   $ ./buildAndPush.sh janesmith/blackboxdemo
@@ -576,7 +581,7 @@ If you update the Docker image, run `buildAndPush.sh` to refresh the image on Do
   $ wsk action update --docker example janesmith/blackboxdemo
   ```
 
-You can find more information about creating Docker actions in the [References](./reference.md#docker-actions) section.
+  You can find more information about creating Docker actions in the [References](./reference.md#docker-actions) section.
 
 
 ## Watching action output

--- a/docs/mobile_sdk.md
+++ b/docs/mobile_sdk.md
@@ -6,9 +6,10 @@ OpenWhisk provides a mobile SDK for iOS and watchOS 2 devices that enables mobil
 The mobile SDK is written in Swift 2.2 and supports iOS 9 and later releases.
 
 ## Adding the SDK to your app
+
 You can install the mobile SDK by using CocoaPods, Carthage, or from the source directory.
 
-### Installing by using CocoaPods
+### Installing by using CocoaPods 
 
 The OpenWhisk SDK for mobile is available for public distribution through CocoaPods. Assuming CocoaPods is installed, put the following lines into a file called 'Podfile' inside the starter app project directory. 
 
@@ -28,6 +29,7 @@ end
 From the command line, type `pod install`. This command installs the SDK for an iOS app with a watchOS 2 extension.  Use the workspace file CocoaPods creates for your app to open the project in Xcode.
 
 ### Installing by using Carthage
+
 Create a file in your app's project directory and name it 'Cartfile'. Put the following line in the file:
 ```
 github "openwhisk/openwhisk-client-swift.git" ~> 0.1.7 # Or latest version

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -84,7 +84,7 @@ Every invocation that is successfully received, and that the user might be bille
 Note that in the case of *action developer error*, the action may have partially run and generated externally visible
 side effects.   It is the user's responsibility to check whether such side effects actually happened, and issue retry
 logic if desired.   Also note that certain *whisk internal errors* will indicate that an action started running but the
-system failed before the action registered completion.    
+system failed before the action registered completion.
 
 ## Activation record
 
@@ -200,11 +200,11 @@ The `whisk.invoke()` function invokes another action. It takes as an argument a 
 
 - *name*: The fully qualified name of the action to invoke,
 - *parameters*: A JSON object that represents the input to the invoked action. If omitted, defaults to an empty object.
-- *apiKey*: The authorization key with which to invoke the action. Defaults to `whisk.getAuthKey()`.
+- *apiKey*: The authorization key with which to invoke the action. Defaults to `whisk.getAuthKey()`. 
 - *blocking*: Whether the action should be invoked in blocking or non-blocking mode. Defaults to `false`, indicating a non-blocking invocation.
 - *next*: An optional callback function to be executed when the invocation completes. If next is not supplied, `whisk.invoke()` returns a promise.
 
-  The signature for `next` is `function(error, activation)`, where:
+The signature for `next` is `function(error, activation)`, where:
 
   - `error` is `false` if the invocation succeeded, and a *truthy* value (a value that translates to true when evaluated in a Boolean context) if it failed, usually a string that describes the error.
   - On errors, `activation` might be undefined, depending on the failure mode.
@@ -248,11 +248,11 @@ The `whisk.trigger()` function fires a trigger. It takes as an argument a JSON o
 - *apiKey*: The authorization key with which to fire the trigger. Defaults to `whisk.getAuthKey()`.
 - *next*: An optional callback to be executed when the firing completes.
 
-  The signature for `next` is `function(error, activation)`, where:
+The signature for `next` is `function(error, activation)`, where:
 
-  - `error` is `false` if the firing succeeded, and a *truthy* value  if it failed, usually a string that describes the error.
-  - On errors, `activation` might be undefined, depending on the failure mode.
-  - When defined, `activation` is a dictionary with an `activationId` field that contains the activation ID.
+- `error` is `false` if the firing succeeded, and a *truthy* value  if it failed, usually a string that describes the error.
+- On errors, `activation` might be undefined, depending on the failure mode.
+- When defined, `activation` is a dictionary with an `activationId` field that contains the activation ID.
 
   If `next` is not provided, then `whisk.trigger()` returns a promise.
   - If the trigger fails, the promise will reject with an object describing the error.
@@ -354,7 +354,7 @@ The following packages are available to be used in the Node.js 0.12.14 environme
 
 ## Docker actions
 
-Docker actions run a user-supplied binary in a Docker container. The binary runs in a Docker image based on Ubuntu 14.04 LTD, so the binary must be compatible with this distribution.
+Docker actions run a user-supplied binary in a Docker container. The binary runs in a Docker image based on [python:2.7.12-alpine](https://hub.docker.com/r/library/python), so the binary must be compatible with this distribution.
 
 The Docker skeleton is a convenient way to build OpenWhisk-compatible Docker images. You can install the skeleton with the `wsk sdk install docker` CLI command.
 
@@ -418,7 +418,6 @@ $ curl -u USERNAME:PASSWORD https://openwhisk.ng.bluemix.net/api/v1/namespaces/w
   ...
 ]
 ```
-
 The OpenWhisk API supports request-response calls from web clients. OpenWhisk responds to `OPTIONS` requests with Cross-Origin Resource Sharing headers. Currently, all origins are allowed (that is, Access-Control-Allow-Origin is "`*`") and Access-Control-Allow-Headers yield Authorization and Content-Type.
 
 **Attention:** Because OpenWhisk currently supports only one key per account, it is not recommended to use CORS beyond simple experiments. Your key would need to be embedded in client-side code, making it visible to the public. Use with caution.

--- a/docs/triggers_rules.md
+++ b/docs/triggers_rules.md
@@ -109,7 +109,7 @@ As an example, create a rule that calls the hello action whenever a location upd
   $ wsk rule create myRule locationUpdate hello
   ```
 
-At any time, you can choose to disable a rule.
+  At any time, you can choose to disable a rule.
   ```
   $ wsk rule disable myRule
   ```


### PR DESCRIPTION
Fixes #1177 

@rabbah should we mention just alpine or say that they can use any, or maybe don't mention anything about the specific base image and put more info on the protocol contract that image should follow.
