### PR TITLE
docker rm instead of outdated ansible for now.

### DIFF
--- a/ansible/roles/go-cli/tasks/deploy.yml
+++ b/ansible/roles/go-cli/tasks/deploy.yml
@@ -24,9 +24,6 @@
 
 - name: "stop Docker"
   shell: "docker stop go-cli"
-  
+
 - name: "remove go-cli container after publishing"
-  docker:
-    name: go-cli
-    image: "{{ docker_registry }}{{ docker_image_prefix }}/go-cli:{{ docker_image_tag }}"
-    state: absent
+  shell: "docker rm go-cli"


### PR DESCRIPTION
old ansible docker module makes problems since docker upgrade. this should work until we use a newer docker ansible module (docker_container module)