### PR TITLE
Adding `requests` to the python container

### DIFF
--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -3,6 +3,9 @@ FROM dockerskeleton
 
 RUN apk add --no-cache python-dev
 
+# Install common modules for python
+RUN pip install requests
+
 ENV FLASK_PROXY_PORT 8080
 
 RUN mkdir -p /pythonAction


### PR DESCRIPTION
- Add the requests module to the python container
- Add tests to assert that module installation for the python container works as expected.

Solves #1190