### PR TITLE
Delete hourly limits and add override mechanism for deployment specfic limits

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -16,3 +16,12 @@ db_password: "{{ lookup('ini', 'db_password section=db_creds file={{ playbook_di
 db_protocol: "{{ lookup('ini', 'db_protocol section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 db_host: "{{ lookup('ini', 'db_host section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
+
+limits:
+  actions:
+    invokes:
+      perMinute: 60
+      concurrent: 30
+  triggers:
+    fires:
+      perMinute: 60

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -7,16 +7,15 @@ whisk:
   version:
     date: "{{ansible_date_time.iso8601}}"
 
-limits:
+defaultLimits:
   actions:
     invokes:
       perMinute: 120
-      perHour: 3600
       concurrent: 100
   triggers:
     fires:
       perMinute: 60
-      perHour: 720
+
 
 # port means outer port
 controller:

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -18,6 +18,12 @@ defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinu
 defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
 defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
 
+{% if limits is defined %}
+limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
+limits.actions.invokes.concurrent={{ limits.actions.invokes.concurrent }}
+limits.triggers.fires.perMinute={{ limits.triggers.fires.perMinute }}
+{% endif %}
+
 consulserver.host={{ groups["consul_servers"]|first }}
 controller.host={{ groups["controllers"]|first }}
 edge.host={{ groups["edge"]|first }}

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -14,11 +14,9 @@ whisk.ssl.cert={{ openwhisk_home }}/ansible/roles/nginx/files/openwhisk-cert.pem
 whisk.ssl.key={{ openwhisk_home }}/ansible/roles/nginx/files/openwhisk-key.pem
 whisk.ssl.challenge=openwhisk
 
-limits.actions.invokes.perMinute={{ limits.actions.invokes.perMinute }}
-limits.actions.invokes.perHour={{ limits.actions.invokes.perHour }}
-limits.actions.invokes.concurrent={{ limits.actions.invokes.concurrent }}
-limits.triggers.fires.perMinute={{ limits.triggers.fires.perMinute }}
-limits.triggers.fires.perHour={{ limits.triggers.fires.perHour }}
+defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinute }}
+defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
+defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}
 
 consulserver.host={{ groups["consul_servers"]|first }}
 controller.host={{ groups["controllers"]|first }}

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -16,6 +16,8 @@
 
 package whisk.common
 
+import scala.util.Try
+
 /**
  * A set of properties which define a configuration.
  *
@@ -39,21 +41,19 @@ package whisk.common
  *
  * @param propertiesFile a file which defines the properties
  */
