### PR TITLE
Add fully-qualified action name and action limits to annotations of activations

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -83,7 +83,6 @@ import whisk.core.entity.BlackBoxExec
 import whisk.core.entity.DocId
 import whisk.core.entity.DocInfo
 import whisk.core.entity.DocRevision
-import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
 import whisk.core.entity.LogLimit
 import whisk.core.entity.SemVer
@@ -98,6 +97,9 @@ import whisk.core.entity.size.SizeLong
 import whisk.core.entity.size.SizeString
 import whisk.http.BasicHttpService
 import whisk.utils.ExecutionContextFactory
+import whisk.common.Logging
+import whisk.core.entity.Parameters
+import whisk.core.entity.ActionLimits
 
 /**
  * A kafka message handler that invokes actions as directed by message on topic "/actions/invoke".
@@ -186,11 +188,11 @@ class Invoker(
         implicit transid: TransactionId): Unit = {
         error(this, errorMsg)
         val msg = tran.msg
-        val name = EntityName(actionDocInfo.id().split(EntityPath.PATHSEP)(1))
+        val name = EntityPath(actionDocInfo.id())
         val version = SemVer() // TODO: this is wrong, when the semver is passed from controller, fix this
         val response = ActivationResponse.whiskError(errorMsg)
         val interval = computeActivationInterval(tran)
-        val activation = makeWhiskActivation(msg, name, version, response, interval)
+        val activation = makeWhiskActivation(msg, name, version, response, interval, None)
         completeTransaction(tran, activation, FailedActivation(transid))
     }
 
@@ -253,7 +255,7 @@ class Invoker(
 
                     val activationInterval = computeActivationInterval(tran)
                     val activationResponse = getActivationResponse(activationInterval, action.limits.timeout.duration, response, failedInit)
-                    val activationResult = makeWhiskActivation(msg, action.name, action.version, activationResponse, activationInterval)
+                    val activationResult = makeWhiskActivation(msg, EntityPath(action.docid.id), action.version, activationResponse, activationInterval, Some(action.limits))
                     val completeMsg = CompletionMessage(transid, activationResult)
 
                     producer.send("completed", completeMsg) map { status =>
@@ -278,7 +280,7 @@ class Invoker(
                     ActivationResponse.whiskError("error starting container to run action")
                 }
                 val interval = computeActivationInterval(tran)
-                val activation = makeWhiskActivation(msg, action.name, action.version, response, interval)
+                val activation = makeWhiskActivation(msg, EntityPath(action.docid.id), action.version, response, interval, Some(action.limits))
                 completeTransaction(tran, activation, FailedActivation(transid))
             }
         }
@@ -432,13 +434,14 @@ class Invoker(
      */
     private def makeWhiskActivation(
         msg: Message,
-        actionName: EntityName,
+        actionName: EntityPath,
         actionVersion: SemVer,
         activationResponse: ActivationResponse,
-        interval: Interval) = {
+        interval: Interval,
+        limits: Option[ActionLimits]) = {
         WhiskActivation(
             namespace = msg.activationNamespace,
-            name = actionName,
+            name = actionName.last,
             version = actionVersion,
             publish = false,
             subject = msg.subject,
@@ -447,7 +450,8 @@ class Invoker(
             start = interval.start,
             end = interval.end,
             response = activationResponse,
-            logs = ActivationLogs())
+            logs = ActivationLogs(),
+            annotations = Parameters("limits", limits.toJson) ++ Parameters("fqdn", actionName.toJson))
     }
 
     /**

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -451,7 +451,7 @@ class Invoker(
             end = interval.end,
             response = activationResponse,
             logs = ActivationLogs(),
-            annotations = Parameters("limits", limits.toJson) ++ Parameters("fqdn", actionName.toJson))
+            annotations = Parameters("limits", limits.toJson) ++ Parameters("path", actionName.toJson))
     }
 
     /**

--- a/tests/src/common/WskTestHelpers.scala
+++ b/tests/src/common/WskTestHelpers.scala
@@ -97,9 +97,9 @@ trait WskTestHelpers extends Matchers {
     /**
      * Activation record as it is returned by the CLI.
      */
-    case class CliActivation(activationId: String, logs: Option[List[String]], response: CliActivationResponse, start: Long, end: Long, cause: Option[String])
+    case class CliActivation(activationId: String, logs: Option[List[String]], response: CliActivationResponse, start: Long, end: Long, cause: Option[String], annotations: Option[List[JsObject]])
     object CliActivation extends DefaultJsonProtocol {
-        implicit val serdes = jsonFormat6(CliActivation.apply)
+        implicit val serdes = jsonFormat7(CliActivation.apply)
     }
 
     /**

--- a/tests/src/system/basic/WskActionTests.scala
+++ b/tests/src/system/basic/WskActionTests.scala
@@ -16,6 +16,8 @@
 
 package system.basic
 
+import scala.language.postfixOps
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -29,6 +31,8 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import spray.json.pimpAny
+import whisk.core.entity.size.SizeInt
+import scala.concurrent.duration.DurationInt
 
 @RunWith(classOf[JUnitRunner])
 class WskActionTests
@@ -261,6 +265,35 @@ class WskActionTests
                     activation.response.result shouldBe Some(JsObject(
                         "stderr" -> "ping: icmp open socket: Operation not permitted\n".toJson,
                         "stdout" -> "".toJson))
+            }
+    }
+
+    it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "annotations"
+            val memoryLimit = 512 MB
+            val logLimit = 1 MB
+            val timeLimit = 60 seconds
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")), memory = Some(memoryLimit), timeout = Some(timeLimit), logsize = Some(logLimit))
+            }
+
+            val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.status shouldBe "success"
+                    val annotations = activation.annotations.get
+
+                    val limitsObj = JsObject("key" -> JsString("limits"),
+                        "value" -> JsObject("timeout" -> JsNumber(timeLimit.toMillis),
+                            "memory" -> JsNumber(memoryLimit.toMB),
+                            "logs" -> JsNumber(logLimit.toMB)))
+
+                    val path = annotations.find { _.fields("key").convertTo[String] == "path" }.get
+
+                    path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
+                    annotations should contain(limitsObj)
             }
     }
 

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -20,6 +20,7 @@ import (
     "fmt"
     "net/http"
     "errors"
+    "encoding/json"
     "net/url"
     "../wski18n"
 )
@@ -41,6 +42,7 @@ type Activation struct {
     End          int64  `json:"end"`                    // Since a 0 is a valid value from server, don't omit
     Response     `json:"response,omitempty"`
     Logs         []string `json:"logs,omitempty"`
+    Annotations *json.RawMessage `json:"annotations,omitempty"`
 }
 
 type Response struct {


### PR DESCRIPTION
In addition, a cloudant view is provided, that returns only action-activations.