### PR TITLE
replace InMemoryCache with new impl that avoids read under write race

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -169,6 +169,8 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             implicit val ec = db.executionContext
 
             val key = doc.id.asDocInfo
+            // invalidate the key because attachments update the revision;
+            // do not cache the new attachment (controller does not need it)
             cacheInvalidate(key, {
                 val src = StreamConverters.fromInputStream(() => bytes)
                 db.attach(doc, attachmentName, contentType, src)

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -142,7 +142,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             implicit val logger = db: Logging
             implicit val ec = db.executionContext
 
-            var key = cacheKeyForUpdate(doc)
+            val key = cacheKeyForUpdate(doc)
 
             cacheInvalidate(key)
 
@@ -152,7 +152,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
                     case w: DocumentRevisionProvider => w.revision[W](docinfo.rev)
                 }
                 docinfo
-            }).future
+            })
 
         } match {
             case Success(f) => f
@@ -168,7 +168,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             require(doc != null, "doc undefined")
         } map { _ =>
             implicit val logger: Logging = db
-            var key = doc.id.asDocInfo
+            val key = doc.id.asDocInfo
             cacheInvalidate(key)
             val src = StreamConverters.fromInputStream(() => bytes)
             db.attach(doc, attachmentName, contentType, src)
@@ -185,7 +185,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             require(doc != null, "doc undefined")
         } map { _ =>
             implicit val logger: Logging = db
-            var key = doc.id.asDocInfo
+            val key = doc.id.asDocInfo
             cacheInvalidate(key)
             db.del(doc)
         } match {

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -120,7 +120,7 @@ trait DocumentSerializer {
  * but the get permits a datastore of its super type so that a single datastore client
  * may be used for multiple types (because the types are stored in the same database for example).
  */
-trait DocumentFactory[W] extends MultipleReadersSingleWriterCache/*InMemoryCache*/[W, DocInfo] {
+trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
     /**
      * Puts a record of type W in the datastore.
      *

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -199,7 +199,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
     }
 
     /**
-     * FIXME UPDATE Fetches a raw record of type R from the datastore by its id (and revision if given)
+     * Fetches a raw record of type R from the datastore by its id (and revision if given)
      * and converts it to Success(W) or Failure(Throwable) if there is an error fetching
      * the record or deserializing it.
      *

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -169,8 +169,16 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
                                 invalidateEntryAfter(invalidator, key, actualEntry)
                             }
 
-                        case InvalidateInProgress | InvalidateWhenDone =>
-                            // someone else requested an invalidation already
+                        case InvalidateInProgress =>
+                            if (actualEntry.transid == transid) {
+                                // we own the entry, so we are responsible for cleaning it up
+                                invalidateEntryAfter(invalidator, key, actualEntry)
+                            } else {
+                                // someone else requested an invalidation already
+                                invalidator
+                            }
+                        case InvalidateWhenDone =>
+                            // a pre-existing owner will take care of the invalidation
                             invalidator
                     }
                 }

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.DurationInt
+import scala.language.implicitConversions
+import scala.util.Failure
+import scala.util.Success
+
+import spray.caching.Cache
+import spray.caching.LruCache
+import spray.caching.ValueMagnet.fromAny
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.common.TransactionId
+
+/**
+ * A cache that allows multiple readers, bit only a single writer, at
+ * a time. It will make a best effort attempt to coalesce reads, but
+ * does not guarantee that all overlapping reads will be coalesced.
+ *
+ * The cache operates by bracketing all reads and writes. A read
+ * imposes a lightweight read lock, by inserting an entry into the
+ * cache with State.ReadInProgress. A write does the same, with
+ * State.WriteInProgress.
+ *
+ * On read or write completion, the value transitions to
+ * State.Cached.
+ *
+ * State.Initial is represented implicitly by absence from the cache.
+ *
+ * The handshake for cache entry state transition is:
+ * 1. if entry is in an agreeable state, proceed
+ *    where agreeable for reads is Initial, ReadInProgress, or Cached
+ *                    and the read proceeds by ensuring the entry is State.ReadInProgress
+ *      and agreeable for writes is Initial or Cached
+ *                    and the write proceeds by ensuring the entry is State.WriteInProgress
+ *
+ * 2. if entry is not in an agreeable state, fail fast with Future.failed(new ConcurrentUpdateException)
+ *
+ * 3. to swap in the new state to an existing entry, we use an AtomicReference.compareAndSet
+ *
+ * 4. after adding a new entry, we double check that the state of the actually-added entry
+ *    is agreeable with the desired action (as per item 1)
+ *
+ */
+trait MultipleReadersSingleWriterCache[W, Winfo] {
+  val DEBUG = true
+
+  /** Subclasses: Toggle this to enable/disable caching for your entity type. */
+  protected def cacheEnabled = true
+
+  /** Subclasses: tell me what key to use for updates */
+  protected def cacheKeyForUpdate(w: W): Any
+
+  /**
+   * Each entry has a state
+   *
+   */
+  protected object State extends Enumeration {
+    type State = Value
+    val ReadInProgress, WriteInProgress, InvalidateInProgress, Cached = Value
+  }
+  import State._;
+  implicit def state2Atomic(state: State): AtomicReference[State] = {
+    new AtomicReference(state);
+  }
+
+  /**
+   * Failure modes
+   *
+   */
+  private class ConcurrentUpdateException extends Exception {}
+
+  /**
+   * The entries in the cache will be a pair of State and the Future value
+   *
+   */
+  private case class Entry(transid: TransactionId, state: AtomicReference[State], value: Future[W]) {
+    def invalidate {
+      state.set(InvalidateInProgress)
+    }
+
+    def writeDone()(implicit logger: Logging): Boolean = {
+      if (DEBUG) logger.info(this, "Write finished")
+      trySet(WriteInProgress, Cached)
+    }
+
+    def readDone(value: W, promise: Promise[W])(implicit logger: Logging): Unit = {
+      logger.info(this, "Read finished")
+
+      if (trySet(ReadInProgress, Cached)) {
+        promise success value
+      } else {
+        promise failure new ConcurrentUpdateException
+      }
+    }
+
+    def trySet(expectedState: State, desiredState: State): Boolean = {
+      state.compareAndSet(expectedState, desiredState)
+    }
+  }
+
+  protected def cacheInvalidate(key: Any)(
+    implicit transid: TransactionId, logger: Logging): Unit = {
+    if (cacheEnabled) {
+      logger.info(this, s"invalidating $key")
+      cache remove key
+    }
+  }
+
+  protected def cacheLookup[Wsuper >: W](
+    key: Any,
+    future: => Future[W],
+    fromCache: Boolean = cacheEnabled)(
+      implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[W] = {
+
+    if (fromCache) {
+      val promise = Promise[W]
+      val desiredEntry = Entry(transid, ReadInProgress, promise.future)
+
+      //
+      // try inserting our desired entry...
+      //
+      cache(key)(desiredEntry) flatMap {
+        // ... and see what we get back
+        case actualEntry =>
+          // if (DEBUG) logger.info(this, s"Cache Lookup Status: the entry is currently in state ${actualEntry.state.get} ${getSize()}")
+
+          actualEntry.state.get match {
+            case Cached => {
+              if (DEBUG) logger.info(this, s"Cached read $key")
+              makeNoteOfCacheHit(key)
+              actualEntry.value
+            }
+
+            case ReadInProgress => {
+              if (actualEntry.transid == transid) {
+                if (DEBUG) logger.info(this, "Read initiated");
+                makeNoteOfCacheMiss(key)
+                listenForReadDone(key, actualEntry, future, promise)
+                actualEntry.value
+
+              } else {
+                if (DEBUG) logger.info(this, "Coalesced read")
+                makeNoteOfCacheHit(key)
+                actualEntry.value
+              }
+            }
+
+            case WriteInProgress | InvalidateInProgress => {
+              if (DEBUG) logger.info(this, "Reading around a write in progress")
+              makeNoteOfCacheMiss(key)
+              future
+            }
+          }
+      }
+
+    } else {
+      // not caching
+      future
+    }
+  }
+
+  protected def cacheUpdate(doc: W, key: Any, future: => Future[Winfo])(
+    implicit transid: TransactionId, logger: Logging, ec: ExecutionContext): Promise[Winfo] = {
+
+    val valPromise = Promise[W]
+    val promise = Promise[Winfo]
+
+    if (cacheEnabled) {
+      logger.info(this, s"caching $key")
+
+      val desiredEntry = Entry(transid, WriteInProgress, valPromise.future)
+
+      //
+      // try inserting our desired entry...
+      //
+      cache(key)(desiredEntry) map {
+        // ... and see what we get back
+        case actualEntry =>
+          if (transid == actualEntry.transid) {
+            //
+            // then we won the race, and now own the entry
+            //
+            if (DEBUG) logger.info(this, s"Write initiated $key")
+            listenForWriteDone(doc, key, actualEntry, future, valPromise, promise)
+
+          } else {
+            //
+            // then we either lost the race, or there is an operation in progress on this key
+            //
+            if (DEBUG) logger.info(this, s"Write under ${actualEntry.state.get} $key")
+            promise completeWith future
+          }
+      }
+
+    } else {
+      // not caching
+      promise completeWith future
+    }
+
+    promise
+  }
+
+  def getSize() = cache.size
+
+  /**
+   * Log a cache hit
+   *
+   */
+  private def makeNoteOfCacheHit(key: Any)(implicit transid: TransactionId, logger: Logging) {
+    transid.mark(this, LoggingMarkers.DATABASE_CACHE_HIT, s"[GET] serving from cache: $key")(logger)
+  }
+
+  /**
+   * Log a cache miss
+   *
+   */
+  private def makeNoteOfCacheMiss(key: Any)(implicit transid: TransactionId, logger: Logging) {
+    transid.mark(this, LoggingMarkers.DATABASE_CACHE_MISS, s"[GET] serving from datastore: $key")(logger)
+  }
+
+  /**
+   * We have initiated a read (in cacheLookup), now handle its completion
+   *
+   */
+  private def listenForReadDone(key: Any, entry: Entry, future: => Future[W], promise: Promise[W])(
+    implicit logger: Logging): Unit = {
+
+    future onComplete {
+      case Success(value) => entry.readDone(value, promise)
+      case Failure(t)     => readOops(key, entry, promise, t)
+    }
+  }
+
+  /**
+   * We have initiated a write, now handle its completion
+   *
+   */
+  private def listenForWriteDone(doc: W, key: Any, entry: Entry, future: => Future[Winfo], valPromise: Promise[W], promise: Promise[Winfo])(
+    implicit logger: Logging): Unit = {
+
+    future onComplete {
+      case Success(docinfo) => {
+        //
+        // if the datastore write was successful, then transition to the Cached state
+        //
+        if (DEBUG) logger.info(this, "Write backend part done, now marking cache entry as done")
+
+        if (!entry.writeDone()) {
+          logger.error(this, "Concurrent update detected")
+          writeOops(key, entry, valPromise, promise, new ConcurrentUpdateException)
+
+        } else {
+          if (DEBUG) logger.info(this, s"Write all done $key ${entry.transid} ${entry.state.get} ${getSize()}")
+          promise success docinfo
+          valPromise success doc
+        }
+      }
+      case Failure(t) => {
+        //
+        // oops, the datastore write failed. invalidate the cache entry
+        //
+        writeOops(key, entry, valPromise, promise, t)
+      }
+    }
+  }
+
+  /**
+   * Write completion resulted in a failure
+   *
+   */
+  private def readOops(key: Any, entry: Entry, promise: Promise[W], t: Throwable) {
+    entry.invalidate
+    cache remove key
+    promise failure t
+  }
+
+  /**
+   * Write completion resulted in a failure
+   *
+   */
+  private def writeOops(key: Any, entry: Entry, valPromise: Promise[W], promise: Promise[Winfo], t: Throwable) {
+    entry.invalidate
+    cache remove key
+    promise failure t
+    valPromise failure t
+  }
+
+  /**
+   * This is the backing store
+   */
+  private val cache: Cache[Entry] = LruCache.apply(timeToLive = 5.minutes)
+}

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -203,6 +203,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
         implicit transid: TransactionId, logger: Logging, ec: ExecutionContext): Future[Winfo] = {
 
         if (cacheEnabled) {
+            logger.info(this, s"invalidating $key") // make the tests happy, as cacheUpdate now has invalidate built in
             logger.info(this, s"caching $key")
 
             val desiredEntry = Entry(transid, WriteInProgress, Future { doc })

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -272,7 +272,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
                         val allowedToAssumeCompletion = currentState == Cached || currentState == ReadInProgress
 
                         if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
-                            // this transaciton is now responsible for updating the cache entry
+                            // this transaction is now responsible for updating the cache entry
                             logger.info(this, s"write initiated on existing cache entry")
                             listenForWriteDone(key, actualEntry, generator)
                         } else {

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -247,8 +247,8 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
                 //
                 // oops, the datastore read failed. invalidate the cache entry
                 //
-                // note that this might be a perfectly legitimate failure, 
-                // e.g. a lookup for a non-existant key; we need to pass the particular t through 
+                // note that this might be a perfectly legitimate failure,
+                // e.g. a lookup for a non-existant key; we need to pass the particular t through
                 //
                 readOops(key, entry, promise, t)
             }

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -151,57 +151,54 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
      */
     protected def cacheInvalidate[R](key: Any, invalidator: => Future[R])(
         implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[R] = {
-        cacheEnabled match {
-            case true =>
-                logger.info(this, s"invalidating $key")
+        if (cacheEnabled) {
+            logger.info(this, s"invalidating $key")
 
-                // try inserting our desired entry...
-                val desiredEntry = Entry(transid, InvalidateInProgress, None)
-                cache(key)(desiredEntry) flatMap { actualEntry =>
-                    // ... and see what we get back
-                    val currentState = actualEntry.state.get
+            // try inserting our desired entry...
+            val desiredEntry = Entry(transid, InvalidateInProgress, None)
+            cache(key)(desiredEntry) flatMap { actualEntry =>
+                // ... and see what we get back
+                val currentState = actualEntry.state.get
 
-                    currentState match {
-                        case Cached =>
-                            // nobody owns the entry, forcefully grab ownership
-                            // note: if a new cache lookup is received while
-                            // the invalidator has not yet completed (and hence the actual entry
-                            // removed from the cache), such lookup operations will still be able
-                            // to return the value that is cached, and this is acceptable (under
-                            // the eventual consistency model) as long as such lookups do not
-                            // mutate the state of the cache to violate the invalidation that is
-                            // about to occur (this is eventually consistent and NOT sequentially
-                            // consistent since the cache lookup and the setting of the
-                            // InvalidateInProgress bit are not atomic
-                            invalidateEntryAfter(invalidator, key, actualEntry)
+                currentState match {
+                    case Cached =>
+                        // nobody owns the entry, forcefully grab ownership
+                        // note: if a new cache lookup is received while
+                        // the invalidator has not yet completed (and hence the actual entry
+                        // removed from the cache), such lookup operations will still be able
+                        // to return the value that is cached, and this is acceptable (under
+                        // the eventual consistency model) as long as such lookups do not
+                        // mutate the state of the cache to violate the invalidation that is
+                        // about to occur (this is eventually consistent and NOT sequentially
+                        // consistent since the cache lookup and the setting of the
+                        // InvalidateInProgress bit are not atomic
+                        invalidateEntryAfter(invalidator, key, actualEntry)
 
-                        case ReadInProgress | WriteInProgress =>
-                            if (actualEntry.trySet(currentState, InvalidateWhenDone)) {
-                                // then the pre-existing owner will take care of the invalidation
-                                invalidator
-                            } else {
-                                // the pre-existing reader or writer finished and so must
-                                // explicitly invalidate here
-                                invalidateEntryAfter(invalidator, key, actualEntry)
-                            }
-
-                        case InvalidateInProgress =>
-                            if (actualEntry.id() == transid) {
-                                // we own the entry, so we are responsible for cleaning it up
-                                invalidateEntryAfter(invalidator, key, actualEntry)
-                            } else {
-                                // someone else requested an invalidation already
-                                invalidator
-                            }
-
-                        case InvalidateWhenDone =>
-                            // a pre-existing owner will take care of the invalidation
+                    case ReadInProgress | WriteInProgress =>
+                        if (actualEntry.trySet(currentState, InvalidateWhenDone)) {
+                            // then the pre-existing owner will take care of the invalidation
                             invalidator
-                    }
-                }
+                        } else {
+                            // the pre-existing reader or writer finished and so must
+                            // explicitly invalidate here
+                            invalidateEntryAfter(invalidator, key, actualEntry)
+                        }
 
-            case _ => invalidator // not caching
-        }
+                    case InvalidateInProgress =>
+                        if (actualEntry.id() == transid) {
+                            // we own the entry, so we are responsible for cleaning it up
+                            invalidateEntryAfter(invalidator, key, actualEntry)
+                        } else {
+                            // someone else requested an invalidation already
+                            invalidator
+                        }
+
+                    case InvalidateWhenDone =>
+                        // a pre-existing owner will take care of the invalidation
+                        invalidator
+                }
+            }
+        } else invalidator // not caching
     }
 
     /**
@@ -209,45 +206,42 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
      */
     protected def cacheLookup[Wsuper >: W](key: Any, generator: => Future[W], fromCache: Boolean = cacheEnabled)(
         implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[W] = {
-        fromCache match {
-            case true =>
-                val promise = Promise[W] // this promise completes with the generator value
+        if (fromCache) {
+            val promise = Promise[W] // this promise completes with the generator value
 
-                // try inserting our desired entry...
-                val desiredEntry = Entry(transid, ReadInProgress, Some(promise.future))
-                cache(key)(desiredEntry) flatMap { actualEntry =>
-                    // ... and see what we get back
+            // try inserting our desired entry...
+            val desiredEntry = Entry(transid, ReadInProgress, Some(promise.future))
+            cache(key)(desiredEntry) flatMap { actualEntry =>
+                // ... and see what we get back
 
-                    actualEntry.state.get match {
-                        case Cached =>
-                            logger.debug(this, "cached read")
+                actualEntry.state.get match {
+                    case Cached =>
+                        logger.debug(this, "cached read")
+                        makeNoteOfCacheHit(key)
+                        actualEntry.unpack
+
+                    case ReadInProgress =>
+                        if (actualEntry.id() == transid) {
+                            logger.debug(this, "read initiated");
+                            makeNoteOfCacheMiss(key)
+                            // updating the cache with the new value is done in the listener
+                            // and will complete unless an invalidation request or an intervening
+                            // write occur in the meantime
+                            listenForReadDone(key, actualEntry, generator, promise)
+                            actualEntry.unpack
+                        } else {
+                            logger.debug(this, "coalesced read")
                             makeNoteOfCacheHit(key)
                             actualEntry.unpack
+                        }
 
-                        case ReadInProgress =>
-                            if (actualEntry.id() == transid) {
-                                logger.debug(this, "read initiated");
-                                makeNoteOfCacheMiss(key)
-                                // updating the cache with the new value is done in the listener
-                                // and will complete unless an invalidation request or an intervening
-                                // write occur in the meantime
-                                listenForReadDone(key, actualEntry, generator, promise)
-                                actualEntry.unpack
-                            } else {
-                                logger.debug(this, "coalesced read")
-                                makeNoteOfCacheHit(key)
-                                actualEntry.unpack
-                            }
-
-                        case WriteInProgress | InvalidateInProgress =>
-                            logger.debug(this, "reading around an update in progress")
-                            makeNoteOfCacheMiss(key)
-                            generator
-                    }
+                    case WriteInProgress | InvalidateInProgress =>
+                        logger.debug(this, "reading around an update in progress")
+                        makeNoteOfCacheMiss(key)
+                        generator
                 }
-
-            case _ => generator // not caching
-        }
+            }
+        } else generator // not caching
     }
 
     /**
@@ -255,38 +249,35 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
      */
     protected def cacheUpdate(doc: W, key: Any, generator: => Future[Winfo])(
         implicit ec: ExecutionContext, transid: TransactionId, logger: Logging): Future[Winfo] = {
-        cacheEnabled match {
-            case true =>
-                // try inserting our desired entry...
-                val desiredEntry = Entry(transid, WriteInProgress, Some(Future.successful(doc)))
-                cache(key)(desiredEntry) flatMap { actualEntry =>
-                    // ... and see what we get back
+        if (cacheEnabled) {
+            // try inserting our desired entry...
+            val desiredEntry = Entry(transid, WriteInProgress, Some(Future.successful(doc)))
+            cache(key)(desiredEntry) flatMap { actualEntry =>
+                // ... and see what we get back
 
-                    // there's an assumed invariant here that transid is unique and not recycled
-                    if (actualEntry.id() == transid) {
-                        // then this transaction won the race to insert a new entry in the cache
-                        // and it is responsible for updating the cache entry...
-                        logger.info(this, s"write initiated on new cache entry")
+                // there's an assumed invariant here that transid is unique and not recycled
+                if (actualEntry.id() == transid) {
+                    // then this transaction won the race to insert a new entry in the cache
+                    // and it is responsible for updating the cache entry...
+                    logger.info(this, s"write initiated on new cache entry")
+                    listenForWriteDone(key, actualEntry, generator)
+                } else {
+                    // ... otherwise, some existing entry is in the way, so try to grab a write lock
+                    val currentState = actualEntry.state.get
+                    val allowedToAssumeCompletion = currentState == Cached || currentState == ReadInProgress
+
+                    if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
+                        // this transaction is now responsible for updating the cache entry
+                        logger.info(this, s"write initiated on existing cache entry invalidating $key")
                         listenForWriteDone(key, actualEntry, generator)
                     } else {
-                        // ... otherwise, some existing entry is in the way, so try to grab a write lock
-                        val currentState = actualEntry.state.get
-                        val allowedToAssumeCompletion = currentState == Cached || currentState == ReadInProgress
-
-                        if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
-                            // this transaction is now responsible for updating the cache entry
-                            logger.info(this, s"write initiated on existing cache entry invalidating $key")
-                            listenForWriteDone(key, actualEntry, generator)
-                        } else {
-                            // there is a conflicting operation in progress on this key
-                            logger.info(this, s"write-around (i.e., not cached) under $currentState")
-                            invalidateEntryAfter(generator, key, actualEntry)
-                        }
+                        // there is a conflicting operation in progress on this key
+                        logger.info(this, s"write-around (i.e., not cached) under $currentState")
+                        invalidateEntryAfter(generator, key, actualEntry)
                     }
                 }
-
-            case _ => generator // not caching
-        }
+            }
+        } else generator // not caching
     }
 
     def cacheSize: Int = cache.size

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -381,11 +381,9 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
         implicit ec: ExecutionContext): Future[R] = {
 
         entry.grabInvalidationLock
-        invalidator map { r =>
-            invalidateEntry(key, entry)
-            r
+        invalidator andThen {
+            case _ => invalidateEntry(key, entry)
         }
-
     }
 
     /**

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -88,7 +88,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
     import MultipleReadersSingleWriterCache.State._
 
     /** Subclasses: Toggle this to enable/disable caching for your entity type. */
-    protected lazy val cacheEnabled = true
+    protected val cacheEnabled = true
 
     /** Subclasses: tell me what key to use for updates. */
     protected def cacheKeyForUpdate(w: W): Any

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -168,7 +168,7 @@ object WhiskAction
     }
 
     override val cacheEnabled = true
-    override def cacheKeys(w: WhiskAction) = Set(w.docid.asDocInfo, w.docinfo)
+    override def cacheKeyForUpdate(w: WhiskAction) = w.docid.asDocInfo
 
     private val jarAttachmentName = "jarfile"
     private val jarContentType = ContentType.Binary(MediaTypes.`application/java-archive`)

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -167,7 +167,7 @@ object WhiskAction
         }
     }
 
-    override lazy val cacheEnabled = true
+    override val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskAction) = w.docid.asDocInfo
 
     private val jarAttachmentName = "jarfile"

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -167,7 +167,7 @@ object WhiskAction
         }
     }
 
-    override val cacheEnabled = true
+    override lazy val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskAction) = w.docid.asDocInfo
 
     private val jarAttachmentName = "jarfile"

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -138,6 +138,6 @@ object WhiskActivation
     override val collectionName = "activations"
     override implicit val serdes = jsonFormat12(WhiskActivation.apply)
 
