### PR TITLE
Display More Informative Error Messages for Bad HTTP Requests and Update "Namespace Get"

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -27,6 +27,7 @@ import common.TestUtils
 import common.TestUtils.CONFLICT
 import common.TestUtils.SUCCESS_EXIT
 import common.TestUtils.UNAUTHORIZED
+import common.TestUtils.FORBIDDEN
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
@@ -446,5 +447,12 @@ class WskBasicTests
         // the default namespace
         wsk.namespace.get(expectedExitCode = SUCCESS_EXIT)(WskProps()).
             stdout should include("default")
+    }
+
+    it should "not list entities with an invalid namespace" in {
+        val namespace = "fakeNamespace"
+        val stderr = wsk.namespace.get(Some(s"/${namespace}"), expectedExitCode = FORBIDDEN).stderr
+
+        stderr should include (s"Unable to obtain the list of entities for namespace '${namespace}'")
     }
 }

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -357,9 +357,8 @@ var actionListCmd = &cobra.Command{
     actions, _, err := client.Actions.List(qName.entityName, options)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.List(%s, %#v) error: %s\n", qName.entityName, options, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to list action(s): {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to obtain the list of actions for namespace '{{.name}}': {{.err}}",
+          map[string]interface{}{"name": getClientNamespace(), "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr

--- a/tools/cli/go-whisk-cli/commands/activation.go
+++ b/tools/cli/go-whisk-cli/commands/activation.go
@@ -91,10 +91,10 @@ var activationListCmd = &cobra.Command{
         activations, _, err := client.Activations.List(options)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Activations.List() error: %s\n", err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain list of activations: {{.err}}",
-                    map[string]interface{}{"err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            errStr := wski18n.T("Unable to obtain the list of activations for namespace '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": getClientNamespace(), "err": err})
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
 

--- a/tools/cli/go-whisk-cli/commands/namespace.go
+++ b/tools/cli/go-whisk-cli/commands/namespace.go
@@ -50,7 +50,7 @@ var namespaceListCmd = &cobra.Command{
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Namespaces.List() error: %s\n", err)
             errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain list of available namespaces: {{.err}}",
+                wski18n.T("Unable to obtain the list of available namespaces: {{.err}}",
                     map[string]interface{}{"err": err}))
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -90,24 +90,18 @@ var namespaceGetCmd = &cobra.Command{
         }
 
         namespace, _, err := client.Namespaces.Get(qName.namespace)
+
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Namespaces.Get(%s) error: %s\n", qName.namespace, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain namespace entities for namespace '{{.namespace}}': {{.err}}",
-                    map[string]interface{}{"namespace": qName.namespace, "err":err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            whisk.Debug(whisk.DbgError, "client.Namespaces.Get(%s) error: %s\n", getClientNamespace(), err)
+            errStr := wski18n.T("Unable to obtain the list of entities for namespace '{{.namespace}}': {{.err}}",
+                    map[string]interface{}{"namespace": getClientNamespace(), "err": err})
+            werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
 
-        fmt.Printf(wski18n.T("Entities in namespace: "))
-
-        if (qName.namespace != "_") {
-            fmt.Fprintf(color.Output, "%s\n", boldString(namespace.Name))
-        } else {
-            fmt.Fprintf(color.Output, "%s\n", boldString("default"))
-        }
-
-
+        fmt.Fprintf(color.Output, wski18n.T("Entities in namespace: {{.namespace}}\n",
+            map[string]interface{}{"namespace": boldString(getClientNamespace())}))
         printList(namespace.Contents.Packages)
         printList(namespace.Contents.Actions)
         printList(namespace.Contents.Triggers)
@@ -119,7 +113,7 @@ var namespaceGetCmd = &cobra.Command{
 
 var listCmd = &cobra.Command{
     Use:   "list",
-    Short: wski18n.T("list available namespaces"),
+    Short: wski18n.T("list entities in the current namespace"),
     SilenceUsage:   true,
     SilenceErrors:  true,
     PreRunE: setupClientConfig,

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -458,8 +458,8 @@ var packageListCmd = &cobra.Command{
     packages, _, err := client.Packages.List(options)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.List(%+v) failed: %s\n", options, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Unable to obtain package list: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Unable to obtain the list of packages for namespace '{{.name}}': {{.err}}",
+          map[string]interface{}{"name": getClientNamespace(), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -480,9 +480,8 @@ var ruleListCmd = &cobra.Command{
         rules, _, err := client.Rules.List(ruleListOptions)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.List(%#v) error: %s\n", ruleListOptions, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain list of rules: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errStr := wski18n.T("Unable to obtain the list of rules for namespace '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": getClientNamespace(), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -581,10 +581,10 @@ var triggerListCmd = &cobra.Command{
         }
         triggers, _, err := client.Triggers.List(options)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Triggers.List(%#v) for namespace '%s' failed: %s\n", options, client.Namespace, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain the trigger list for namespace '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": client.Namespace, "err": err}))
+            whisk.Debug(whisk.DbgError, "client.Triggers.List(%#v) for namespace '%s' failed: %s\n", options,
+                client.Namespace, err)
+            errStr := wski18n.T("Unable to obtain the list of triggers for namespace '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": getClientNamespace(), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -834,3 +834,15 @@ func getURLBase(host string) (*url.URL, error)  {
 
     return url, err
 }
+
+func normalizeNamespace(namespace string) (string) {
+    if (namespace == "_") {
+        namespace = wski18n.T("default")
+    }
+
+    return namespace
+}
+
+func getClientNamespace() (string) {
+    return normalizeNamespace(client.Config.Namespace)
+}

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -68,12 +68,12 @@
     "translation": "work with namespaces"
   },
   {
-    "id": "list available namespaces",
-    "translation": "list available namespaces"
+    "id": "list entities in the current namespace",
+    "translation": "list entities in the current namespace"
   },
   {
-    "id": "Unable to obtain list of available namespaces: {{.err}}",
-    "translation": "Unable to obtain list of available namespaces: {{.err}}"
+    "id": "Unable to obtain the list of available namespaces: {{.err}}",
+    "translation": "Unable to obtain the list of available namespaces: {{.err}}"
   },
   {
     "id": "get triggers, actions, and rules in the registry for a namespace",
@@ -84,12 +84,12 @@
     "translation": "'{{.name}}' is not a valid qualified name: {{.err}}"
   },
   {
-    "id": "Unable to obtain namespace entities for namespace '{{.namespace}}': {{.err}}",
-    "translation": "Unable to obtain namespace entities for namespace '{{.namespace}}': {{.err}}"
+    "id": "Unable to obtain the list of entities for namespace '{{.namespace}}': {{.err}}",
+    "translation": "Unable to obtain the list of entities for namespace '{{.namespace}}': {{.err}}"
   },
   {
-    "id": "Entities in namespace: ",
-    "translation": "Entities in namespace: "
+    "id": "Entities in namespace: {{.namespace}}\n",
+    "translation": "Entities in namespace: {{.namespace}}\n"
   },
   {
     "id": "list available namespaces",
@@ -176,8 +176,8 @@
     "translation": "No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""
   },
   {
-    "id": "Unable to obtain package list: {{.err}}",
-    "translation": "Unable to obtain package list: {{.err}}"
+    "id": "Unable to obtain the list of packages for namespace '{{.name}}': {{.err}}",
+    "translation": "Unable to obtain the list of packages for namespace '{{.name}}': {{.err}}"
   },
   {
     "id": "refresh package bindings",
@@ -489,8 +489,8 @@
     "translation": "Namespace '{{.name}}' is invalid: {{.err}}\n"
   },
   {
-    "id": "Unable to obtain list of rules: {{.err}}",
-    "translation": "Unable to obtain list of rules: {{.err}}"
+    "id": "Unable to obtain the list of rules for namespace '{{.name}}': {{.err}}",
+    "translation": "Unable to obtain the list of rules for namespace '{{.name}}': {{.err}}"
   },
   {
     "note-to-translators": "DO NOT TRANSLATE THE 'yes' AND 'no'.  THOSE ARE FIXED CLI ARGUMENT VALUES",
@@ -655,8 +655,8 @@
     "translation": "list all triggers"
   },
   {
-    "id": "Unable to obtain the trigger list for namespace '{{.name}}': {{.err}}",
-    "translation": "Unable to obtain the trigger list for namespace '{{.name}}': {{.err}}"
+    "id": "Unable to obtain the list of triggers for namespace '{{.name}}': {{.err}}",
+    "translation": "Unable to obtain the list of triggers for namespace '{{.name}}': {{.err}}"
   },
   {
     "id": "Unable to invoke trigger '{{.trigname}}' feed action '{{.feedname}}'; feed is not configured: {{.err}}",
@@ -836,8 +836,8 @@
     "translation": "list all actions"
   },
   {
-    "id": "Unable to list action(s): {{.err}}",
-    "translation": "Unable to list action(s): {{.err}}"
+    "id": "Unable to obtain the list of actions for namespace '{{.name}}': {{.err}}",
+    "translation": "Unable to obtain the list of actions for namespace '{{.name}}': {{.err}}"
   },
   {
     "id": "Could not find 'main' method in '{{.name}}'",
@@ -924,8 +924,8 @@
     "translation": "Namespace '{{.name}}' is invalid"
   },
   {
-    "id": "Unable to obtain list of activations: {{.err}}",
-    "translation": "Unable to obtain list of activations: {{.err}}"
+    "id": "Unable to obtain the list of activations for namespace '{{.name}}': {{.err}}",
+    "translation": "Unable to obtain the list of activations for namespace '{{.name}}': {{.err}}"
   },
   {
     "id": "get activation",
@@ -1106,5 +1106,9 @@
   {
     "id": "parameters",
     "translation": "parameters"
+  },
+  {
+    "id": "default",
+    "translation": "default"
   }
 ]

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -121,10 +121,7 @@ func (s *ActionService) List(packageName string, options *ActionListOptions) ([]
     resp, err := s.client.Do(req, &actions)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errMsg := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
-            NO_DISPLAY_USAGE)
-        return nil, resp, whiskErr
+        return nil, resp, err
     }
 
     return actions, resp, err
@@ -170,10 +167,7 @@ func (s *ActionService) Insert(action *Action, sharedSet bool, overwrite bool) (
     resp, err := s.client.Do(req, &a)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errMsg := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
-            NO_DISPLAY_USAGE)
-        return nil, resp, whiskErr
+        return nil, resp, err
     }
 
     return a, resp, nil
@@ -199,10 +193,7 @@ func (s *ActionService) Get(actionName string) (*Action, *http.Response, error) 
     resp, err := s.client.Do(req, &a)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errMsg := wski18n.T("Request failure: {{.err}}",  map[string]interface{}{"err": err})
-        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
-            NO_DISPLAY_USAGE)
-        return nil, resp, whiskErr
+        return nil, resp, err
     }
 
     return a, resp, nil
@@ -229,10 +220,7 @@ func (s *ActionService) Delete(actionName string) (*http.Response, error) {
     resp, err := s.client.Do(req, a)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errMsg := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
-            NO_DISPLAY_USAGE)
-        return resp, whiskErr
+        return resp, err
     }
 
     return resp, nil
@@ -259,10 +247,7 @@ func (s *ActionService) Invoke(actionName string, payload *json.RawMessage, bloc
     resp, err := s.client.Do(req, &activation)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errMsg := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
-            NO_DISPLAY_USAGE)
-        return activation, resp, whiskErr
+        return activation, resp, err
     }
 
     return activation, resp, nil

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -98,9 +98,7 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
     resp, err := s.client.Do(req, &activations)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return activations, resp, nil
@@ -131,9 +129,7 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
     resp, err := s.client.Do(req, &a)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return a, resp, nil
@@ -162,9 +158,7 @@ func (s *ActivationService) Logs(activationID string) (*Activation, *http.Respon
     resp, err := s.client.Do(req, &activation)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return activation, resp, nil
@@ -193,9 +187,7 @@ func (s *ActivationService) Result(activationID string) (*Response, *http.Respon
     resp, err := s.client.Do(req, &r)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return r, resp, nil

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -295,8 +295,8 @@ func parseErrorResponse(resp *http.Response, data []byte, v interface{}) (*http.
         }
     } else {
         Debug(DbgError, "HTTP response with unexpected body failed due to contents parsing error: '%v'\n", err)
-        var errStr = wski18n.T("Request failed (status code = {{.statusCode}}). Error details: {{.data}}",
-            map[string]interface{}{"statusCode": resp.StatusCode, "data": data})
+        errStr := wski18n.T("The connection failed, or timed out. (HTTP status code {{.code}})",
+            map[string]interface{}{"code": resp.StatusCode})
         werr := MakeWskError(errors.New(errStr), resp.StatusCode - 256, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return resp, werr
     }
@@ -316,8 +316,8 @@ func parseWhiskErrorResponse(resp *http.Response, data []byte, v interface{}) (*
         return parseSuccessResponse(resp, data, v), whiskErr
     } else {
         Debug(DbgError, "HTTP response with unexpected body failed due to contents parsing error: '%v'\n", err)
-        errMsg := wski18n.T("Request failed (status code = {{.statusCode}}). Error details: {{.data}}",
-            map[string]interface{}{"statusCode": resp.StatusCode, "data": data})
+        errMsg := wski18n.T("The connection failed, or timed out. (HTTP status code {{.code}})",
+            map[string]interface{}{"code": resp.StatusCode})
         whiskErr := MakeWskError(errors.New(errMsg), resp.StatusCode - 256, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return resp, whiskErr
     }

--- a/tools/cli/go-whisk/whisk/info.go
+++ b/tools/cli/go-whisk/whisk/info.go
@@ -62,9 +62,7 @@ func (s *InfoService) Get() (*Info, *http.Response, error) {
     resp, err := s.client.Do(req, &info)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, nil, werr
+        return nil, nil, err
     }
 
     return info, resp, nil

--- a/tools/cli/go-whisk/whisk/package.go
+++ b/tools/cli/go-whisk/whisk/package.go
@@ -136,9 +136,7 @@ func (s *PackageService) List(options *PackageListOptions) ([]Package, *http.Res
     resp, err := s.client.Do(req, &packages)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return packages, resp, err
@@ -164,9 +162,7 @@ func (s *PackageService) Get(packageName string) (*Package, *http.Response, erro
     resp, err := s.client.Do(req, &p)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return p, resp, nil
@@ -192,9 +188,7 @@ func (s *PackageService) Insert(x_package PackageInterface, overwrite bool) (*Pa
     resp, err := s.client.Do(req, &p)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return p, resp, nil
@@ -218,9 +212,7 @@ func (s *PackageService) Delete(packageName string) (*http.Response, error) {
     resp, err := s.client.Do(req, nil)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return resp, werr
+        return resp, err
     }
 
     return resp, nil
@@ -242,9 +234,7 @@ func (s *PackageService) Refresh() (*BindingUpdates, *http.Response, error) {
     resp, err := s.client.Do(req, updates)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return updates, resp, nil

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -70,9 +70,7 @@ func (s *RuleService) List(options *RuleListOptions) ([]Rule, *http.Response, er
     resp, err := s.client.Do(req, &rules)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return rules, resp, err
@@ -97,9 +95,7 @@ func (s *RuleService) Insert(rule *Rule, overwrite bool) (*Rule, *http.Response,
     resp, err := s.client.Do(req, &r)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return r, resp, nil
@@ -124,9 +120,7 @@ func (s *RuleService) Get(ruleName string) (*Rule, *http.Response, error) {
     resp, err := s.client.Do(req, &r)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return r, resp, nil
@@ -150,9 +144,7 @@ func (s *RuleService) Delete(ruleName string) (*http.Response, error) {
     resp, err := s.client.Do(req, nil)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return resp, werr
+        return resp, err
     }
 
     return resp, nil
@@ -187,9 +179,7 @@ func (s *RuleService) SetState(ruleName string, state string) (*Rule, *http.Resp
     resp, err := s.client.Do(req, &r)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return r, resp, nil

--- a/tools/cli/go-whisk/whisk/sdk.go
+++ b/tools/cli/go-whisk/whisk/sdk.go
@@ -67,9 +67,7 @@ func (s *SdkService) Install(relFileUrl string) (*http.Response, error) {
     resp, err := s.client.client.Do(req)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return resp, werr
+        return resp, err
     }
 
     return resp, nil

--- a/tools/cli/go-whisk/whisk/trigger.go
+++ b/tools/cli/go-whisk/whisk/trigger.go
@@ -81,9 +81,7 @@ func (s *TriggerService) List(options *TriggerListOptions) ([]TriggerFromServer,
     resp, err := s.client.Do(req, &triggers)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return triggers, resp, nil
@@ -118,9 +116,7 @@ func (s *TriggerService) Insert(trigger *Trigger, overwrite bool) (*TriggerFromS
     resp, err := s.client.Do(req, &t)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return t, resp, nil
@@ -146,9 +142,7 @@ func (s *TriggerService) Get(triggerName string) (*TriggerFromServer, *http.Resp
     resp, err := s.client.Do(req, &t)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return t, resp, nil
@@ -174,9 +168,7 @@ func (s *TriggerService) Delete(triggerName string) (*TriggerFromServer, *http.R
     resp, err := s.client.Do(req, &t)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return t, resp, nil
@@ -201,9 +193,7 @@ func (s *TriggerService) Fire(triggerName string, payload *json.RawMessage) (*Tr
     resp, err := s.client.Do(req, &t)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error: '%s'\n", req.URL.String(), err)
-        errStr := wski18n.T("Request failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return nil, resp, werr
+        return nil, resp, err
     }
 
     return t, resp, nil

--- a/tools/cli/go-whisk/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk/wski18n/resources/en_US.all.json
@@ -4,10 +4,6 @@
     "translation": "Unable to add route options: {{.options}}"
   },
   {
-    "id": "Request failure: {{.err}}",
-    "translation": "Request failure: {{.err}}"
-  },
-  {
     "id": "Unable to create HTTP request for PUT '{{.route}}': {{.err}}",
     "translation": "Unable to create HTTP request for PUT '{{.route}}': {{.err}}"
   },
@@ -64,16 +60,8 @@
     "translation": "Command failed due to an internal failure"
   },
   {
-    "id": "Request failed (status code = {{.statusCode}}). Error details: {{.data}}",
-    "translation": "Request failed (status code = {{.statusCode}}). Error details: {{.data}}"
-  },
-  {
     "id": "The following application error was received: {{.err}}",
     "translation": "The following application error was received: {{.err}}"
-  },
-  {
-    "id": "Request failed (status code = {{.statusCode}}). Error details: {{.data}}",
-    "translation": "Request failed (status code = {{.statusCode}}). Error details: {{.data}}"
   },
   {
     "id": "Invalid request URL '{{.url}}': {{.err}}",
@@ -130,5 +118,9 @@
   {
     "id": "{{.msg}} (code {{.code}})",
     "translation": "{{.msg}} (code {{.code}})"
+  },
+  {
+    "id": "The connection failed, or timed out. (HTTP status code {{.code}})",
+    "translation": "The connection failed, or timed out. (HTTP status code {{.code}})"
   }
 ]


### PR DESCRIPTION
- Display "connection failued, or timed out" when HTTP requests fail
- Update "namespace get" to display the proper namespace when an error occurs.
- Fix defect that prevents a passed namespace from being used with "namespace get"
- Add test to ensure the proper namespace is being used with "namespace get"

Fixes: https://github.com/openwhisk/openwhisk/issues/1203
Fixes: https://github.com/openwhisk/openwhisk/issues/1279
Fixes: https://github.com/openwhisk/openwhisk/issues/1319
PG1: 398
