### PR TITLE
Always use Default Locale

### DIFF
--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -89,6 +89,12 @@ class WskBasicUsageTests
         }
     }
 
+    it should "show help and usage info using the default language" in {
+        val env = Map("LANG" -> "de_DE")
+        // Call will fail with exit code 2 if language not supported
+        wsk.cli(Seq("-h"), env = env)
+    }
+
     it should "show cli build version" in {
         val stdout = wsk.cli(Seq("property", "get", "--cliversion")).stdout
         stdout should include regex ("""(?i)whisk CLI version\s+201.*""")

--- a/tools/go-cli/go-whisk-cli/wski18n/i18n.go
+++ b/tools/go-cli/go-whisk-cli/wski18n/i18n.go
@@ -63,7 +63,8 @@ func CurLocale() string {
 
 func Locale(detector Detector) string {
 
-    sysLocale := normalize(detector.DetectLocale())
+    // Use default locale until strings are translated
+    /*sysLocale := normalize(detector.DetectLocale())
     if isSupported(sysLocale) {
         return sysLocale
     }
@@ -71,7 +72,7 @@ func Locale(detector Detector) string {
     locale := defaultLocaleForLang(detector.DetectLanguage())
     if locale != "" {
         return locale
-    }
+    }*/
 
     return DEFAULT_LOCALE
 }

--- a/tools/go-cli/go-whisk/wski18n/i18n.go
+++ b/tools/go-cli/go-whisk/wski18n/i18n.go
@@ -63,7 +63,8 @@ func CurLocale() string {
 
 func Locale(detector Detector) string {
 
-    sysLocale := normalize(detector.DetectLocale())
+    // Use default locale until strings are translated
+    /*sysLocale := normalize(detector.DetectLocale())
     if isSupported(sysLocale) {
         return sysLocale
     }
@@ -71,7 +72,7 @@ func Locale(detector Detector) string {
     locale := defaultLocaleForLang(detector.DetectLanguage())
     if locale != "" {
         return locale
-    }
+    }*/
 
     return DEFAULT_LOCALE
 }


### PR DESCRIPTION
- Use the default language en_US until externalized messages are translated
- Fixes: https://github.com/openwhisk/openwhisk/issues/1183
- PG2 80