### PR TITLE
tweak/rewrite throttle tests

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -67,20 +67,20 @@ class Config(requiredProperties: Map[String, String]) {
     /*
      * Converts the set of property to a string for debugging.
      */
-    def mkString(): String = settings.mkString("\n")
+    def mkString: String = settings.mkString("\n")
 
     /**
      * Loads the properties as specified above.
      *
      * @return a pair which is the Map defining the properties, and a boolean indicating whether validation succeeded.
      */
-    protected def getProperties: (Map[String, String], Boolean) = {
+    protected def getProperties(): (Map[String, String], Boolean) = {
         val properties = scala.collection.mutable.Map[String, String]() ++= requiredProperties
         Config.readPropertiesFromEnvironment(properties)
         (properties.toMap, Config.validateProperties(requiredProperties, properties))
     }
 
-    private val (settings, valid) = getProperties
+    private val (settings, valid) = getProperties()
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -132,6 +132,7 @@ object TransactionId {
     val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
     val invokerWarmup = TransactionId(-101) // Invoker warmup thread
     val dispatcher = TransactionId(-102) // Kafka message dispatcher
+    val loadbalancer = TransactionId(-103) // Loadbalancer thread
 
     def apply(tid: BigDecimal): TransactionId = {
         Try {

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -45,14 +45,12 @@ class WhiskConfig(
     propertiesFile: File = null)(implicit val system: ActorSystem)
     extends Config(requiredProperties) {
 
-    private val (settings, valid) = getProperties
-
     /**
      * Loads the properties as specified above.
      *
      * @return a pair which is the Map defining the properties, and a boolean indicating whether validation succeeded.
      */
-    override protected def getProperties: (Map[String, String], Boolean) = {
+    override protected def getProperties(): (Map[String, String], Boolean) = {
         val properties = scala.collection.mutable.Map[String, String]() ++= requiredProperties
         Config.readPropertiesFromEnvironment(properties)
         WhiskConfig.readPropertiesFromFile(properties, Option(propertiesFile) getOrElse (WhiskConfig.whiskPropertiesFile))

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -48,6 +48,7 @@ class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
      * services to be able to determine whether a namespace should be throttled or not based on
      * the number of concurrent invocations it has in the system
      */
+    @volatile
     private var userActivationCounter = Map.empty[String, Long]
 
     private val healthCheckInterval = 5.seconds
@@ -106,8 +107,8 @@ class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
 
     Scheduler.scheduleWaitAtLeast(healthCheckInterval) { () =>
         for {
-            loadbalancerActivationCount <- getLoadBalancerActivationCount
-            invokerActivationCount <- getInvokerActivationCount
+            loadbalancerActivationCount <- getLoadBalancerActivationCount()
+            invokerActivationCount <- getInvokerActivationCount()
         } yield {
             userActivationCounter = invokerActivationCount map {
                 case (subject, invokerCount) =>

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -41,6 +41,7 @@ import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 import whisk.core.connector.{ ActivationMessage => Message }
 import whisk.common.Scheduler
+import whisk.common.TransactionId
 
 object InvokerHealth {
     val requiredProperties = consulServer
@@ -154,7 +155,7 @@ class InvokerHealth(
 
             // Warning is issued only if up/down is changed
             if (getInvokerHealth().deep != getHealth(newStatus).deep) {
-                warn(this, s"InvokerHealth status change: ${newStatus.deep.mkString(" ")}")
+                warn(this, s"InvokerHealth status change: ${newStatus.deep.mkString(" ")}")(TransactionId.loadbalancer)
             }
 
             // Existing entries that have become stale require recording and a warning

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -88,7 +88,8 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
             val inFlight = issuedCount - completedCount
             val overload = JsBoolean(overloadThreshold > 0 && inFlight >= overloadThreshold)
             if (count % 10 == 0) {
-                warn(this, s"In flight: $issuedCount - $completedCount = $inFlight $overload")
+                implicit val sid = TransactionId.loadbalancer
+                info(this, s"In flight: $issuedCount - $completedCount = $inFlight $overload")
                 info(this, s"Issued counts: [${issuedCounts.mkString(", ")}]")
                 info(this, s"Completion counts: [${invokerCounts.mkString(", ")}]")
                 info(this, s"Invoker health: [${health.mkString(", ")}]")


### PR DESCRIPTION
1. retry activations that fail
2. make concurrent throttle test sensitive to system capacity
3. temporary: run concurrent throttle test 25 times in a row

Fixes #1196.