### PR TITLE
adding support for openstack persistent volumes

### DIFF
--- a/ansible/README_DISTRIBUTED.md
+++ b/ansible/README_DISTRIBUTED.md
@@ -105,6 +105,6 @@ ansible-playbook -i environments/<environment> postdeploy.yml
 Setup your CLI and verify that OpenWhisk is working.
 
 ```
-../bin/wsk  property set --auth $(cat files/auth.guest) --apihost <edge_url>
-../bin/wsk -v action invoke /whisk.system/utils/echo -p message hello --blocking --result
+../bin/wsk property set --auth $(cat files/auth.whisk.system) --apihost <edge_url>
+../bin/wsk -i -v action invoke /whisk.system/samples/helloWorld --blocking --result
 ```

--- a/ansible/boot_instances_dist.yml
+++ b/ansible/boot_instances_dist.yml
@@ -1,24 +1,22 @@
 # boot_instances.yml
 ---
-- include_vars: environments/distributed/group_vars/all
-
 # TODO, in "with_instance" loops, the "instance" variable that is passed in gets unset, look up the proper way to do nested loops
-- set_fact:
-    name: "{{instance.name}}"
-    volume_env: "OS_WSK_{{instance.name|upper}}_VOLUME"
-
-- name: check for volume ENV / group_vars value
+- name: set vars
   set_fact:
-    volume: "{{lookup('env', volume_env) | default(instance.volume, true) | default('')}}"
+    name: "{{instance.name}}"
+    flavor: "{{instance.flavor | default (default_flavor, true) }}"
+    volume_env: "{{ lookup('env', 'OS_WSK_' + instance.name|upper + '_VOLUME')}}"
+    volume_dict: "{{instance.volume | default({})}}"
+    # instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
 
 - name: create volume
   os_volume:
     state: present
-    size: "{{volume | int}}"
+    size: "{{volume_env | default( volume_dict.size )}}"
     display_name: "{{name}}-{{item}}_volume"
     wait: yes
   with_sequence: count={{instance.num_instances}}
-  when: (volume != "")
+  when: (volume_env and volume_env != "") or (volume_dict and volume_dict.size)
 
 - name: launch an instance
   os_server:
@@ -30,7 +28,7 @@
       - net-id: "{{net_id}}"
       #- net-name: "{{net_name}}"
     image: "{{image}}"
-    flavor: "{{flavor}}"
+    flavor: "{{item.flavor | default (flavor) }}"
     key_name: "{{key_name}}"
     security_groups: "{{security_groups}}"
     auto_ip: no
@@ -43,9 +41,10 @@
     server: "{{name}}-{{item}}"
     state: present
     volume: "{{name}}-{{item}}_volume"
+    wait: yes
   # register: volume_info
   with_sequence: count={{instance.num_instances}}
-  when: (volume != "")
+  when: (volume_env and volume_env != "") or (volume_dict and volume_dict.size)
 
 # - add_host: ansible_ssh_host={{ item.server.private_v4 }} groups={{name}}
 #   with_items: instance_info.results
@@ -61,10 +60,10 @@
 - shell: "echo [{{name}}] >> {{inventory_dir}}/hosts"
   when: "{{hosts_file.rc}} != 0"
 
-- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}} volume={{item.server.volumes[0].device }}" dest="{{inventory_dir}}/hosts"
+- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}} block_device={{item.server.volumes[0].device }}" dest="{{inventory_dir}}/hosts"
   with_items: instance_info.results
-  when: (volume is defined and volume != "")
+  when: (volume_env and volume_env != "") or (volume_dict and volume_dict.size)
 
 - lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}}" dest="{{inventory_dir}}/hosts"
   with_items: instance_info.results
-  when: (volume is not defined or volume == "")
+  when: (not volume_env or volume_env == "" ) and (not volume_dict or not volume_dict.size)

--- a/ansible/boot_instances_dist.yml
+++ b/ansible/boot_instances_dist.yml
@@ -1,10 +1,24 @@
 # boot_instances.yml
 ---
-
 - include_vars: environments/distributed/group_vars/all
 
+# TODO, in "with_instance" loops, the "instance" variable that is passed in gets unset, look up the proper way to do nested loops
 - set_fact:
     name: "{{instance.name}}"
