### PR TITLE
Localize `isOverload` check to ActivationThrottle

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -22,6 +22,7 @@ limits:
     invokes:
       perMinute: 60
       concurrent: 30
+      concurrentInSystem: 5000
   triggers:
     fires:
       perMinute: 60

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -12,6 +12,7 @@ defaultLimits:
     invokes:
       perMinute: 120
       concurrent: 100
+      concurrentInSystem: 5000
   triggers:
     fires:
       perMinute: 60

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -17,10 +17,12 @@ whisk.ssl.challenge=openwhisk
 defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinute }}
 defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
 defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
+defaultLimits.actions.invokes.concurrentInSystem={{ defaultLimits.actions.invokes.concurrentInSystem }}
 
 {% if limits is defined %}
 limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
 limits.actions.invokes.concurrent={{ limits.actions.invokes.concurrent }}
+limits.actions.invokes.concurrentInSystem={{ limits.actions.invokes.concurrentInSystem }}
 limits.triggers.fires.perMinute={{ limits.triggers.fires.perMinute }}
 {% endif %}
 

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -109,7 +109,7 @@ class WhiskConfig(
     val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteDefaultLimit, WhiskConfig.actionInvokePerMinuteLimit)
     val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentDefaultLimit, WhiskConfig.actionInvokeConcurrentLimit)
     val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit, WhiskConfig.triggerFirePerMinuteLimit)
-
+    val actionInvokeSystemOverloadLimit = this(WhiskConfig.actionInvokeSystemOverloadDefaultLimit, WhiskConfig.actionInvokeSystemOverloadLimit)
 }
 
 object WhiskConfig extends Logging {
@@ -263,10 +263,12 @@ object WhiskConfig extends Logging {
 
     val actionInvokePerMinuteDefaultLimit = "defaultLimits.actions.invokes.perMinute"
     val actionInvokeConcurrentDefaultLimit = "defaultLimits.actions.invokes.concurrent"
+    val actionInvokeSystemOverloadDefaultLimit = "defaultLimits.actions.invokes.concurrentInSystem"
     val triggerFirePerMinuteDefaultLimit = "defaultLimits.triggers.fires.perMinute"
 
     val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
     val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
+    val actionInvokeSystemOverloadLimit = "limits.actions.invokes.concurrentInSystem"
     val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
 
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -18,10 +18,8 @@ package whisk.core.entitlement
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
 
 import Privilege.Privilege
 import Privilege.ACTIVATE
@@ -31,12 +29,8 @@ import akka.event.Logging.LogLevel
 import spray.http.StatusCodes.ClientError
 import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.TooManyRequests
-import spray.json.DefaultJsonProtocol.BooleanJsonFormat
-import spray.json.pimpString
 import whisk.common.ConsulClient
-import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.Logging
-import whisk.common.Scheduler
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.controller.RejectRequest
@@ -75,12 +69,14 @@ protected[core] object EntitlementService {
     val requiredProperties = WhiskConfig.consulServer ++ WhiskConfig.entitlementHost ++ Map(
         WhiskConfig.actionInvokePerMinuteDefaultLimit -> null,
         WhiskConfig.actionInvokeConcurrentDefaultLimit -> null,
-        WhiskConfig.triggerFirePerMinuteDefaultLimit -> null)
+        WhiskConfig.triggerFirePerMinuteDefaultLimit -> null,
+        WhiskConfig.actionInvokeSystemOverloadDefaultLimit -> null)
 
     val optionalProperties = Set(
         WhiskConfig.actionInvokePerMinuteLimit,
         WhiskConfig.actionInvokeConcurrentLimit,
-        WhiskConfig.triggerFirePerMinuteLimit)
+        WhiskConfig.triggerFirePerMinuteLimit,
+        WhiskConfig.actionInvokeSystemOverloadLimit)
 
     /**
      * The default list of namespaces for a subject.
@@ -96,27 +92,11 @@ protected[core] abstract class EntitlementService(config: WhiskConfig)(
 
     private implicit val executionContext = actorSystem.dispatcher
 
-    private var loadbalancerOverload: Boolean = false
-
     private val invokeRateThrottler = new RateThrottler(config.actionInvokePerMinuteLimit.toInt)
     private val triggerRateThrottler = new RateThrottler(config.triggerFirePerMinuteLimit.toInt)
-    private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, config.actionInvokeConcurrentLimit.toInt)
-
-    /** query the KV store this often */
-    private val overloadCheckPeriod = 10.seconds
+    private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, config.actionInvokeConcurrentLimit.toInt, config.actionInvokeSystemOverloadLimit.toInt)
 
     private val consul = new ConsulClient(config.consulServer)
-
-    Scheduler.scheduleWaitAtLeast(overloadCheckPeriod) { () =>
-        consul.kv.get(LoadBalancerKeys.overloadKey).map { isOverloaded =>
-            Try(isOverloaded.parseJson.convertTo[Boolean]) foreach { v =>
-                if (loadbalancerOverload != v) {
-                    loadbalancerOverload = v
-                    warn(this, s"loadbalancerOverload = ${v}")(TransactionId.loadbalancer)
-                }
-            }
-        }
-    }
 
     override def setVerbosity(level: LogLevel) = {
         super.setVerbosity(level)
@@ -228,8 +208,9 @@ protected[core] abstract class EntitlementService(config: WhiskConfig)(
 
     /** Limits activations if the load balancer is overloaded. */
     protected def checkSystemOverload(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = {
-        val systemOverload = right == ACTIVATE && loadbalancerOverload
+        val systemOverload = right == ACTIVATE && concurrentInvokeThrottler.isOverloaded
         if (systemOverload) {
+            error(this, "system is overloaded")
             Some {
                 Future failed ThrottleRejectRequest(TooManyRequests, Some(ErrorResponse(systemOverloaded, transid)))
             }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -102,9 +102,12 @@ class InvokerHealth(
         curStatus.get() map { _.index }
     }
 
-    def getInvokerActivationCounts(): Array[(Int, Int)] = {
-        curStatus.get() map { status => (status.index, status.activationCount) }
-    }
+    /**
+     * The current Activation count per Invoker.
+     */
+    def getInvokerActivationCounts(): Map[Int, Int] = curStatus.get().map { status =>
+        status.index -> status.activationCount
+    }.toMap
 
     private def getHealth(statuses: Array[Status]): Array[(Int, Boolean)] = {
         statuses map { status => (status.index, status.status) }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerToKafka.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerToKafka.scala
@@ -99,11 +99,7 @@ trait LoadBalancerToKafka extends Logging {
     }
 
     // Make a new immutable map so caller cannot mess up the state
-    def getIssueCountByInvoker(): Map[Int, Int] = {
-        invokerActivationCounter.foldLeft(Map[Int, Int]()) {
-            case (map, (index, counter)) => map ++ Map(index -> counter.cur)
-        }
-    }
+    def getIssueCountByInvoker(): Map[Int, Int] = invokerActivationCounter.readOnlySnapshot.mapValues(_.cur).toMap
 
     /**
      * Convert user activation counters into a map of JsObjects to be written into consul kv


### PR DESCRIPTION
Reduces the load on consul by not unnecessarily getting system-overload information out of it. This information is already in the controller anyway.

- Some refactoring around loadbalancer health logging
- Reducing loglevel of one log to info (was warn)