### PR TITLE
Use new Identity in API router, authentication and authorization

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -27,6 +27,7 @@ import whisk.core.entity.Subject
 import whisk.core.entity.WhiskActivation
 import whisk.core.entity.EntityPath
 import whisk.core.entity.FullyQualifiedEntityName
+import whisk.core.entity.AuthKey
 
 /** Basic trait for messages that are sent on a message bus connector. */
 trait Message {
@@ -50,6 +51,7 @@ case class ActivationMessage(
     override val transid: TransactionId,
     action: FullyQualifiedEntityName,
     subject: Subject,
+    authkey: AuthKey,
     activationId: ActivationId,
     activationNamespace: EntityPath,
     content: Option[JsObject],
@@ -81,7 +83,7 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
-    implicit val serdes = jsonFormat7(ActivationMessage.apply)
+    implicit val serdes = jsonFormat8(ActivationMessage.apply)
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
+++ b/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
@@ -16,16 +16,12 @@
 
 package whisk.core.entitlement
 
-/** A privilege is a right that is granted to a subject for a given resources. */
-protected[core] case class Privilege private (val right: String) extends AnyVal {
-    override def toString = right
-}
-
 /** An enumeration of privileges available to subjects. */
-protected[core] object Privilege {
-    val READ = new Privilege("read")
-    val PUT = new Privilege("put") // create or update
-    val DELETE = new Privilege("delete")
-    val ACTIVATE = new Privilege("activate") // usually a POST
-    val REJECT = new Privilege("reject")
+protected[core] object Privilege extends Enumeration {
+    type Privilege = Value
+
+    val READ, PUT, DELETE, ACTIVATE, REJECT = Value
+
+    val CRUD = Set(READ, PUT, DELETE)
+    val ALL = CRUD + ACTIVATE
 }

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -117,6 +117,7 @@ protected[core] object EntityPath {
 protected[core] class EntityName private (val name: String) extends AnyVal {
     def apply() = name
     def toJson = JsString(name)
+    def toPath = EntityPath(name)
     override def toString = name
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/Subject.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Subject.scala
@@ -17,15 +17,18 @@
 package whisk.core.entity
 
 import scala.util.Try
+
+import spray.json.JsString
 import spray.json.JsValue
 import spray.json.RootJsonFormat
-import spray.json.JsString
 import spray.json.deserializationError
+import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Privilege.Privilege
 
 protected[core] class Subject private (private val subject: String) extends AnyVal {
     protected[core] def apply() = subject
-    protected[core] def namespace = EntityPath(subject)
     protected[entity] def toJson = JsString(subject)
+    protected[core] def toIdentity(authkey: AuthKey) = Identity(this, EntityName(subject), authkey, Privilege.ALL)
     override def toString = subject
 }
 
@@ -66,3 +69,5 @@ protected[core] object Subject extends ArgNormalizer[Subject] {
 
     private val rand = new scala.util.Random()
 }
+
+protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege])

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -50,7 +50,6 @@ case class WhiskAuth(
     def uuid = authkey.uuid
     def key = authkey.key
     def revoke = WhiskAuth(subject, authkey.revoke)
-    def compact = authkey.toString
 
     override def toString = {
         s"""|subject: $subject
@@ -63,6 +62,8 @@ case class WhiskAuth(
         "subject" -> subject.toJson,
         "uuid" -> authkey.uuid.toJson,
         "key" -> authkey.key.toJson)
+
+    def toIdentity = subject.toIdentity(authkey)
 }
 
 object WhiskAuth extends DocumentFactory[WhiskAuth] {

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -36,6 +36,31 @@ import spray.routing.Rejection
 import spray.routing.StandardRoute
 import whisk.common.TransactionId
 
+object Messages {
+    /** Standard message for reporting resource conflicts. */
+    val conflictMessage = "Concurrent modification to resource detected."
+
+    /**
+     * Standard message for reporting resource conformance error when trying to access
+     * a resource from a different collection.
+     */
+    val conformanceMessage = "Resource by this name already exists but is not in this collection."
+
+    val systemOverloaded = "System is overloaded, try again later."
+
+    /** Standard message for resource not found. */
+    val resourceDoesNotExist = "The requested resource does not exist."
+
+    /** Standard message for too many activation requests within a rolling time window. */
+    val tooManyRequests = "Too many requests from user."
+
+    /** Standard message for too many concurrent activation requests within a time window. */
+    val tooManyConcurrentRequests = "The user has sent too many requests in a given amount of time."
+
+    /** Standard message when supplied authkey is not authorized for an operation. */
+    val notAuthorizedtoOperateOnResource = "The supplied authentication token is not authorized to perform operation resource."
+}
+
 /** Replaces rejections with Json object containing cause and transaction id. */
 case class ErrorResponse(error: String, code: TransactionId)
 
@@ -55,7 +80,7 @@ object ErrorResponse extends Directives {
     }
 
     def response(status: StatusCode)(implicit transid: TransactionId): ErrorResponse = status match {
-        case NotFound => ErrorResponse("The requested resource does not exist.", transid)
+        case NotFound => ErrorResponse(Messages.resourceDoesNotExist, transid)
         case _        => ErrorResponse(status.defaultMessage, transid)
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -37,11 +37,11 @@ import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskActivationStore
 import whisk.core.entity.types.ActivationStore
 import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
-import whisk.core.entity.WhiskAuth
 import scala.language.postfixOps
+import whisk.core.entity.Identity
 
 object WhiskActivationsApi {
     def requiredProperties = WhiskActivationStore.requiredProperties
@@ -82,7 +82,7 @@ trait WhiskActivationsApi
      * Overrides because API allows for GET on /activations and /activations/[result|log] which
      * would be rejected in the superclass.
      */
-    override protected def innerRoutes(user: WhiskAuth, ns: EntityPath)(implicit transid: TransactionId) = {
+    override protected def innerRoutes(user: Identity, ns: EntityPath)(implicit transid: TransactionId) = {
         (entityPrefix & entityOps & requestMethod) { (segment, m) =>
             entityname(segment) {
                 // defer rest of the path processing to the fetch operation, which is
@@ -93,7 +93,7 @@ trait WhiskActivationsApi
     }
 
     /** Dispatches resource to the proper handler depending on context. */
-    protected override def dispatchOp(user: WhiskAuth, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
+    protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
         resource.entity match {
             case Some(ActivationId(id)) => op match {
                 case READ => fetch(resource.namespace, id)

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -26,12 +26,15 @@ import spray.http.StatusCodes.InternalServerError
 import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
 import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
+import spray.httpx.SprayJsonSupport._
 import spray.json.JsObject
 import spray.json.JsValue
 import spray.json.RootJsonFormat
-import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
+import spray.json.JsBoolean
 import spray.routing.RequestContext
+import spray.routing.Directives
+
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.controller.PostProcess.PostProcessEntity
@@ -41,23 +44,12 @@ import whisk.core.database.NoDocumentException
 import whisk.core.database.DocumentConflictException
 import whisk.core.entity.DocId
 import whisk.core.entity.WhiskDocument
-import spray.routing.Directives
+import whisk.core.database.DocumentTypeMismatchException
 import whisk.core.entity.WhiskEntity
 import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.terminate
-import spray.json.JsBoolean
-import whisk.core.database.DocumentTypeMismatchException
+import whisk.http.Messages._
 
-protected sealed trait Messages {
-    /** Standard message for reporting resource conflicts. */
-    protected val conflictMessage = "Concurrent modification to resource detected"
-
-    /**
-     * Standard message for reporting resource conformance error when trying to access
-     * a resource from a different collection.
-     */
-    protected val conformanceMessage = "Resource by this name already exists but is not in this collection"
-}
 
 /** An exception to throw inside a Predicate future. */
 protected[core] case class RejectRequest(code: ClientError, message: Option[ErrorResponse]) extends Throwable
@@ -114,7 +106,7 @@ package object PostProcess {
 }
 
 /** A trait for REST APIs that read entities from a datastore */
-trait ReadOps extends Directives with Messages with Logging {
+trait ReadOps extends Directives with Logging {
 
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext
@@ -220,7 +212,7 @@ trait ReadOps extends Directives with Messages with Logging {
 }
 
 /** A trait for REST APIs that write entities to a datastore */
-trait WriteOps extends Directives with Messages with Logging {
+trait WriteOps extends Directives with Logging {
 
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -31,7 +31,7 @@ import spray.routing.Directives
 import spray.routing.RequestContext
 import spray.routing.Route
 import whisk.common.TransactionId
-import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Privilege.ACTIVATE
 import whisk.core.entitlement.Privilege.DELETE
 import whisk.core.entitlement.Privilege.PUT
@@ -41,8 +41,8 @@ import whisk.core.entity.EntityName
 import whisk.core.entity.LimitedWhiskEntityPut
 import whisk.core.entity.EntityPath
 import whisk.core.entity.Parameters
-import whisk.core.entity.WhiskAuth
 import whisk.http.ErrorResponse.terminate
+import whisk.core.entity.Identity
 
 protected[controller] trait ValidateEntitySize extends Directives {
     protected def validateSize(check: ⇒ Boolean)(implicit tid: TransactionId) = new Directive0 {
@@ -66,7 +66,7 @@ trait WhiskCollectionAPI
     protected def create(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId): RequestContext => Unit
 
     /** Activates entity. Examples include invoking an action, firing a trigger, enabling/disabling a rule. */
-    protected def activate(user: WhiskAuth, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId): RequestContext => Unit
+    protected def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId): RequestContext => Unit
 
     /** Removes entity from namespace. Terminates HTTP request. */
     protected def remove(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId): RequestContext => Unit
@@ -81,7 +81,7 @@ trait WhiskCollectionAPI
     protected val listRequiresPrivateEntityFilter = false // currently supported on PACKAGES only
 
     /** Dispatches resource to the proper handler depending on context. */
-    protected override def dispatchOp(user: WhiskAuth, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
+    protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
         resource.entity match {
             case Some(EntityName(name)) => op match {
                 case READ => fetch(resource.namespace, name, resource.env)

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -25,12 +25,11 @@ import spray.httpx.SprayJsonSupport._
 import spray.routing.Directives
 import whisk.common.TransactionId
 import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath
 import whisk.core.entity.Subject
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskActivation
 import whisk.core.entity.WhiskPackage
@@ -40,6 +39,7 @@ import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
 import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
+import whisk.core.entity.Identity
 
 object WhiskNamespacesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
@@ -71,7 +71,7 @@ trait WhiskNamespacesApi
      *
      * @param user the authenticated user for this route
      */
-    override def routes(user: WhiskAuth)(implicit transid: TransactionId) = {
+    override def routes(user: Identity)(implicit transid: TransactionId) = {
         pathPrefix(collection.path) {
             (collectionOps & requestMethod) { m =>
                 getNamespaces(user.subject)
@@ -91,7 +91,7 @@ trait WhiskNamespacesApi
      * The namespace of the resource is derived from the authenticated user. The
      * resource entity name, if it is defined, may be a different namespace.
      */
-    protected override def dispatchOp(user: WhiskAuth, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
+    protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(implicit transid: TransactionId) = {
         resource.entity match {
             case None if op == READ => getAllInNamespace(resource.namespace)
             case _                  => reject // should not get here

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -50,7 +50,7 @@ import whisk.core.entity.WhiskPackageAction
 import whisk.core.entity.WhiskPackagePut
 import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
-import whisk.core.entity.WhiskAuth
+import whisk.core.entity.Identity
 
 object WhiskPackagesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
@@ -102,7 +102,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
      * Responses are one of (Code, Message)
      * - 405 Not Allowed
      */
-    override def activate(user: WhiskAuth, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
+    override def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
         error(this, "activate is not permitted on packages")
         reject
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -47,14 +47,15 @@ import whisk.core.entity.ReducedRule
 import whisk.core.entity.SemVer
 import whisk.core.entity.Status
 import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskRulePut
 import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.types.EntityStore
+import whisk.core.entity.Identity
 import whisk.http.ErrorResponse.terminate
+import whisk.http.Messages._
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -127,7 +128,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * - 409 Conflict
      * - 500 Internal Server Error
      */
-    override def activate(user: WhiskAuth, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
+    override def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
         extractStatusRequest { requestedState =>
             val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
 

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -54,7 +54,6 @@ import whisk.core.entity.SemVer
 import whisk.core.entity.Status
 import whisk.core.entity.TriggerLimits
 import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskTrigger
@@ -64,6 +63,7 @@ import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
 import spray.httpx.UnsuccessfulResponseException
 import spray.http.StatusCodes
+import whisk.core.entity.Identity
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -125,7 +125,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
      * - 404 Not Found
      * - 500 Internal Server Error
      */
-    override def activate(user: WhiskAuth, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
+    override def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
 
         entity(as[Option[JsObject]]) {
             payload =>
@@ -137,7 +137,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                         info(this, s"[POST] trigger activation id: ${triggerActivationId}")
 
                         val triggerActivation = WhiskActivation(
-                            namespace = user.subject.namespace, // all activations should end up in the one space regardless trigger.namespace,
+                            namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
                             name,
                             user.subject,
                             triggerActivationId,
@@ -162,7 +162,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                             } foreach {
                                 case (ruleName, rule) =>
                                     val ruleActivation = WhiskActivation(
-                                        namespace = user.subject.namespace, // all activations should end up in the one space regardless trigger.namespace,
+                                        namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
                                         ruleName.last,
                                         user.subject,
                                         activationId.make(),

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -19,6 +19,8 @@ package whisk.core.entitlement
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import Privilege.Privilege
+import akka.event.Logging.LogLevel
 import spray.http.HttpMethod
 import spray.http.HttpMethods.DELETE
 import spray.http.HttpMethods.GET
@@ -33,7 +35,6 @@ import whisk.core.entity.WhiskPackage
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.types.EntityStore
-import akka.event.Logging.LogLevel
 
 /**
  * A collection encapsulates the name of a collection and implicit rights when subject

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -16,14 +16,14 @@
 
 package whisk.core.entitlement
 
-import akka.actor.ActorSystem
-
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 
+import Privilege.Privilege
+import akka.actor.ActorSystem
 import whisk.common.TransactionId
-import whisk.core.entity.Subject
 import whisk.core.WhiskConfig
+import whisk.core.entity.Subject
 
 private object LocalEntitlementService {
     /** Poor mans entitlement matrix. Must persist to datastore eventually. */

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -19,6 +19,7 @@ package whisk.core.entitlement
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import Privilege.Privilege
 import spray.http.StatusCodes.NotFound
 import whisk.common.TransactionId
 import whisk.core.controller.RejectRequest

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -22,6 +22,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
+import Privilege.Privilege
 import akka.actor.ActorSystem
 import spray.client.pipelining.Get
 import spray.client.pipelining.Post
@@ -37,12 +38,13 @@ import spray.http.StatusCodes.Unauthorized
 import spray.http.Uri
 import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
 import spray.httpx.UnsuccessfulResponseException
-import spray.json._
+import spray.json.DefaultJsonProtocol
 import spray.json.DefaultJsonProtocol._
+import spray.json.pimpString
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
-import whisk.core.entity.Subject
 import whisk.core.controller.RejectRequest
+import whisk.core.entity.Subject
 
 protected[core] class RemoteEntitlementService(
     private val config: WhiskConfig,

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -45,13 +45,13 @@ import whisk.core.entity.MemoryLimit
 import whisk.core.entity.LogLimit
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.NodeJS6Exec
 import akka.event.Logging.LogLevel
 import akka.event.Logging.InfoLevel
 import whisk.core.entity.BlackBoxExec
+import whisk.core.entity.AuthKey
 
 /**
  * A thread-safe container pool that internalizes container creation/teardown and allows users
@@ -163,7 +163,7 @@ class ContainerPool(
      * The invariant of returning the container back to the pool holds regardless of whether init succeeded or not.
      * In case of failure to start a container, None is returned.
      */
-    def getAction(action: WhiskAction, auth: WhiskAuth)(implicit transid: TransactionId): Option[(WhiskContainer, Option[RunResult])] =
+    def getAction(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): Option[(WhiskContainer, Option[RunResult])] =
         if (shuttingDown) {
             info(this, s"Shutting down: Not getting container for ${action.fullyQualifiedName} with ${auth.uuid}")
             None
@@ -525,7 +525,7 @@ class ContainerPool(
         }
 
     // Obtain a container (by creation or promotion) and initialize by sending code.
-    private def makeWhiskContainer(action: WhiskAction, auth: WhiskAuth)(implicit transid: TransactionId): FinalContainerResult = {
+    private def makeWhiskContainer(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): FinalContainerResult = {
         val imageName = getDockerImageName(action)
         val limits = action.limits
         val nodeImageName = WhiskAction.containerImageName(nodejsExec, config.dockerRegistry, config.dockerImagePrefix, config.dockerImageTag)

--- a/tests/src/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/whisk/core/admin/WskAdminTests.scala
@@ -56,8 +56,8 @@ class WskAdminTests
         wskadmin.cli(Seq("user", "whois", authkey)).stdout.trim should be(subject)
         wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
 
-        val recreate = wskadmin.cli(Seq("user", "create", subject, "-u", auth.compact))
-        wskadmin.cli(Seq("user", "get", subject)).stdout.trim should be(auth.compact)
+        val recreate = wskadmin.cli(Seq("user", "create", subject, "-u", auth.authkey.compact))
+        wskadmin.cli(Seq("user", "get", subject)).stdout.trim should be(auth.authkey.compact)
         wskadmin.cli(Seq("user", "delete", subject)).stdout should include("Subject deleted")
     }
 

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -39,9 +39,7 @@ import whisk.core.entity.AuthKey
 import whisk.core.entity.EntityName
 import whisk.core.entity.Exec
 import whisk.core.entity.EntityPath
-import whisk.core.entity.Subject
 import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import scala.language.postfixOps
@@ -220,7 +218,7 @@ class ContainerPoolTests extends FlatSpec
     }
 
     private val defaultNamespace = EntityPath("container pool test")
-    private val defaultAuth = WhiskAuth(Subject(), AuthKey()) // XXXXXX test this with a real uuid/key
+    private val defaultAuth = AuthKey()
 
     /*
      * Create an action with the given name that print hello_N payload !

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -81,7 +81,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     /** Actions API tests */
     behavior of "Actions API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("action_tests")
@@ -137,7 +137,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         }
 
         // it should "reject list action with explicit namespace not owned by subject" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -173,7 +173,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         }
 
         // it should "reject get action by name in explicit namespace not owned by subject" in
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -202,7 +202,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, action)
 
         // it should "reject delete action by name not owned by subject" in
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -436,7 +436,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val content = WhiskActionPut(Some(action.exec), Some(action.parameters))
 
         // it should "reject put action in namespace not owned by subject" in
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Put(s"/$namespace/${collection.path}/${action.name}", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -564,7 +564,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, action)
 
         // it should "reject post to action in namespace not owned by subject"
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Post(s"/$namespace/${collection.path}/${action.name}", args) ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }

--- a/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
@@ -58,7 +58,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     /** Activations API tests */
     behavior of "Activations API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("activations_tests")

--- a/tests/src/whisk/core/controller/test/AuthenticateTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthenticateTests.scala
@@ -62,7 +62,7 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
         val creds = createTempCredentials._1
         val pass = UserPass(creds.uuid(), creds.key())
         val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
-        user.get should be(creds)
+        user.get should be(creds.toIdentity)
     }
 
     it should "authorize a known user from cache" in {
@@ -76,13 +76,13 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
         authStore.outputStream = printstream
         try {
             val user = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
-            user.get should be(creds)
+            user.get should be(creds.toIdentity)
             stream.toString should include regex (s"serving from datastore: ${creds.uuid()}")
             stream.reset()
 
             // repeat query, should be served from cache
             val cachedUser = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
-            cachedUser.get should be(creds)
+            cachedUser.get should be(creds.toIdentity)
             stream.toString should include regex (s"serving from cache: ${creds.uuid()}")
             stream.reset()
 
@@ -103,7 +103,7 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
             val refetchedUser = Await.result(validateCredentials(Some(newPass))(transid()), dbOpTimeout)
             stream.toString should include regex (s"serving from cache: ${creds.uuid()}")
             refetchedUser.isDefined should be(true)
-            refetchedUser.get should be(newCreds)
+            refetchedUser.get should be(newCreds.toIdentity)
         } finally {
             authStore.outputStream = savedstream
             stream.close()

--- a/tests/src/whisk/core/controller/test/NamespacesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/NamespacesApiTests.scala
@@ -53,7 +53,7 @@ class NamespacesApiTests extends ControllerTestCommon with WhiskNamespacesApi {
     behavior of "Namespaces API"
 
     val collectionPath = s"/${collection.path}"
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
 
     it should "list namespaces for subject" in {

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -67,7 +67,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     /** Package Actions API tests */
     behavior of "Package Actions API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("package_action_tests")
@@ -188,7 +188,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject put action in package owned by different subject" in {
         implicit val tid = transid()
-        val provider = WhiskPackage(Subject().namespace, aname, publish = true)
+        val provider = WhiskPackage(EntityPath(Subject()()), aname, publish = true)
         val content = WhiskActionPut(Some(Exec.js("??")))
         put(entityStore, provider)
         Put(s"/${provider.namespace}/${collection.path}/${provider.name}/$aname", content) ~> sealRoute(routes(creds)) ~> check {
@@ -205,7 +205,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, action)
 
         // it should "reject delete action in package owned by different subject" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Delete(s"/${provider.namespace}/${collection.path}/${provider.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -266,7 +266,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "get action in package binding with public package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, publish = true)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
@@ -284,7 +284,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "get action in package binding with public package with overriding parameters" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A") ++ Parameters("b", "b"))
@@ -304,7 +304,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     // check on either one or both of the binding and package
     ignore should "get action in package binding with explicit entitlement grant" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A"))
@@ -343,7 +343,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject get action in package binding that does not exist" in {
         implicit val tid = transid()
         val name = aname
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A"))
@@ -357,7 +357,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject get action in package binding with package that does not exist" in {
         implicit val tid = transid()
         val name = aname
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A"))
@@ -371,7 +371,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject get non-existing action in package binding" in {
         implicit val tid = transid()
         val name = aname
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = true)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A"))
@@ -384,7 +384,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject get action in package binding with private package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, None, Parameters("p", "P"), publish = false)
         val binding = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind, Parameters("b", "B"))
         val action = WhiskAction(provider.path, aname, Exec.js("??"), Parameters("a", "A"))
@@ -413,7 +413,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "allow non-owner to invoke an action in public package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, publish = true)
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
         val content = JsObject("xxx" -> "yyy".toJson)
@@ -428,7 +428,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "invoke action in package binding with public package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, publish = true)
         val reference = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind)
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
@@ -447,7 +447,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     // check on either one or both of the binding and package
     ignore should "invoke action in package binding with explicit entitlement grant even if package is not public" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, publish = false)
         val reference = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind)
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
@@ -466,7 +466,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject non-owner invoking an action in private package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, publish = false)
         val action = WhiskAction(provider.path, aname, Exec.js("??"))
         val content = JsObject("xxx" -> "yyy".toJson)
@@ -502,7 +502,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject invoke action in package binding with private package" in {
         implicit val tid = transid()
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         val provider = WhiskPackage(namespace, aname, publish = false)
         val reference = WhiskPackage(EntityPath(auser.subject()), aname, provider.bind)
         val action = WhiskAction(provider.path, aname, Exec.js("??"))

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -65,7 +65,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     /** Packages API tests */
     behavior of "Packages API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("packages_tests")
@@ -99,7 +99,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
         }
 
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(auser)) ~> check {
             val response = responseAs[List[JsObject]]
             response should be(List()) // cannot list packages that are private in another namespace
@@ -131,7 +131,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             expected forall { p => (response contains p.summaryAsJson) } should be(true)
         }
 
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(auser)) ~> check {
             status should be(OK)
             val response = responseAs[List[JsObject]]
@@ -213,7 +213,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             Get(s"$collectionPath?public=true") ~> sealRoute(routes(creds)) ~> check {
                 status should be(OK)
                 val response = responseAs[List[JsObject]]
-                val expected = providers filter { _.namespace == creds.subject.namespace }
+                val expected = providers filter { _.namespace == creds.namespace.toPath }
                 response.length should be >= (expected.length)
                 expected forall { p => (response contains p.summaryAsJson) && p.binding == None } should be(true)
             }
@@ -273,7 +273,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, feed)
 
         // it should "reject get private package from other subject" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${provider.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -297,7 +297,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, feed)
 
         // it should "reject get package reference from other subject" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${reference.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -334,7 +334,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
 
         // it should "reject create package reference in some other namespace" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -434,7 +434,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
 
         // it should "reject update package owned by different user" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Put(s"/$namespace/${collection.path}/${provider.name}?overwrite=true", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -457,7 +457,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, reference)
 
         // it should "reject update package reference owned by different user"
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Put(s"/$namespace/${collection.path}/${reference.name}?overwrite=true", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -504,7 +504,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
 
         // it should "reject deleting package owned by different user" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${provider.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }
@@ -523,7 +523,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, reference)
 
         // it should "reject deleting package reference owned by different user" in {
-        val auser = WhiskAuth(Subject(), AuthKey())
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
         Get(s"/$namespace/${collection.path}/${reference.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(Forbidden)
         }

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -71,7 +71,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     /** Rules API tests */
     behavior of "Rules API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     def aname = MakeName.next("rules_tests")
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -70,7 +70,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     /** Triggers API tests */
     behavior of "Triggers API"
 
-    val creds = WhiskAuth(Subject(), AuthKey())
+    val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("triggers_tests")

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -45,6 +45,7 @@ import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
 import whisk.core.entity.FullyQualifiedEntityName
 import whisk.common.Logging
+import whisk.core.entity.AuthKey
 
 @RunWith(classOf[JUnitRunner])
 class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
@@ -64,8 +65,9 @@ class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
     def sendMessage(connector: TestConnector, count: Int) = {
         val content = JsObject("payload" -> JsNumber(count))
         val subject = Subject()
+        val authkey = AuthKey()
         val path = FullyQualifiedEntityName(EntityPath("test"), EntityName(s"count-$count"), None)
-        val msg = Message(TransactionId.testing, path, subject, ActivationId(), subject.namespace, Some(content))
+        val msg = Message(TransactionId.testing, path, subject, authkey, ActivationId(), EntityPath(subject()), Some(content))
         connector.send(msg)
     }
 


### PR DESCRIPTION
Introduces the foundation for limited scope keys: an activation only key with no CRUD rights. Commits are incremental and self-contained, working up to the point of using the new Identity type to reject requests to CRUD resources with activation keys.

This builds on #1254 (first two commits will be dropped from this pull request).