+    volume_env: "OS_WSK_{{instance.name|upper}}_VOLUME"
+
+- name: check for volume ENV / group_vars value
+  set_fact:
+    volume: "{{lookup('env', volume_env) | default(instance.volume, true) | default('')}}"
+
+- name: create volume
+  os_volume:
+    state: present
+    size: "{{volume | int}}"
+    display_name: "{{name}}-{{item}}_volume"
+    wait: yes
+  with_sequence: count={{instance.num_instances}}
+  when: (volume != "")
 
 - name: launch an instance
   os_server:
@@ -20,21 +34,37 @@
     key_name: "{{key_name}}"
     security_groups: "{{security_groups}}"
     auto_ip: no
+    wait: yes
   register: instance_info
   with_sequence: count={{instance.num_instances}}
+
+- name: attach volume to host
+  os_server_volume:
+    server: "{{name}}-{{item}}"
+    state: present
+    volume: "{{name}}-{{item}}_volume"
+  # register: volume_info
+  with_sequence: count={{instance.num_instances}}
+  when: (volume != "")
+
+# - add_host: ansible_ssh_host={{ item.server.private_v4 }} groups={{name}}
+#   with_items: instance_info.results
+
+# - local_action: add_host ansible_ssh_host={{ item.server.private_v4 }} groupname={{name}}
+#   with_items: instance_info.results
 
 - shell: "grep -e {{name}} {{inventory_dir}}/hosts"
   ignore_errors: True
   register: hosts_file
 
+# TODO, should render the hosts file from a template by using the add_host module commented below with a template
 - shell: "echo [{{name}}] >> {{inventory_dir}}/hosts"
   when: "{{hosts_file.rc}} != 0"
 
-  # - add_host: ansible_ssh_host={{ item.server.private_v4 }} groups={{name}}
-  # with_items: instance_info.results
-
-# - lineinfile: insertafter="[{{name}}]" line="{{instance_info.results[0].server.private_v4}}" dest="{{inventory_dir}}/hosts"
-#- lineinfile: insertafter="^{{name}}" line="{{item.server.private_v4}}" dest="{{inventory_dir}}/hosts"
+- lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}} volume={{item.server.volumes[0].device }}" dest="{{inventory_dir}}/hosts"
+  with_items: instance_info.results
+  when: (volume is defined and volume != "")
 
 - lineinfile: insertafter="^{{name}}" line="{{item.server.networks.itervalues().next()[0]}}" dest="{{inventory_dir}}/hosts"
   with_items: instance_info.results
+  when: (volume is not defined or volume == "")

--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -27,11 +27,13 @@ registry:
     threshold: 80
     keeptags: 5
 
+# openstack vars
+# TODO, should move these to a role and create a designated "defaults.yml" file
 rc_file:
 #net_name: "{{ lookup('env','OS_NET_NAME') }}"
 net_id: "{{ lookup('env','OS_NET_ID') }}"
 image: "{{ lookup('env','OS_IMAGE') }}"
-flavor: "{{ lookup('env','OS_FLAVOR') }}"
+default_flavor: "{{ lookup('env','OS_FLAVOR') | default('m1.small') }}"
 auth:
   auth_url: "{{ lookup('env','OS_AUTH_URL') }}"
   username: "{{ lookup('env','OS_USERNAME') }}"
@@ -40,6 +42,8 @@ auth:
 key_name: "{{ lookup('env','OS_KEY_NAME') }}"
 security_groups: "{{ lookup('env','OS_SECURITY_GROUPS') }}"
 
+# list of instances.
+# TODO, move each object to designated group_vars file
 instances:
   - name: registry
     num_instances: 1
@@ -69,3 +73,7 @@ instances:
     num_instances: 1
     flavor:
     volume:
+      name:
+      size:
+      fstype:
+      fsmount:

--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -68,3 +68,4 @@ instances:
   - name: db
     num_instances: 1
     flavor:
+    volume:

--- a/ansible/environments/distributed/templates/hosts.j2
+++ b/ansible/environments/distributed/templates/hosts.j2
@@ -1,0 +1,13 @@
+; the first parameter in a host is the inventory_hostname which has to be
+; either an ip
+; or a resolvable hostname
+
+; used for local actions only
+ansible ansible_connection=local
+
+{% for group in group_names%}
+[{{group}}]
+{% for host in groups[group] %}
+{{ hostvars[host]["ansible_lo"]["ipv4"]["address"] }}
+{% endfor %}
+{% endfor %}

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -72,7 +72,7 @@ docker:
   restart:
     policy: always
 
-cli_path: "{{ openwhisk_home }}/bin/wsk"
+cli_path: "{{ openwhisk_home }}/bin/go-cli/wsk"
 
 # The default name space is /whisk.system. The catalog namespace must begin with a slash "/".
 catalog_namespace: "/whisk.system"

--- a/ansible/provision_env_dist.yml
+++ b/ansible/provision_env_dist.yml
@@ -6,11 +6,11 @@
     #- name: Load rc file if provided
     #  shell: . rc_file
 
-    # TODO, not sure if this is necessary
+    # TODO, ensure this is necessary
     - include_vars: environments/distributed/group_vars/all
 
     - name: add header to hosts file
-      copy: 
+      copy:
         content: "; the first parameter in a host is the inventory_hostname which has to be\n; either an ip\n; or a resolvable hostname\n\n; used for local actions only\nansible ansible_connection=local\n"
         dest: "{{inventory_dir}}/hosts"
 
@@ -18,9 +18,40 @@
       include: boot_instances_dist.yml instance={{item}}
       with_items: instances
 
-    - include_vars: environments/distributed/group_vars/all
-
     - meta: refresh_inventory
+
+    - name: refresh vars
+      include_vars: environments/distributed/group_vars/all
+
+# TODO, add support to loop through instances, configure all vms that have cinder disks (kafka, elk, etc). Hardcoding to db for now
+- name: Configure couch db disks
+  hosts: db
+  tasks:
+    - name: Ensure VM is up and running before starting disk configuration
+      wait_for: host={{ansible_default_ipv4.address}} port=22
+    - name: Get list of configured disks
+      shell: df -h
+      register: disks
+    - name: Check to see if volume size has been set in either env var or in environments/distributed/all
+      set_fact:
+        db_volume_env: "{{lookup('env', 'OS_WSK_DB_VOLUME')}}"
+        db_instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
+    - name: Set boolean flag to determine if volume is to be configured or not. Skip if volume value is not set in both env and group_vars, or if it has already been configured
+      set_fact:
+        configure_volume: "{{((db_volume_env is defined and db_volume_env != '') or (db_instance.volume is defined and db_instance.volume != '')) and ('/var/couchdb' not in disks.stdout) and (volume is defined)}}"
+    - name: Create mount folder
+      shell: mkdir -p /var/couchdb
+      become: true
+      when: configure_volume
+    - name: Partition persistent disk
+      shell: mkfs.ext3 {{volume}} 2>/dev/null
+      become: true
+      when: configure_volume
+    - name: Mount persistent disk
+      shell: mount -t ext3 {{volume}} /var/couchdb
+      # - mount: name=/var/couchdb src=/dev/vdb fstype=ext4 state=present # TODO, mount module not workng as expected
+      become: true
+      when: configure_volume
 
 - name: append registry url to hosts file
   hosts: all:!ansible

--- a/ansible/provision_env_dist.yml
+++ b/ansible/provision_env_dist.yml
@@ -3,12 +3,6 @@
 - name: create instances and hosts file
   hosts: ansible
   tasks:
-    #- name: Load rc file if provided
-    #  shell: . rc_file
-
-    # TODO, ensure this is necessary
-    - include_vars: environments/distributed/group_vars/all
-
     - name: add header to hosts file
       copy:
         content: "; the first parameter in a host is the inventory_hostname which has to be\n; either an ip\n; or a resolvable hostname\n\n; used for local actions only\nansible ansible_connection=local\n"
@@ -20,9 +14,6 @@
 
     - meta: refresh_inventory
 
-    - name: refresh vars
-      include_vars: environments/distributed/group_vars/all
-
 # TODO, add support to loop through instances, configure all vms that have cinder disks (kafka, elk, etc). Hardcoding to db for now
 - name: Configure couch db disks
   hosts: db
