### PR TITLE
Fixes ContainerName in the Invoker

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -49,7 +49,7 @@ class Container(
     implicit var transid = originalId
 
     val id = Container.idCounter.next()
-    val name = containerName.getOrElse("anon")
+    val name = containerName.getOrElse(ContainerName.fromString("anon"))
 
     val (containerId, containerHostAndPort) = bringup(containerName, image, network, cpuShare, env, args, limits, policy)
 

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -83,7 +83,9 @@ package object container {
         override def toString() = s"$host:$port"
     }
 
-    sealed abstract class ContainerIdentifier(val id: String)
+    sealed abstract class ContainerIdentifier(val id: String) {
+        override def toString() = id
+    }
     class ContainerName(val name: String) extends ContainerIdentifier(name)
     class ContainerHash(val hash: String) extends ContainerIdentifier(hash)
 


### PR DESCRIPTION
Logs extracted from the Invoker are currently named after JVM object addresses. This restores old behaviour.