### PR TITLE
Allow Namespace to be Set When Setting an API Host

### DIFF
--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -97,6 +97,21 @@ class WskBasicUsageTests
         stdout should include regex ("""(?i)whisk API version\s+v1""")
     }
 
+    it should "set apihost, auth, and namespace" in {
+        val tmpwskprops = File.createTempFile("wskprops", ".tmp")
+        try {
+            val namespace = wsk.namespace.list().stdout.trim.split("\n").last
+            val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
+            val stdout = wsk.cli(Seq("property", "set", "-i", "--apihost", wskprops.apihost, "--auth", wskprops.authKey,
+                "--namespace", namespace), env = env).stdout
+            stdout should include (s"ok: whisk auth set to ${wskprops.authKey}")
+            stdout should include (s"ok: whisk API host set to ${wskprops.apihost}")
+            stdout should include (s"ok: whisk namespace set to ${namespace}")
+        } finally {
+            tmpwskprops.delete()
+        }
+    }
+
     it should "show api build version using property file" in {
         val tmpwskprops = File.createTempFile("wskprops", ".tmp")
         try {

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -32,12 +32,12 @@ import (
 var client *whisk.Client
 
 func setupClientConfig(cmd *cobra.Command, args []string) (error){
-    baseURL, err := urlBase()
+    baseURL, err := getURLBase(Properties.APIHost)
 
     // Don't display the 'invalid apihost' error if this CLI invocation is setting that value
     isApiHostPropSetCmd := cmd.Parent().Name() == "property" && cmd.Name() == "set" && len(flags.property.apihostSet) > 0
     if err != nil && !isApiHostPropSetCmd {
-        whisk.Debug(whisk.DbgError, "urlBase() error: %s\n", err)
+        whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s\n", Properties.APIHost, err)
         errMsg := fmt.Sprintf(
             wski18n.T("error: The configured API host property value '{{.apihost}}' is invalid : {{.err}}",
                 map[string]interface{}{"apihost": Properties.APIHost, "err": err}))

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -90,11 +90,11 @@ var propertySetCmd = &cobra.Command{
         }
 
         if apiHost := flags.property.apihostSet; len(apiHost) > 0 {
-            baseURL, err := urlBase()
+            baseURL, err := getURLBase(apiHost)
 
             if err != nil {
                 // Not aborting now.  Subsequent commands will result in error
-                whisk.Debug(whisk.DbgError, "urlBase() error: %s", err)
+                whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s", apiHost, err)
                 errStr := fmt.Sprintf(
                     wski18n.T("Unable to set API host value; the API host value '{{.apihost}}' is invalid: {{.err}}",
                         map[string]interface{}{"apihost": apiHost, "err": err}))
@@ -482,10 +482,10 @@ func parseConfigFlags(cmd *cobra.Command, args []string) error {
 
         if client != nil {
             client.Config.Host = apiHost
-            baseURL, err := urlBase()
+            baseURL, err := getURLBase(apiHost)
 
             if err != nil {
-                whisk.Debug(whisk.DbgError, "urlBase() failed: %s\n", err)
+                whisk.Debug(whisk.DbgError, "getURLBase(%s) failed: %s\n", apiHost, err)
                 errStr := fmt.Sprintf(
                     wski18n.T("Invalid host address '{{.host}}': {{.err}}",
                         map[string]interface{}{"host": Properties.APIHost, "err": err}))

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -823,12 +823,12 @@ func checkArgs(args []string, minimumArgNumber int, maximumArgNumber int, comman
     }
 }
 
-func urlBase() (*url.URL, error)  {
-    urlBase := fmt.Sprintf("%s/api/", Properties.APIHost)
+func getURLBase(host string) (*url.URL, error)  {
+    urlBase := fmt.Sprintf("%s/api/", host)
     url, err := url.Parse(urlBase)
 
     if len(url.Scheme) == 0 || len(url.Host) == 0 {
-        urlBase = fmt.Sprintf("https://%s/api/", Properties.APIHost)
+        urlBase = fmt.Sprintf("https://%s/api/", host)
         url, err = url.Parse(urlBase)
     }
 


### PR DESCRIPTION
- Fix bug that prevents a namespace from being set at the same time the API is set
- Add test to ensure namespace can be set with API host and auth
