### PR TITLE
Move starting counter to where it should be.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
@@ -138,7 +138,6 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
         response map {
             case (code, contents) =>
                 logger.debug(this, s"response: '$contents'")
-                print(code, contents)
                 Try { contents.parseJson.asJsObject } match {
                     case scala.util.Success(result @ JsObject(fields)) =>
                         // If the response is a JSON object container an error field, accept it as the response error.

--- a/core/dispatcher/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
@@ -70,6 +70,7 @@ protected class ActivationFeed(
 
     private val pipelineFillThreshold = maxPipelineDepth - consumer.maxPeek
     private var pipelineOccupancy = 0
+    private implicit val tid = TransactionId.dispatcher
 
     override def receive = {
         case FillQueueWithMessages =>
@@ -89,7 +90,7 @@ protected class ActivationFeed(
                     case (records, count) =>
                         records foreach {
                             case (topic, partition, offset, bytes) =>
-                                logging.info(this, s"processing $topic[$partition][$offset ($count)]")(TransactionId.dispatcher)
+                                logging.info(this, s"processing $topic[$partition][$offset ($count)]")
                                 pipelineOccupancy += 1
                                 handler(topic, bytes)
                         }
@@ -107,10 +108,10 @@ protected class ActivationFeed(
 
     private def fill() = {
         if (pipelineOccupancy <= pipelineFillThreshold) {
-            logging.debug(this, s"filling activation pipeline: $pipelineOccupancy <= $pipelineFillThreshold")(TransactionId.dispatcher)
+            logging.debug(this, s"filling activation pipeline: $pipelineOccupancy <= $pipelineFillThreshold")
             self ! FillQueueWithMessages
         } else {
-            logging.info(this, s"waiting for activation pipeline to drain: $pipelineOccupancy > $pipelineFillThreshold")(TransactionId.dispatcher)
+            logging.info(this, s"waiting for activation pipeline to drain: $pipelineOccupancy > $pipelineFillThreshold")
         }
     }
 }

--- a/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -70,7 +70,6 @@ import whisk.core.dispatcher.ActivationFeed.ContainerReleased
 import whisk.core.dispatcher.ActivationFeed.FailedActivation
 import whisk.core.dispatcher.DispatchRule
 import whisk.core.dispatcher.Dispatcher
-import whisk.core.entity.ActivationId
 import whisk.core.entity.ActivationLogs
 import whisk.core.entity.ActivationResponse
 import whisk.core.entity.BlackBoxExec
@@ -334,7 +333,8 @@ class Invoker(
      *
      * Note: Updates the container's log cursor to indicate consumption of log.
      */
-    private def getContainerLogs(con: WhiskContainer, sentinelled: Boolean, loglimit: LogLimit, tries: Int = LogRetryCount)(implicit transid: TransactionId): JsArray = {
+    private def getContainerLogs(con: WhiskContainer, sentinelled: Boolean, loglimit: LogLimit, tries: Int = LogRetryCount)(
+        implicit transid: TransactionId): JsArray = {
         val size = con.getLogSize(runningInContainer)
         val advanced = size != con.lastLogSize
         if (tries <= 0 || advanced) {
@@ -422,7 +422,7 @@ class Invoker(
         }
     }
 
-    private def incrementUserActivationCounter(user: Subject): Int = {
+    private def incrementUserActivationCounter(user: Subject)(implicit transid: TransactionId): Int = {
         val count = userActivationCounter get user() match {
             case Some(counter) => counter.next()
             case None =>


### PR DESCRIPTION
Fixes two problems:

1. starting container counter incorrectly incremented when action gets a stem cell container; this should not be the case and over accounts for active containers. Moved the counter into the docker serializer where it will correctly account for the new container. The counter is inside the synchronized region rather than outside may allow more actions to try and make progress but will these will serialize on the docker lock anyway.

2. the activation counting had a race and was off by ~1 (approximately because the initialization was wrong and how many counters are created depends on the number of concurrent activations for a specific user).