-class Config(requiredProperties: Map[String, String]) {
+class Config(requiredProperties: Map[String, String], optionalProperties: Set[String] = Set()) extends Logging {
 
     def isValid: Boolean = valid
 
     /**
      * Gets value for key if it exists else the empty string.
+     * The value of the override key will instead be returned if its value is present in the map.
      *
      * @param key to lookup
+     * @param overrideKey the property whose value will be returned if the map contains the override key.
      * @return value for the key or the empty string if the key does not have a value/does not exist
      */
-    def apply(key: String): String = try {
-        settings(key)
-    } catch {
-        case _: Throwable => ""
-    }
+    def apply(key: String, overrideKey: String = ""): String = Try(settings(overrideKey)).orElse(Try(settings(key))).getOrElse("")
 
     /**
      * Returns the value of a given key.

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -105,11 +105,10 @@ class WhiskConfig(
     val kafkaDockerEndpoint = this(WhiskConfig.kafkaDockerEndpoint)
     val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
-    val actionInvokePerHourLimit = this(WhiskConfig.actionInvokePerHourLimit)
-    val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteLimit)
-    val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentLimit)
-    val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteLimit)
-    val triggerFirePerHourLimit = this(WhiskConfig.triggerFirePerHourLimit)
+    val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteDefaultLimit)
+    val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentDefaultLimit)
+    val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit)
+
 }
 
 object WhiskConfig extends Logging {
@@ -261,9 +260,8 @@ object WhiskConfig extends Logging {
     // an empty string is permitted but null is not
     val entitlementHost = Map(entitlementHostName -> "", entitlementHostPort -> "")
 
-    val actionInvokePerHourLimit = "limits.actions.invokes.perHour"
-    val actionInvokePerMinuteLimit = "limits.actions.invokes.perMinute"
-    val actionInvokeConcurrentLimit = "limits.actions.invokes.concurrent"
-    val triggerFirePerMinuteLimit = "limits.triggers.fires.perMinute"
-    val triggerFirePerHourLimit = "limits.triggers.fires.perHour"
+    val actionInvokePerMinuteDefaultLimit = "defaultLimits.actions.invokes.perMinute"
+    val actionInvokeConcurrentDefaultLimit = "defaultLimits.actions.invokes.concurrent"
+    val triggerFirePerMinuteDefaultLimit = "defaultLimits.triggers.fires.perMinute"
+
 }

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -92,6 +92,8 @@ object Controller {
         LoadBalancerService.requiredProperties ++
         EntitlementService.requiredProperties
 
+    def optionalProperties = EntitlementService.optionalProperties
+
     // akka-style factory to create a Controller object
     private class ServiceBuilder(config: WhiskConfig, instance: Int) extends Creator[Controller] {
         def create = new Controller(config, instance, InfoLevel)
@@ -101,7 +103,7 @@ object Controller {
         implicit val system = ActorSystem("controller-actor-system")
 
         // extract configuration data from the environment
-        val config = new WhiskConfig(requiredProperties)
+        val config = new WhiskConfig(requiredProperties, optionalProperties)
 
         // if deploying multiple instances (scale out), must pass the instance number as the
         // second argument.  (TODO .. seems fragile)

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -41,6 +41,8 @@ import whisk.core.entity.Subject
 class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
     implicit val system: ActorSystem) extends Logging {
 
+    info(this, s"concurrencyLimit = $concurrencyLimit")
+
     implicit private val executionContext = system.dispatcher
 
     /**

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -112,11 +112,14 @@ class ActivationThrottler(consulServer: String, concurrencyLimit: Int)(
             loadbalancerActivationCount <- getLoadBalancerActivationCount()
             invokerActivationCount <- getInvokerActivationCount()
         } yield {
+            debug(this, s"loadbalancerActivationCount = $loadbalancerActivationCount")
+            debug(this, s"invokerActivationCount = $invokerActivationCount")
             userActivationCounter = invokerActivationCount map {
                 case (subject, invokerCount) =>
                     val loadbalancerCount = loadbalancerActivationCount(subject)
                     subject -> (loadbalancerCount - invokerCount)
             }
+            debug(this, s"userActivationCounter = $userActivationCounter")
         }
         publishUserConcurrentActivation()
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -77,6 +77,11 @@ protected[core] object EntitlementService {
         WhiskConfig.actionInvokeConcurrentDefaultLimit -> null,
         WhiskConfig.triggerFirePerMinuteDefaultLimit -> null)
 
+    val optionalProperties = Set(
+        WhiskConfig.actionInvokePerMinuteLimit,
+        WhiskConfig.actionInvokeConcurrentLimit,
+        WhiskConfig.triggerFirePerMinuteLimit)
+
     /**
      * The default list of namespaces for a subject.
      */

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -73,11 +73,9 @@ protected[core] case class Resource(
 
 protected[core] object EntitlementService {
     val requiredProperties = WhiskConfig.consulServer ++ WhiskConfig.entitlementHost ++ Map(
-        WhiskConfig.actionInvokePerMinuteLimit -> null,
-        WhiskConfig.actionInvokePerHourLimit -> null,
-        WhiskConfig.actionInvokeConcurrentLimit -> null,
-        WhiskConfig.triggerFirePerMinuteLimit -> null,
-        WhiskConfig.triggerFirePerHourLimit -> null)
+        WhiskConfig.actionInvokePerMinuteDefaultLimit -> null,
+        WhiskConfig.actionInvokeConcurrentDefaultLimit -> null,
+        WhiskConfig.triggerFirePerMinuteDefaultLimit -> null)
 
     /**
      * The default list of namespaces for a subject.
@@ -95,8 +93,8 @@ protected[core] abstract class EntitlementService(config: WhiskConfig)(
 
     private var loadbalancerOverload: Boolean = false
 
-    private val invokeRateThrottler = new RateThrottler(config.actionInvokePerMinuteLimit.toInt, config.actionInvokePerHourLimit.toInt)
-    private val triggerRateThrottler = new RateThrottler(config.triggerFirePerMinuteLimit.toInt, config.triggerFirePerHourLimit.toInt)
+    private val invokeRateThrottler = new RateThrottler(config.actionInvokePerMinuteLimit.toInt)
+    private val triggerRateThrottler = new RateThrottler(config.triggerFirePerMinuteLimit.toInt)
     private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, config.actionInvokeConcurrentLimit.toInt)
 
     /** query the KV store this often */

--- a/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RateThrottler.scala
@@ -28,8 +28,9 @@ import akka.event.Logging.InfoLevel
  *
  * For now, we throttle only at a 1-minute granularity.
  */
-class RateThrottler(maxPerMinute: Int,
-                    maxPerHour: Int) extends Logging {
+class RateThrottler(maxPerMinute: Int) extends Logging {
+
+    info(this, s"maxPerMinute = $maxPerMinute")
 
     // Parameters
     private val exemptSubject = Set[Subject]() // We exempt no one.
@@ -49,7 +50,7 @@ class RateThrottler(maxPerMinute: Int,
             roll()
             lastMinCount = lastMinCount + 1
             lastHourCount = lastHourCount + 1
-            lastMinCount <= maxPerMinute && lastHourCount <= maxPerHour
+            lastMinCount <= maxPerMinute // Add this to check hourly rates: && lastHourCount <= maxPerHour
         }
 
         def roll()(implicit transid: TransactionId) = {

--- a/tests/src/whisk/core/WhiskConfigTests.scala
+++ b/tests/src/whisk/core/WhiskConfigTests.scala
@@ -37,7 +37,7 @@ class WhiskConfigTests extends FlatSpec with Matchers with WskActorSystem {
         bw.write("a=A")
         bw.close()
 
-        val config = new WhiskConfig(Map("a" -> null), file)
+        val config = new WhiskConfig(Map("a" -> null), Set(), file)
         assert(config.isValid && config("a") == "A")
     }
 
@@ -49,7 +49,7 @@ class WhiskConfigTests extends FlatSpec with Matchers with WskActorSystem {
         bw.write("a=A")
         bw.close()
 
-        val config = new WhiskConfig(Map("a" -> null, "b" -> null), file)
+        val config = new WhiskConfig(Map("a" -> null, "b" -> null), Set(), file)
         assert(!config.isValid && config("b") == null)
     }
 }


### PR DESCRIPTION
While ansible does not have an override mechanism, this can be accomplished by grouping keys together in WhiskConfig.  PG1-408