### PR TITLE
Use variable to represent CLI executable path

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -73,6 +73,8 @@ docker:
   restart:
     policy: always
 
+cli_path: "{{ openwhisk_home }}/bin/go-cli/wsk"
+
 # The default name space is /whisk.system. The catalog namespace must begin with a slash "/".
 catalog_namespace: "/whisk.system"
 

--- a/ansible/tasks/installOpenwhiskCatalog.yml
+++ b/ansible/tasks/installOpenwhiskCatalog.yml
@@ -29,6 +29,6 @@
     version: "{{ version }}"
 
 - name: install the catalog from the catalog location
-  shell: ./installCatalog.sh {{ catalog_auth_key }} {{ api_host }} {{ catalog_namespace }} chdir="{{ catalog_location }}/packages"
+  shell: ./installCatalog.sh {{ catalog_auth_key }} {{ api_host }} {{ catalog_namespace }} {{ cli_path }} chdir="{{ catalog_location }}/packages"
   environment:
     OPENWHISK_HOME: "{{ openwhisk_home }}"


### PR DESCRIPTION
CLI location is changing and this will affect the catalog repository.  Updating the catalog script to allow the CLI path to be passed in as a variable.