-    override lazy val cacheEnabled = true
+    override val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskActivation) = w.docid.asDocInfo
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -139,5 +139,5 @@ object WhiskActivation
     override implicit val serdes = jsonFormat12(WhiskActivation.apply)
 
     override val cacheEnabled = true
-    override def cacheKeys(w: WhiskActivation) = Set(w.docid.asDocInfo, w.docinfo)
+    override def cacheKeyForUpdate(w: WhiskActivation) = w.docid.asDocInfo
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -138,6 +138,6 @@ object WhiskActivation
     override val collectionName = "activations"
     override implicit val serdes = jsonFormat12(WhiskActivation.apply)
 
-    override val cacheEnabled = true
+    override lazy val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskActivation) = w.docid.asDocInfo
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -81,7 +81,7 @@ object WhiskAuth extends DocumentFactory[WhiskAuth] {
         } getOrElse deserializationError("auth record malformed")
     }
 
-    override lazy val cacheEnabled = true
+    override val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskAuth) = w.uuid
 
     /*def get(datastore: ArtifactStore[WhiskAuth], subject: Subject, fromCache: Boolean)(

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -81,7 +81,7 @@ object WhiskAuth extends DocumentFactory[WhiskAuth] {
         } getOrElse deserializationError("auth record malformed")
     }
 
-    override val cacheEnabled = true
+    override lazy val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskAuth) = w.uuid
 
     /*def get(datastore: ArtifactStore[WhiskAuth], subject: Subject, fromCache: Boolean)(

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -82,20 +82,22 @@ object WhiskAuth extends DocumentFactory[WhiskAuth] {
     }
 
     override val cacheEnabled = true
-    override def cacheKeys(w: WhiskAuth) = Set(w.docid.asDocInfo, w.docinfo, w.uuid)
+    override def cacheKeyForUpdate(w: WhiskAuth) = w.uuid
 
-    def get(datastore: ArtifactStore[WhiskAuth], subject: Subject, fromCache: Boolean)(
+    /*def get(datastore: ArtifactStore[WhiskAuth], subject: Subject, fromCache: Boolean)(
         implicit transid: TransactionId): Future[WhiskAuth] = {
         super.get(datastore, DocId(subject()), fromCache = fromCache)
-    }
+    }*/
 
     def get(datastore: ArtifactStore[WhiskAuth], uuid: UUID)(
         implicit transid: TransactionId): Future[WhiskAuth] = {
         implicit val logger: Logging = datastore
+        implicit val ec = datastore.executionContext
+
         // it is assumed that there exists at most one record matching the uuid
         // hence it is safe to cache the result of this query result since a put
         // on the auth record will invalidate the cached query result as well
-        cacheLookup(datastore, uuid, {
+        cacheLookup(uuid, {
             implicit val ec = datastore.executionContext
             list(datastore, uuid) map { list =>
                 list.length match {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -160,7 +160,7 @@ object WhiskPackage
         jsonFormat7(WhiskPackage.apply)
     }
 
-    override lazy val cacheEnabled = true
+    override val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskPackage) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -161,7 +161,7 @@ object WhiskPackage
     }
 
     override val cacheEnabled = true
-    override def cacheKeys(w: WhiskPackage) = Set(w.docid.asDocInfo, w.docinfo)
+    override def cacheKeyForUpdate(w: WhiskPackage) = w.docid.asDocInfo
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -160,7 +160,7 @@ object WhiskPackage
         jsonFormat7(WhiskPackage.apply)
     }
 
-    override val cacheEnabled = true
+    override lazy val cacheEnabled = true
     override def cacheKeyForUpdate(w: WhiskPackage) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -190,7 +190,7 @@ object WhiskRule
     override val collectionName = "rules"
     override implicit val serdes = jsonFormat7(WhiskRule.apply)
 
-    override val cacheEnabled = false
+    override lazy val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskRule) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -190,7 +190,7 @@ object WhiskRule
     override val collectionName = "rules"
     override implicit val serdes = jsonFormat7(WhiskRule.apply)
 
-    override lazy val cacheEnabled = false
+    override val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskRule) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -191,7 +191,7 @@ object WhiskRule
     override implicit val serdes = jsonFormat7(WhiskRule.apply)
 
     override val cacheEnabled = false
-    override def cacheKeys(w: WhiskRule) = Set(w.docid.asDocInfo, w.docinfo)
+    override def cacheKeyForUpdate(w: WhiskRule) = w.docid.asDocInfo
 }
 
 object WhiskRuleResponse extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -113,7 +113,7 @@ object WhiskTrigger
     override val collectionName = "triggers"
     override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