@@ -32,26 +23,31 @@
     - name: Get list of configured disks
       shell: df -h
       register: disks
-    - name: Check to see if volume size has been set in either env var or in environments/distributed/all
+    - name: Check to see if volume size has been set via env or group_vars
       set_fact:
-        db_volume_env: "{{lookup('env', 'OS_WSK_DB_VOLUME')}}"
-        db_instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
+        volume_env: "{{lookup('env', 'OS_WSK_DB_VOLUME')}}"
+        instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
     - name: Set boolean flag to determine if volume is to be configured or not. Skip if volume value is not set in both env and group_vars, or if it has already been configured
       set_fact:
-        configure_volume: "{{((db_volume_env is defined and db_volume_env != '') or (db_instance.volume is defined and db_instance.volume != '')) and ('/var/couchdb' not in disks.stdout) and (volume is defined)}}"
+        configure_volume: "{{(volume_env is defined and volume_env != '') or
+                            ((instance.volume) and (instance.volume.fsmount and instance.volume.fsmount not in disks.stdout))}}"
+    - name: Get fsmount/fstype params
+      set_fact:
+        fsmount: "{{ instance.volume.fsmount | default('/mnt/' + group_names|first, true ) }}"
+        fstype: "{{ instance.volume.fstype | default('ext4', true) }}"
     - name: Create mount folder
-      shell: mkdir -p /var/couchdb
+      shell: mkdir -p {{ fsmount }}
       become: true
-      when: configure_volume
+      when: configure_volume and (fsmount not in disks.stdout)
     - name: Partition persistent disk
-      shell: mkfs.ext3 {{volume}} 2>/dev/null
+      shell: mkfs.{{ fstype }} {{ block_device }} 2>/dev/null
       become: true
-      when: configure_volume
+      when: configure_volume and (fsmount not in disks.stdout)
     - name: Mount persistent disk
-      shell: mount -t ext3 {{volume}} /var/couchdb
-      # - mount: name=/var/couchdb src=/dev/vdb fstype=ext4 state=present # TODO, mount module not workng as expected
+      shell: mount -t {{ fstype }} {{ block_device }} {{ fsmount }}
+      # - mount: name={{fsmount}} src={{device}} fstype={{fstype}} state=present # TODO, mount module not working as expected
       become: true
-      when: configure_volume
+      when: configure_volume and (fsmount not in disks.stdout)
 
 - name: append registry url to hosts file
   hosts: all:!ansible

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -8,10 +8,12 @@
 - name: check for persistent disk
   shell: df -h
   register: disk_status
+  when: "{{ block_device is defined }}"
 
 - set_fact:
-    volume_dir: "/var/couchdb:/usr/local/var/lib/couchdb"
-  when: "{{'/var/couchdb' in disk_status}}"
+    instance: "{{instances | selectattr('name', 'equalto', 'db') | list | first}}"
+    volume_dir: "{{ instance.volume.fsmount | default( '/mnt/' + group_names|first, true ) }}:/usr/local/var/lib/couchdb"
+  when: "{{ (block_device is defined) and (block_device in disk_status.stdout) }}"
 
 - name: (re)start CouchDB
   docker:

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -5,12 +5,21 @@
   fail: msg="The db provider in your {{ inventory_dir }}/group_vars/all is {{ db_provider }}, it has to be CouchDB, pls double check"
   when: db_provider != "CouchDB"
 
+- name: check for persistent disk
+  shell: df -h
+  register: disk_status
+
+- set_fact:
+    volume_dir: "/var/couchdb:/usr/local/var/lib/couchdb"
+  when: "{{'/var/couchdb' in disk_status}}"
+
 - name: (re)start CouchDB
   docker:
     name: couchdb
     image: couchdb
     state: reloaded
     restart_policy: "{{ docker.restart.policy }}"
+    volumes: "{{volume_dir | default([])}}"
     ports:
       - "{{ db_port }}:5984"
 


### PR DESCRIPTION
These proposed changes enhance the distributed ansible playbooks with the ability to create and attach a persistent disk to the couchdb instance. The size of the couchdb disk (in GB) can be set either as an environment variable (OS_WSK_DB_VOLUME=15) or in the instances object from environments/distributed/group_vars/all.