### PR TITLE
[proposal ]consume timestamp parameter from kafka records and log in activation …

### DIFF
--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -56,7 +56,7 @@ class KafkaConsumerConnector(
      */
     override def peek(duration: Duration = 500 milliseconds) = {
         val records = consumer.poll(duration.toMillis)
-        records map { r => (r.topic, r.partition, r.offset, r.value) }
+        records map { r => (r.topic, r.partition, r.offset, r.value, r.timestamp) }
     }
 
     /**
@@ -64,7 +64,7 @@ class KafkaConsumerConnector(
      */
     def commit() = consumer.commitSync()
 
-    override def onMessage(process: (String, Int, Long, Array[Byte]) => Unit) = {
+    override def onMessage(process: (String, Int, Long, Array[Byte], Long) => Unit) = {
         val self = this
         val thread = new Thread() {
             override def run() = {

--- a/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/MessageConsumer.scala
@@ -31,7 +31,7 @@ trait MessageConsumer {
      * @param duration for the long poll
      * @return iterable collection (topic, partition, offset, bytes)
      */
-    def peek(duration: Duration): Iterable[(String, Int, Long, Array[Byte])]
+    def peek(duration: Duration): Iterable[(String, Int, Long, Array[Byte], Long)]
 
     /**
      * Commits offsets from last peek operation to ensure they are removed
@@ -43,7 +43,7 @@ trait MessageConsumer {
      * Calls process for every message received. Process receives a tuple
      * (topic, partition, offset, and message as byte array).
      */
-    def onMessage(process: (String, Int, Long, Array[Byte]) => Unit): Unit
+    def onMessage(process: (String, Int, Long, Array[Byte], Long) => Unit): Unit
 
     /** Closes consumer. */
     def close(): Unit

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -141,7 +141,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
 
     val consumer = new KafkaConsumerConnector(config.kafkaHost, "completions", "completed")
     consumer.setVerbosity(verbosity)
-    consumer.onMessage((topic, partition, offset, bytes) => {
+    consumer.onMessage((topic, partition, offset, bytes, timestamp) => {
         val raw = new String(bytes, "utf-8")
         CompletionMessage(raw) match {
             case Success(m) => processCompletion(m)

--- a/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
@@ -89,9 +89,10 @@ protected class ActivationFeed(
                 } map {
                     case (records, count) =>
                         records foreach {
-                            case (topic, partition, offset, bytes) =>
-                                logging.info(this, s"processing $topic[$partition][$offset ($count)]")
+                            case (topic, partition, offset, bytes, timestamp) =>
                                 pipelineOccupancy += 1
+                                val diff = System.currentTimeMillis()-timestamp
+                                logging.info(this, s"processing $topic[$partition][$offset ($count)], time msg in queue ${diff}ms, pipeline occupancy ${pipelineOccupancy}")
                                 handler(topic, bytes)
                         }
                 } recover {


### PR DESCRIPTION
…feed

The broker adds a timestamp when a message get's created in kafka. This PR will read the timestamp from the record consumed and print in activation feed along with the pipeline occupancy. It's supposed to give some insights how long the messages live in the queue.

ideally, the timestamp should be printed with the tid. need to figure out how to do. suggestions?

alternative would be to extend the ActivationMessage and set the timestamp in the controller. would prefer the proposed option.

reference: https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message#KIP-32-AddtimestampstoKafkamessage-Brokerconfigurationchange
