### PR TITLE
add more log markers for load balancing and kafka connection to contr…

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -163,10 +163,18 @@ object LoggingMarkers {
     private val invoker = "invoker"
     private val database = "database"
     private val activation = "activation"
+    private val kafka = "kafka"
+    private val loadbalancer = "loadbalancer"
 
     // Time of the activation in controller until it is delivered to Kafka
     val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
     val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
+
+    // Time that is needed load balance the activation
+    val CONTROLLER_LOADBALANCER = LogMarkerToken(controller, loadbalancer, start)
+
+    // Time that is needed to produce message in kafka
+    val CONTROLLER_KAFKA = LogMarkerToken(controller, kafka, start)
 
     // Time that is needed to execute the action
     val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -455,13 +455,14 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
             (message.activationId, None)
         }
 
-        info(this, s"[POST] action activation id: ${message.activationId}")
+        val start = transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"[POST] action activation id: ${message.activationId}")
         performLoadBalancerRequest(message, transid) flatMap { _ =>
             if (!blocking) {
                 // Duration of the non-blocking activation in Controller.
                 // We use the start time of the tid instead of a startMarker to avoid passing the start marker around.
                 transid.finished(this, StartMarker(transid.meta.start, LoggingMarkers.CONTROLLER_ACTIVATION))
             }
+            transid.finished(this, start)
             activationResponse
         }
     }


### PR DESCRIPTION
…oller

Result looks as follows:
```
controller           +0s   [2016-09-23T15:02:05.828Z] [INFO] [#tid_40] [ActionsApi] [marker:controller_loadbalancer_start:44]
controller           +0s   [2016-09-23T15:02:05.829Z] [INFO] [#tid_40] [LoadBalancerService] [marker:controller_kafka_start:45]
controller           +0s   [2016-09-23T15:02:05.863Z] [INFO] [#tid_40] [LoadBalancerService] [marker:controller_kafka_finish:79:34]
controller           +0s   [2016-09-23T15:02:05.864Z] [INFO] [#tid_40] [ActionsApi] [marker:controller_loadbalancer_finish:80:36]

```