### PR TITLE
Fixes two errors in invoke path

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -23,11 +23,12 @@ import spray.json.JsObject
 import spray.json.pimpString
 import whisk.common.TransactionId
 import whisk.core.entity.ActivationId
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskActivation
+import whisk.core.entity.AuthKey
+import whisk.core.entity.DocRevision
 import whisk.core.entity.EntityPath
 import whisk.core.entity.FullyQualifiedEntityName
-import whisk.core.entity.AuthKey
+import whisk.core.entity.Subject
+import whisk.core.entity.WhiskActivation
 
 /** Basic trait for messages that are sent on a message bus connector. */
 trait Message {
@@ -50,6 +51,7 @@ trait Message {
 case class ActivationMessage(
     override val transid: TransactionId,
     action: FullyQualifiedEntityName,
+    revision: DocRevision,
     subject: Subject,
     authkey: AuthKey,
     activationId: ActivationId,
@@ -83,7 +85,7 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
-    implicit val serdes = jsonFormat8(ActivationMessage.apply)
+    implicit val serdes = jsonFormat9(ActivationMessage.apply)
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -20,6 +20,7 @@ import whisk.core.entity.ArgNormalizer.trim
 import scala.util.Try
 import spray.json.JsValue
 import spray.json.RootJsonFormat
+import spray.json.JsNull
 import spray.json.JsString
 import spray.json.deserializationError
 
@@ -105,6 +106,16 @@ protected[core] object DocRevision {
      * @return DocRevision
      */
     protected[core] def apply(s: String = null): DocRevision = new DocRevision(trim(s))
+
+    implicit val serdes = new RootJsonFormat[DocRevision] {
+        def write(d: DocRevision) = if (d.rev != null) JsString(d.rev) else JsNull
+
+        def read(value: JsValue) = value match {
+            case JsString(s) => DocRevision(s)
+            case JsNull      => DocRevision()
+            case _           => deserializationError("doc revision malformed")
+        }
+    }
 }
 
 protected[core] object DocInfo {

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -160,13 +160,10 @@ protected[core] object EntityName {
  * A FullyQualifiedEntityName (qualified name) is a triple consisting of
  * - EntityPath: the namespace and package where the entity is located
  * - EntityName: the name of the entity
- * - Version: a unique version for the resource
- *
- * The version is not a SemVer (yet) because it semantic versioning of entities
- * is not enforced. Instead this will be a context specific version identifier.
+ * - Version: the semantic version of the resource
  */
-protected[core] case class FullyQualifiedEntityName(path: EntityPath, name: EntityName, version: Option[String]) {
-    override def toString = path.addpath(name) + version.map("@" + _).getOrElse("")
+protected[core] case class FullyQualifiedEntityName(path: EntityPath, name: EntityName, version: SemVer) {
+    override def toString = path.addpath(name) + "@" + version.toString
 }
 
 protected[core] object FullyQualifiedEntityName extends DefaultJsonProtocol {

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -434,7 +434,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         val args = { env map { _ ++ action.parameters } getOrElse action.parameters } merge payload
         val message = Message(
             transid,
-            FullyQualifiedEntityName(action.namespace, action.name, Some(action.rev())),
+            FullyQualifiedEntityName(action.namespace, action.name, action.version),
+            action.rev,
             user.subject,
             user.authkey,
             activationId.make(),

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -16,12 +16,12 @@
 
 package whisk.core
 
-import scala.concurrent.duration._
-
 import java.time.Instant
 
-import whisk.core.entity.UUID
+import scala.concurrent.duration._
+
 import whisk.core.entity.DocRevision
+import whisk.core.entity.UUID
 
 /**
  * This object contains type definitions that are useful when observing and timing container operations.
@@ -115,4 +115,8 @@ package object container {
         def apply(content: String) = new DockerOutput(Some(content))
         def unavailable = new DockerOutput(None)
     }
+
+    sealed class ContainerError(val msg: String) extends Throwable(msg)
+    case class WhiskContainerError(override val msg: String) extends ContainerError(msg)
+    case class BlackBoxContainerError(override val msg: String) extends ContainerError(msg)
 }

--- a/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
@@ -95,8 +95,8 @@ protected class ActivationFeed(
                                 handler(topic, bytes)
                         }
                 } recover {
-                    case e: CommitFailedException => logging.error(this, s"failed to commit consumer offset: ${e.getMessage}")
-                    case e: Throwable             => logging.error(this, s"exception while pulling new records: ${e.getMessage}")
+                    case e: CommitFailedException => logging.error(this, s"failed to commit consumer offset: $e")
+                    case e: Throwable             => logging.error(this, s"exception while pulling new records: $e")
                 }
                 fill()
             } else logging.debug(this, "dropping fill request until feed is drained")

--- a/tests/src/limits/ThrottleTests.scala
+++ b/tests/src/limits/ThrottleTests.scala
@@ -193,8 +193,11 @@ class ThrottleTests
                 val alreadyWaited = durationBetween(afterInvokes, Instant.now)
                 settleThrottles(alreadyWaited)
                 println("clearing activations")
-                Try { waitForActivations(results.par) }
             }
+            // wait for the activations last, if these fail, the throttle should be settled
+            // and this gives the activations time to complete and may avoid unnecessarily polling
+            println("waiting for activations to complete")
+            waitForActivations(results.par)
     }
 
     it should "throttle multiple activations of one trigger" in withAssetCleaner(wskprops) {
@@ -266,7 +269,10 @@ class ThrottleTests
                 val alreadyWaited = durationBetween(afterSlowInvokes, Instant.now)
                 settleThrottles(alreadyWaited)
                 println("clearing activations")
-                Try { waitForActivations(combinedResults.par) }
             }
+            // wait for the activations last, giving the activations time to complete and
+            // may avoid unnecessarily polling; if these fail, the throttle may not be settled
+            println("waiting for activations to complete")
+            waitForActivations(combinedResults.par)
     }
 }

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -33,19 +33,21 @@ import akka.event.Logging.{ InfoLevel, DebugLevel }
 import common.WskActorSystem
 import spray.json.JsNumber
 import spray.json.JsObject
+import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.connector.{ ActivationMessage => Message }
 import whisk.core.dispatcher.ActivationFeed
-import whisk.core.dispatcher.MessageHandler
 import whisk.core.dispatcher.Dispatcher
+import whisk.core.dispatcher.MessageHandler
 import whisk.core.entity.ActivationId
-import whisk.core.entity.Subject
-import whisk.utils.retry
+import whisk.core.entity.AuthKey
+import whisk.core.entity.DocRevision
 import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
 import whisk.core.entity.FullyQualifiedEntityName
-import whisk.common.Logging
-import whisk.core.entity.AuthKey
+import whisk.core.entity.SemVer
+import whisk.core.entity.Subject
+import whisk.utils.retry
 
 @RunWith(classOf[JUnitRunner])
 class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
@@ -66,8 +68,8 @@ class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
         val content = JsObject("payload" -> JsNumber(count))
         val subject = Subject()
         val authkey = AuthKey()
-        val path = FullyQualifiedEntityName(EntityPath("test"), EntityName(s"count-$count"), None)
-        val msg = Message(TransactionId.testing, path, subject, authkey, ActivationId(), EntityPath(subject()), Some(content))
+        val path = FullyQualifiedEntityName(EntityPath("test"), EntityName(s"count-$count"), SemVer())
+        val msg = Message(TransactionId.testing, path, DocRevision(), subject, authkey, ActivationId(), EntityPath(subject()), Some(content))
         connector.send(msg)
     }
 
@@ -100,7 +102,7 @@ class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
                 Console.withErr(stream) {
                     retry({
                         val logs = stream.toString()
-                        logs should include regex (s"exception while pulling new records: commit failed")
+                        logs should include regex (s"exception while pulling new records *.* commit failed")
                     }, 10, Some(100 milliseconds))
 
                     connector.throwCommitException = false

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -45,6 +45,7 @@ import whisk.core.entity.ActivationId
 import whisk.core.entity.AuthKey
 import whisk.core.entity.DocId
 import whisk.core.entity.DocInfo
+import whisk.core.entity.DocRevision
 import whisk.core.entity.EntityName
 import whisk.core.entity.Exec
 import whisk.core.entity.LogLimit
@@ -86,6 +87,22 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
         Seq("a", " a", "a ").foreach { i =>
             val d = DocInfo(i)
             assert(d.id() == i.trim)
+        }
+    }
+
+    it should "accept any string as doc revision" in {
+        Seq("a", " a", "a ", "", null).foreach { i =>
+            val d = DocRevision(i)
+            assert(d.rev == (if (i != null) i.trim else null))
+        }
+
+        DocRevision.serdes.read(JsNull) shouldBe DocRevision()
+        DocRevision.serdes.read(JsString("")) shouldBe DocRevision("")
+        DocRevision.serdes.read(JsString("a")) shouldBe DocRevision("a")
+        DocRevision.serdes.read(JsString(" a")) shouldBe DocRevision("a")
+        DocRevision.serdes.read(JsString("a ")) shouldBe DocRevision("a")
+        intercept[DeserializationException] {
+            DocRevision.serdes.read(JsNumber(1))
         }
     }
 


### PR DESCRIPTION
1. if docker pull fails for black box container, do not attempt to run container
2. if action is a black box, set appropriate bits correctly

FYI @markusthoemmes @psuter.
Fixes #1149.

Note that at the level of the docker pull/run command we can't distinguish (without additional context) if the command fails because it's a black box action or not. This should matter so that we can attribute the error to the appropriate status (internal vs client).

Rather than wrap operations with `Try` types because it is pervasive, I left the `throws` in place and handled the exception at the outermost level after writing them to a more specific type along the way (where the context is available).