### PR TITLE
Revert to Apache HTTP client for invoker->containers communication

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -49,12 +49,12 @@ class Container(
     implicit var transid = originalId
 
     val id = Container.idCounter.next()
-    val name = containerName.getOrElse("anon")
+    val nameAsString = containerName.map(_.name).getOrElse("anon")
 
     val (containerId, containerHostAndPort) = bringup(containerName, image, network, cpuShare, env, args, limits, policy)
 
     def details: String = {
-        val name = containerName getOrElse "??"
+        val name = containerName.map(_.name) getOrElse "??"
         val id = containerId.id
         val ip = containerHostAndPort getOrElse "??"
         s"container [$name] [$id] [$ip]"

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -705,7 +705,7 @@ class ContainerPool(
         val rawLogBytes = container.synchronized {
             this.getDockerLogContent(container.containerId, 0, size, !standalone)
         }
-        val filename = s"${_logDir}/${container.name}.log"
+        val filename = s"${_logDir}/${container.nameAsString}.log"
         Files.write(Paths.get(filename), rawLogBytes)
         info(this, s"teardownContainers: wrote docker logs to $filename")
         runDockerOp { container.remove() }


### PR DESCRIPTION
Unit tests still use Akka HTTP.