### PR TITLE
Reading old invoker state upon startup

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Counter.scala
+++ b/common/scala/src/main/scala/whisk/common/Counter.scala
@@ -38,4 +38,9 @@ class Counter {
     def prev(): Int = {
         cnt.decrementAndGet()
     }
+
+    /**
+     * Sets the value
+     */
+    def set(i: Int) = cnt.set(i)
 }


### PR DESCRIPTION
This is intended to be a stop-gap solution to make the Invoker restartable until the new algorithm by @perryibm is in place.