### PR TITLE
Bump Akka version

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     compile 'io.spray:spray-io_2.11:1.3.3'
     compile 'io.spray:spray-routing_2.11:1.3.3'
 
-    compile 'com.typesafe.akka:akka-actor_2.11:2.4.8'
-    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.8'
-    compile 'com.typesafe.akka:akka-http-core_2.11:2.4.8'
-    compile 'com.typesafe.akka:akka-http-spray-json-experimental_2.11:2.4.8'
+    compile 'com.typesafe.akka:akka-actor_2.11:2.4.10'
+    compile 'com.typesafe.akka:akka-slf4j_2.11:2.4.10'
+    compile 'com.typesafe.akka:akka-http-core_2.11:2.4.10'
+    compile 'com.typesafe.akka:akka-http-spray-json-experimental_2.11:2.4.10'
 
     compile 'log4j:log4j:1.2.16'
     compile 'commons-codec:commons-codec:1.9'


### PR DESCRIPTION
The latest Akka distribution fixed a number of connection pool-related issues (see https://github.com/akka/akka/commit/1c8c2595d2192f9d2f9784224209e57014c2946d).

At least one of the symptoms we have observed and were able to consistently reproduce is now treated (pool hanging after failed requests to an unreachable host).