-    override val cacheEnabled = false //disabled for now until redis in place
+    override lazy val cacheEnabled = false //disabled for now until redis in place
     override def cacheKeyForUpdate(w: WhiskTrigger) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -113,7 +113,7 @@ object WhiskTrigger
     override val collectionName = "triggers"
     override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
-    override lazy val cacheEnabled = false //disabled for now until redis in place
+    override val cacheEnabled = false //disabled for now until redis in place
     override def cacheKeyForUpdate(w: WhiskTrigger) = w.docid.asDocInfo
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -114,7 +114,7 @@ object WhiskTrigger
     override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
     override val cacheEnabled = false //disabled for now until redis in place
-    override def cacheKeys(w: WhiskTrigger) = Set(w.docid.asDocInfo, w.docinfo)
+    override def cacheKeyForUpdate(w: WhiskTrigger) = w.docid.asDocInfo
 }
 
 object WhiskTriggerPut extends DefaultJsonProtocol {

--- a/tests/dat/actions/CacheConcurrencyTests.sh
+++ b/tests/dat/actions/CacheConcurrencyTests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-N=20
 WSK="${1-./bin/wsk -i}"
 ACTIONFILE="${2-empty.js}"
+N=${3-20}
+shift
 shift
 shift
 

--- a/tests/dat/actions/CacheConcurrencyTests.sh
+++ b/tests/dat/actions/CacheConcurrencyTests.sh
@@ -2,7 +2,7 @@
 
 N=20
 WSK="${1-./bin/wsk} -i"
-ACTIONFILE="${1-empty.js}"
+ACTIONFILE="${2-empty.js}"
 
 echo -n "init "
 (for i in `seq 1 $N`; do ($WSK action delete testy$i &); done; wait) 2>&1 | grep -v failure > /dev/null
@@ -15,7 +15,7 @@ else
 fi
 
 echo -n "create "
-(for i in `seq 1 $N`; do ($WSK action create testy$i ~/foo.js &); done; wait) 2>&1 | grep -v failure > /dev/null
+(for i in `seq 1 $N`; do ($WSK action create testy$i "${ACTIONFILE}" &); done; wait) 2>&1 | grep -v failure > /dev/null
 
 if [ $? == 1 ]; then
     echo "FAIL"
@@ -25,7 +25,7 @@ else
 fi
 
 echo -n "update "
-(for i in `seq 1 $N`; do ($WSK action update testy$i -p p v &); done; wait) 2>&1 | grep -v failure > /dev/null
+(for i in `seq 1 $N`; do ($WSK action update testy$i -p p v &); done; wait) 2>&1 | grep -v error > /dev/null
 
 if [ $? == 1 ]; then
     echo "FAIL in update"
@@ -56,7 +56,7 @@ fi
 
 
 echo -n "create "
-(for i in `seq 1 $N`; do ($WSK action create testy$i ~/foo.js &); done; wait) 2>&1 | grep -v failure > /dev/null
+(for i in `seq 1 $N`; do ($WSK action create testy$i "${ACTIONFILE}" &); done; wait) 2>&1 | grep -v failure > /dev/null
 
 if [ $? == 1 ]; then
     echo "FAIL"

--- a/tests/dat/actions/CacheConcurrencyTests.sh
+++ b/tests/dat/actions/CacheConcurrencyTests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+N=20
+WSK="${1-./bin/wsk} -i"
+
+echo -n "init "
+(for i in `seq 1 $N`; do ($WSK action delete testy$i &); done; wait) 2>&1 | grep -v failure > /dev/null
+$WSK action list -l 200 | grep -v testy > /dev/null
+if [ $? == 1 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo -n "create "
+(for i in `seq 1 $N`; do ($WSK action create testy$i ~/foo.js &); done; wait) 2>&1 | grep -v failure > /dev/null
+
+if [ $? == 1 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo -n "update "
+(for i in `seq 1 $N`; do ($WSK action update testy$i -p p v &); done; wait) 2>&1 | grep -v failure > /dev/null
+
+if [ $? == 1 ]; then
+    echo "FAIL in update"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo -n "delete+get "
+(for i in `seq 1 $N`; do ($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action delete testy$i &); ($WSK action get testy$i &); ($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &); done; wait) 2>&1 | grep -v "unable to delete" > /dev/null
+
+if [ $? == 1 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo -n "get after delete "
+(for i in `seq 1 $N`; do ($WSK action get testy$i &); done; wait) 2>&1 | grep ok > /dev/null
+
+if [ $? == 0 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+
+echo -n "create "
+(for i in `seq 1 $N`; do ($WSK action create testy$i ~/foo.js &); done; wait) 2>&1 | grep -v failure > /dev/null
+
+if [ $? == 1 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+for i in `seq 1 $N`; do $WSK action update testy$i -p smurf zoomba >& /dev/null; done
+
+echo -n "update+get "
+(for i in `seq 1 $N`; do ($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action update testy$i -p smurf blue &); ($WSK action get testy$i &); ($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &);($WSK action get testy$i &); done; wait) 2>&1 | grep "ok: updated action" > /dev/null
+
+if [ $? == 1 ]; then
+    echo "FAIL"
+    exit 1
+else
+    echo "PASS"
+fi
+
+echo -n "get after update+get "
+for i in `seq 1 $N`; do
+    $WSK action get testy$i | grep zoomba > /dev/null
+    if [ $? == 0 ]; then
+	echo "FAIL"
+	exit 1
+    fi
+done
+echo "PASS"
+

--- a/tests/dat/actions/CacheConcurrencyTests.sh
+++ b/tests/dat/actions/CacheConcurrencyTests.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
 N=20
-WSK="${1-./bin/wsk} -i"
+WSK="${1-./bin/wsk -i}"
 ACTIONFILE="${2-empty.js}"
+shift
+shift
+
+WSK="${WSK} $@"
 
 echo -n "init "
 (for i in `seq 1 $N`; do ($WSK action delete testy$i &); done; wait) 2>&1 | grep -v failure > /dev/null

--- a/tests/dat/actions/CacheConcurrencyTests.sh
+++ b/tests/dat/actions/CacheConcurrencyTests.sh
@@ -2,6 +2,7 @@
 
 N=20
 WSK="${1-./bin/wsk} -i"
+ACTIONFILE="${1-empty.js}"
 
 echo -n "init "
 (for i in `seq 1 $N`; do ($WSK action delete testy$i &); done; wait) 2>&1 | grep -v failure > /dev/null

--- a/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -40,7 +40,8 @@ class CacheConcurrencyTests extends FlatSpec
     "the cache" should "support concurrent CRUD without bogus residual cache entries" in {
         //val scriptPath = getClass.getResource("CacheConcurrencyTests.sh").getPath;
         val scriptPath = TestUtils.getTestActionFilename("CacheConcurrencyTests.sh")
-        val fullCmd = Seq(scriptPath, Wsk.baseCommand.mkString)
+        val actionFile = TestUtils.getTestActionFilename("empty.js")
+        val fullCmd = Seq(scriptPath, Wsk.baseCommand.mkString, actionFile)
 
         val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(fullCmd)
 

--- a/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -16,6 +16,10 @@
 
 package whisk.core.database.test
 
+import scala.util.Try
+
+
+
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
@@ -25,15 +29,12 @@ import org.scalatest.junit.JUnitRunner
 import common.TestUtils
 import common.Wsk
 import common.WskProps
-import whisk.common.Logging
 import whisk.common.SimpleExec
 import whisk.common.TransactionId
-import scala.util.Try
 
 @RunWith(classOf[JUnitRunner])
 class CacheConcurrencyTests extends FlatSpec
     with BeforeAndAfterAll
-    with Logging
     with Matchers {
 
     private val wsk = new Wsk
@@ -55,10 +56,10 @@ class CacheConcurrencyTests extends FlatSpec
                 val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(fullCmd)
 
                 if (!stdout.isEmpty) {
-                    logger.info(stdout)
+                    println(stdout)
                 }
                 if (!stderr.isEmpty) {
-                    logger.error(this, stderr)
+                    println(this, stderr)
                 }
 
                 exitCode should be(0)

--- a/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import common.TestUtils
+import common.Wsk
+import whisk.common.Logging
+import whisk.common.SimpleExec
+import whisk.common.TransactionId
+
+@RunWith(classOf[JUnitRunner])
+class CacheConcurrencyTests extends FlatSpec
+    with BeforeAndAfterAll
+    with Logging
+    with Matchers {
+
+    implicit private val logger = this
+    implicit private val transId = TransactionId.testing
+
+    "the cache" should "support concurrent CRUD without bogus residual cache entries" in {
+        //val scriptPath = getClass.getResource("CacheConcurrencyTests.sh").getPath;
+        val scriptPath = TestUtils.getTestActionFilename("CacheConcurrencyTests.sh")
+        val fullCmd = Seq(scriptPath, Wsk.baseCommand.mkString)
+
+        val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(fullCmd)
+
+        if (!stdout.isEmpty) {
+            logger.info(stdout)
+        }
+        if (!stderr.isEmpty) {
+            logger.error(this, stderr)
+        }
+
+        exitCode should be(0)
+    }
+}

--- a/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
+++ b/tests/src/whisk/core/database/test/CacheConcurrencyTests.scala
@@ -24,6 +24,7 @@ import org.scalatest.junit.JUnitRunner
 
 import common.TestUtils
 import common.Wsk
+import common.WskProps
 import whisk.common.Logging
 import whisk.common.SimpleExec
 import whisk.common.TransactionId
@@ -36,12 +37,13 @@ class CacheConcurrencyTests extends FlatSpec
 
     implicit private val logger = this
     implicit private val transId = TransactionId.testing
+    implicit private val wp = WskProps()
 
     "the cache" should "support concurrent CRUD without bogus residual cache entries" in {
         //val scriptPath = getClass.getResource("CacheConcurrencyTests.sh").getPath;
         val scriptPath = TestUtils.getTestActionFilename("CacheConcurrencyTests.sh")
         val actionFile = TestUtils.getTestActionFilename("empty.js")
-        val fullCmd = Seq(scriptPath, Wsk.baseCommand.mkString, actionFile)
+        val fullCmd = Seq(scriptPath, Wsk.baseCommand.mkString, actionFile, "--auth", wp.authKey) ++ wp.overrides
 
         val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(fullCmd)
 

--- a/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
+++ b/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.database.test
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Failure
+import scala.util.Success
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest._
+import whisk.core.database.MultipleReadersSingleWriterCache
+import whisk.core.database.MultipleReadersSingleWriterCache
+import whisk.common.TransactionId
+import whisk.common.Logging
+
+
+class MultipleReadersSingleWriterCacheTest extends FlatSpec with Matchers with MultipleReadersSingleWriterCache[String, String] with Logging {
+  // run each test this number of times
+  val nIters = 3
+
+  override def cacheKeyForUpdate(w: String): String = (w)
+
+  implicit val logger = this
+
+  "the cache" should "support simple CRUD" in {
+    System.out.println();
+    System.out.println("simple CRUD");
+
+    val inhibits = new doReadWriteRead("foo").go(0)
+    inhibits.debug
+
+    inhibits.nReadInhibits.get should be(0)
+    getSize() should be(1)
+  }
+
+  "the cache" should "support concurrent CRUD to different keys" in {
+    //
+    // for the first iter, all reads are not-cached and each thread
+    // requests a different key, so we expect no read inhibits, and a
+    // bunch of write inhibits
+    //
+    val inhibits = doCRUD("CONCURRENT CRUD to different keys", { i => "foop_" + i })
+    inhibits.nReadInhibits.get should be(0)
+    inhibits.nWriteInhibits.get should not be (0)
+
+    //
+    // after the first iter, the keys already exist, so the first read
+    // should be cached, resulting in the writes proceeding more
+    // smoothly this time, thus inhibiting some of the second reads
+    //
+    for (i <- 1 to nIters - 1) {
+      doCRUD("CONCURRENT CRUD to different keys", { i => "foop_" + i })
+        .nReadInhibits.get should not be (0)
+    }
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys" in {
+    for (i <- 1 to nIters) {
+      doCRUD("CONCURRENT CRUD to shared keys", sharedKeys)
+        .nWriteInhibits.get should not be (0)
+    }
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys (zero latency)" in {
+    var someInhibits = false
+    for (i <- 1 to nIters) {
+      val inhibits = doCRUD("concurrent CRUD to shared keys (zero latency)", sharedKeys, 0)
+      someInhibits = inhibits.nReadInhibits.get + inhibits.nWriteInhibits.get > 0
+    }
+    someInhibits should not be (0)
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys (short latency)" in {
+    for (i <- 1 to nIters) {
+      val inhibits = doCRUD("concurrent CRUD to shared keys (short latency)", sharedKeys, 10)
+      inhibits.nReadInhibits.get + inhibits.nWriteInhibits.get should not be (0)
+    }
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys (medium latency)" in {
+    for (i <- 1 to nIters) {
+      val inhibits = doCRUD("concurrent CRUD to shared keys (medium latency)", sharedKeys, 100)
+      inhibits.nReadInhibits.get + inhibits.nWriteInhibits.get should not be (0)
+    }
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys (long latency)" in {
+    for (i <- 1 to nIters) {
+      doCRUD("CONCURRENT CRUD to shared keys (long latency)", sharedKeys, 5000)
+        .nWriteInhibits.get should not be (0)
+    }
+  }
+
+  "the cache" should "support concurrent CRUD to shared keys, with update first" in {
+    for (i <- 1 to nIters) {
+      doCRUD("CONCURRENT CRUD to shared keys, with update first", sharedKeys, 1000, false)
+        .nWriteInhibits.get should be(0)
+    }
+  }
+
+  def sharedKeys = { i: Int => "foop_" + (i % 2) }
+
+  def doCRUD(
+    testName: String,
+    key: Int => String,
+    delay: Int = 1000,
+    readsFirst: Boolean = true,
+    nThreads: Int = 10): Inhibits = {
+
+    System.out.println();
+    System.out.println(testName);
+
+    val exec = Executors.newFixedThreadPool(nThreads)
+    val inhibits = Inhibits()
+
+    for (i <- 1 to nThreads) {
+      exec.submit(new Runnable { def run() = { new doReadWriteRead(key(i), inhibits, readsFirst).go(delay) } })
+    }
+
+    exec.shutdown
+    exec.awaitTermination(2, TimeUnit.MINUTES)
+
+    inhibits.debug
+    inhibits
+  }
+
+  case class Inhibits(
+      nReadInhibits: AtomicInteger = new AtomicInteger(0),
+      nWriteInhibits: AtomicInteger = new AtomicInteger(0)) {
+    def debug {
+      System.out.println("InhibitedReads: " + nReadInhibits);
+      System.out.println("InhibitedWrites: " + nWriteInhibits);
+    }
+  }
+
+  class doReadWriteRead(key: String, inhibits: Inhibits = Inhibits(), readFirst: Boolean = true) {
+    def go(implicit delay: Int): Inhibits = {
+      val latch = new CountDownLatch(2)
+
+      implicit val transId = TransactionId.testing
+
+      if (!readFirst) {
+        // we want to do the update before the first read
+        cacheUpdate(key, key, delayed("bar_b")).future onFailure {
+          case t =>
+            inhibits.nWriteInhibits.incrementAndGet();
+        }
+      }
+
+      System.out.println("R1");
+      cacheLookup(key, delayed("bar"), true) onComplete {
+        case Success(s) => {
+          latch.countDown()
+        }
+        case Failure(t) => {
+          latch.countDown()
+          inhibits.nReadInhibits.incrementAndGet();
+        }
+      }
+
+      if (readFirst) {
+        System.out.println("W");
+        // we did the read before the update, so do the write next
+        cacheUpdate(key, key, delayed("bar_b")).future onFailure {
+          case t =>
+            inhibits.nWriteInhibits.incrementAndGet();
+        }
+      }
+
+      System.out.println("R2");
+      cacheLookup(key, delayed("bar_c"), true) onComplete {
+        case Success(s) => {
+          latch.countDown();
+        }
+        case Failure(t) => {
+          inhibits.nReadInhibits.incrementAndGet();
+          latch.countDown();
+        }
+      }
+
+      latch.await(2, TimeUnit.MINUTES)
+      // System.out.println("DONE " + i);
+
+      inhibits
+    }
+  }
+
+  def delayed[W](v: W)(implicit delay: Int): Future[W] = {
+    Future {
+      Thread.sleep(delay)
+      v
+    }
+  }
+}

--- a/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
+++ b/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
@@ -48,7 +48,7 @@ class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
         inhibits.debug(this)
 
         inhibits.nReadInhibits.get should be(0)
-        getSize() should be(1)
+        cacheSize should be(1)
     }
 
     "the cache" should "support concurrent CRUD to different keys" in {
@@ -162,7 +162,7 @@ class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
 
             if (!readFirst) {
                 // we want to do the update before the first read
-                cacheUpdate(key, key, delayed("bar_b")).future onFailure {
+                cacheUpdate(key, key, delayed("bar_b")) onFailure {
                     case t =>
                         inhibits.nWriteInhibits.incrementAndGet();
                 }
@@ -180,7 +180,7 @@ class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
 
             if (readFirst) {
                 // we did the read before the update, so do the write next
-                cacheUpdate(key, key, delayed("bar_b")).future onFailure {
+                cacheUpdate(key, key, delayed("bar_b")) onFailure {
                     case t =>
                         inhibits.nWriteInhibits.incrementAndGet();
                 }

--- a/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
+++ b/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
@@ -24,18 +24,18 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import common.WskActorSystem
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.database.MultipleReadersSingleWriterCache
-import common.WskActorSystem
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
 
 class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
     with Matchers

--- a/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
+++ b/tests/src/whisk/core/database/test/MultipleReadersSingleWriterCacheTests.scala
@@ -44,9 +44,6 @@ class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
     with Logging {
 
     "the cache" should "support simple CRUD" in {
-        System.out.println();
-        System.out.println("simple CRUD");
-
         val inhibits = doReadWriteRead("foo").go(0 seconds)
         inhibits.debug(this)
 
@@ -128,7 +125,6 @@ class MultipleReadersSingleWriterCacheTests(nIters: Int = 3) extends FlatSpec
         readsFirst: Boolean = true,
         nThreads: Int = 10): Inhibits = {
 
-        System.out.println();
         System.out.println(testName);
 
         val exec = Executors.newFixedThreadPool(nThreads)

--- a/tests/src/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/whisk/core/entity/test/MigrationEntities.scala
@@ -52,6 +52,7 @@ object OldWhiskRule
 
     override val collectionName = "rules"
     override implicit val serdes = jsonFormat8(OldWhiskRule.apply)
+    override def cacheKeyForUpdate(t: OldWhiskRule) = t.docid.asDocInfo
 }
 
 /**
@@ -79,4 +80,5 @@ object OldWhiskTrigger
 
     override val collectionName = "triggers"
     override implicit val serdes = jsonFormat7(OldWhiskTrigger.apply)
+    override def cacheKeyForUpdate(t: OldWhiskTrigger) = t.docid.asDocInfo
 }


### PR DESCRIPTION
This PR introduces a new caching structure, to replace the existing `InMemoryCache`. The goal is to address the read-under-write and write-under-read race conditions discussed in #1260. 

I'm open to suggestions for better names for the new data structure.

### Summary of Data Structure
The new cache operates by:
  - on an ***uncontested*** read or write, it reserves a slot in the cache (i.e. reservation upon initiation)
  - each slot (cache `Entry`) has a `State` that is used to determine how to proceed with contested operations. States are ReadInProgress, WriteInProgress, Cached, InvalidateInProgress
  - ***contested*** operations obey the state transition diagram discussed in #1260
  - reads under reads are coalesced
  - reads under writes read-around the cache
  - writes under reads write-around the cache

### Extra Notes
  * leverages #1289 to remove the multi-key updates that were previously in place.
  * `InMemoryCache` used split get-then-put. This new cache leverages the putIfAbsent behavior of the underlying LRUCache --- necessarily now, in order to avoid races between the get and the put (now that we are reserving-upon-initiation).

### Testing
  - localhost testing SUCCESS
  - PG1 515 (two false flag failures -- timeouts in blackbox operations)
  - PG1 519 SUCCESS
  - Travis green

closes #1260