### PR TITLE
Add Toggle to Allow Activation Commands to Use Different Namespaces

### DIFF
--- a/tools/cli/go-whisk-cli/commands/namespace.go
+++ b/tools/cli/go-whisk-cli/commands/namespace.go
@@ -67,8 +67,7 @@ var namespaceGetCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var qName qualifiedName
-        var err error
+        var qualifiedName QualifiedName
 
         if whiskErr := checkArgs(args, 0, 1, "Namespace get",
                 wski18n.T("An optional namespace is the only valid argument.")); whiskErr != nil {
@@ -77,19 +76,10 @@ var namespaceGetCmd = &cobra.Command{
 
         // Namespace argument is optional; defaults to configured property namespace
         if len(args) == 1 {
-            qName, err = parseQualifiedName(args[0])
-            if err != nil {
-                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                        map[string]interface{}{"name": args[0], "err": err}))
-                werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                    whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-                return werr
-            }
+            qualifiedName = parseQualifiedName(args[0])
         }
 
-        namespace, _, err := client.Namespaces.Get(qName.namespace)
+        namespace, _, err := client.Namespaces.Get(qualifiedName.namespace)
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Namespaces.Get(%s) error: %s\n", getClientNamespace(), err)

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -48,29 +48,9 @@ var packageBindCmd = &cobra.Command{
     }
 
     packageName := args[0]
-    pkgQName, err := parseQualifiedName(packageName)
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", packageName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": packageName, "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-
+    pkgQName := parseQualifiedName(packageName)
     bindingName := args[1]
-    bindQName, err := parseQualifiedName(bindingName)
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", bindingName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": bindingName, "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-
+    bindQName := parseQualifiedName(bindingName)
     client.Namespace = bindQName.namespace
 
     // Convert the binding's list of default parameters from a string into []KeyValue
@@ -145,17 +125,8 @@ var packageCreateCmd = &cobra.Command{
       return whiskErr
     }
 
-    qName, err := parseQualifiedName(args[0])
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-    client.Namespace = qName.namespace
+    qualifiedName := parseQualifiedName(args[0])
+    client.Namespace = qualifiedName.namespace
 
     if flags.common.shared == "yes" {
       shared = true
@@ -194,16 +165,16 @@ var packageCreateCmd = &cobra.Command{
     var p whisk.PackageInterface
     if sharedSet {
       p = &whisk.SentPackagePublish{
-        Name:        qName.entityName,
-        Namespace:   qName.namespace,
+        Name:        qualifiedName.entityName,
+        Namespace:   qualifiedName.namespace,
         Publish:     shared,
         Annotations: annotations,
         Parameters:  parameters,
       }
     } else {
       p = &whisk.SentPackageNoPublish{
-        Name:        qName.entityName,
-        Namespace:   qName.namespace,
+        Name:        qualifiedName.entityName,
+        Namespace:   qualifiedName.namespace,
         Publish:     shared,
         Annotations: annotations,
         Parameters:  parameters,
@@ -220,7 +191,7 @@ var packageCreateCmd = &cobra.Command{
     }
 
     fmt.Fprintf(color.Output, wski18n.T("{{.ok}} created package {{.name}}\n",
-      map[string]interface{}{"ok": color.GreenString(wski18n.T("ok:")), "name":boldString(qName.entityName)}))
+      map[string]interface{}{"ok": color.GreenString(wski18n.T("ok:")), "name":boldString(qualifiedName.entityName)}))
     return nil
   },
 }
@@ -239,17 +210,8 @@ var packageUpdateCmd = &cobra.Command{
       return whiskErr
     }
 
-    qName, err := parseQualifiedName(args[0])
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-    client.Namespace = qName.namespace
+    qualifiedName := parseQualifiedName(args[0])
+    client.Namespace = qualifiedName.namespace
 
     if flags.common.shared == "yes" {
       shared = true
@@ -287,16 +249,16 @@ var packageUpdateCmd = &cobra.Command{
     var p whisk.PackageInterface
     if sharedSet {
       p = &whisk.SentPackagePublish{
-        Name:        qName.entityName,
-        Namespace:   qName.namespace,
+        Name:        qualifiedName.entityName,
+        Namespace:   qualifiedName.namespace,
         Publish:     shared,
         Annotations: annotations,
         Parameters:  parameters,
       }
     } else {
       p = &whisk.SentPackageNoPublish{
-        Name:        qName.entityName,
-        Namespace:   qName.namespace,
+        Name:        qualifiedName.entityName,
+        Namespace:   qualifiedName.namespace,
         Publish:     shared,
         Annotations: annotations,
         Parameters:  parameters,
@@ -313,7 +275,7 @@ var packageUpdateCmd = &cobra.Command{
     }
 
     fmt.Fprintf(color.Output, wski18n.T("{{.ok}} updated package {{.name}}\n",
-      map[string]interface{}{"ok": color.GreenString(wski18n.T("ok:")), "name":boldString(qName.entityName)}))
+      map[string]interface{}{"ok": color.GreenString(wski18n.T("ok:")), "name":boldString(qualifiedName.entityName)}))
     return nil
   },
 }
@@ -331,21 +293,12 @@ var packageGetCmd = &cobra.Command{
       return whiskErr
     }
 
-    qName, err := parseQualifiedName(args[0])
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-    client.Namespace = qName.namespace
+    qualifiedName := parseQualifiedName(args[0])
+    client.Namespace = qualifiedName.namespace
+    xPackage, _, err := client.Packages.Get(qualifiedName.entityName)
 
-    xPackage, _, err := client.Packages.Get(qName.entityName)
     if err != nil {
-      whisk.Debug(whisk.DbgError, "client.Packages.Get(%s) failed: %s\n", qName.entityName, err)
+      whisk.Debug(whisk.DbgError, "client.Packages.Get(%s) failed: %s\n", qualifiedName.entityName, err)
       errStr := fmt.Sprintf(
         wski18n.T("Package get failed: {{.err}}", map[string]interface{}{"err":err}))
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -357,7 +310,7 @@ var packageGetCmd = &cobra.Command{
     } else {
       fmt.Fprintf(color.Output,
         wski18n.T("{{.ok}} got package {{.name}}\n",
-          map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qName.entityName)}))
+          map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.entityName)}))
       printJSON(xPackage)
     }
 
@@ -378,21 +331,12 @@ var packageDeleteCmd = &cobra.Command{
       return whiskErr
     }
 
-    qName, err := parseQualifiedName(args[0])
-    if err != nil {
-      whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
-      werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-        whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-      return werr
-    }
-    client.Namespace = qName.namespace
+    qualifiedName := parseQualifiedName(args[0])
+    client.Namespace = qualifiedName.namespace
+    _, err = client.Packages.Delete(qualifiedName.entityName)
 
-    _, err = client.Packages.Delete(qName.entityName)
     if err != nil {
-      whisk.Debug(whisk.DbgError, "client.Packages.Delete(%s) failed: %s\n", qName.entityName, err)
+      whisk.Debug(whisk.DbgError, "client.Packages.Delete(%s) failed: %s\n", qualifiedName.entityName, err)
       errStr := fmt.Sprintf(
         wski18n.T("Package delete failed: {{.err}}", map[string]interface{}{"err":err}))
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -401,7 +345,7 @@ var packageDeleteCmd = &cobra.Command{
 
     fmt.Fprintf(color.Output,
       wski18n.T("{{.ok}} deleted package {{.name}}\n",
-        map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qName.entityName)}))
+        map[string]interface{}{"ok": color.GreenString("ok:"), "name": boldString(qualifiedName.entityName)}))
     return nil
   },
 }
@@ -413,31 +357,11 @@ var packageListCmd = &cobra.Command{
   SilenceErrors: true,
   PreRunE:       setupClientConfig,
   RunE: func(cmd *cobra.Command, args []string) error {
-    var err error
     var shared bool
 
-    qName := qualifiedName{}
     if len(args) == 1 {
-      qName, err = parseQualifiedName(args[0])
-      if err != nil {
-        whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-            map[string]interface{}{"name": args[0], "err": err}))
-        werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-          whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-        return werr
-      }
-      ns := qName.namespace
-      if len(ns) == 0 {
-        whisk.Debug(whisk.DbgError, "An empty namespace in the package name '%s' is invalid \n", args[0])
-        errStr := fmt.Sprintf(
-          wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-        werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-        return werr
-      }
-
-      client.Namespace = ns
+      qualifiedName := parseQualifiedName(args[0])
+      client.Namespace = qualifiedName.namespace
     } else if whiskErr := checkArgs(args, 0, 1, "Package list",
         wski18n.T("An optional namespace is the only valid argument.")); whiskErr != nil {
       return whiskErr
@@ -477,35 +401,18 @@ var packageRefreshCmd = &cobra.Command{
   PreRunE:       setupClientConfig,
   RunE: func(cmd *cobra.Command, args []string) error {
     var err error
-    var qName qualifiedName
+    var qualifiedName QualifiedName
 
     if whiskErr := checkArgs(args, 0, 1, "Package refresh",
         wski18n.T("An optional namespace is the only valid argument.")); whiskErr != nil {
       return whiskErr
     } else {
-      if len(args) == 0 {
-        qName, err = parseQualifiedName("")
-      } else {
-        qName, err = parseQualifiedName(args[0])
-      }
+      if len(args) == 1 {
+        qualifiedName = parseQualifiedName(args[0])
+        client.Config.Namespace = qualifiedName.namespace
 
-      if err != nil {
-        whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-            map[string]interface{}{"name": args[0], "err": err}))
-        werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-          whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-        return werr
       }
     }
-
-    currentNamespace := client.Config.Namespace
-    client.Config.Namespace = qName.namespace
-
-    defer func() {
-      client.Config.Namespace = currentNamespace
-    }()
 
     updates, resp, err := client.Packages.Refresh()
     if err != nil {

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -40,33 +40,15 @@ var ruleEnableCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-
         if whiskErr := checkArgs(args, 1, 1, "Rule enable", wski18n.T("A rule name is required.")); whiskErr != nil {
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
 
-        _, _, err = client.Rules.SetState(ruleName, "active")
+        _, _, err := client.Rules.SetState(ruleName, "active")
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf(
@@ -90,33 +72,15 @@ var ruleDisableCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-
         if whiskErr := checkArgs(args, 1, 1, "Rule disable", wski18n.T("A rule name is required.")); whiskErr != nil {
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
 
-        _, _, err = client.Rules.SetState(ruleName, "inactive")
+        _, _, err := client.Rules.SetState(ruleName, "inactive")
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf(
@@ -140,33 +104,15 @@ var ruleStatusCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-
         if whiskErr := checkArgs(args, 1, 1, "Rule status", wski18n.T("A rule name is required.")); whiskErr != nil {
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
-
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
         rule, _, err := client.Rules.Get(ruleName)
+
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf(
@@ -204,25 +150,9 @@ var ruleCreateCmd = &cobra.Command{
             shared = false
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
         triggerName := args[1]
         actionName := args[2]
 
@@ -260,7 +190,6 @@ var ruleUpdateCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
         var shared bool
 
         if whiskErr := checkArgs(args, 3, 3, "Rule update",
@@ -268,27 +197,11 @@ var ruleUpdateCmd = &cobra.Command{
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
-        triggerName := args[1]  //MWD qualified name?
-        actionName := args[2]   //MWD qualified name?
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
+        triggerName := args[1]
+        actionName := args[2]
 
         if (flags.common.shared == "yes") {
             shared = true
@@ -303,7 +216,7 @@ var ruleUpdateCmd = &cobra.Command{
             Publish: shared,
         }
 
-        _, _, err = client.Rules.Insert(rule, true)
+        _, _, err := client.Rules.Insert(rule, true)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Insert(%#v) failed: %s\n", rule, err)
             errStr := fmt.Sprintf(
@@ -327,33 +240,15 @@ var ruleGetCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-
         if whiskErr := checkArgs(args, 1, 1, "Rule get", wski18n.T("A rule name is required.")); whiskErr != nil {
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
-
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
         rule, _, err := client.Rules.Get(ruleName)
+
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
             errStr := fmt.Sprintf(
@@ -383,31 +278,13 @@ var ruleDeleteCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-
         if whiskErr := checkArgs(args, 1, 1, "Rule delete", wski18n.T("A rule name is required.")); whiskErr != nil {
             return whiskErr
         }
 
-        qName, err := parseQualifiedName(args[0])
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
-            werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-        if len(qName.namespace) == 0 {
-            whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-            errStr := fmt.Sprintf(
-                wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return werr
-        }
-        client.Namespace = qName.namespace
-        ruleName := qName.entityName
+        qualifiedName := parseQualifiedName(args[0])
+        client.Namespace = qualifiedName.namespace
+        ruleName := qualifiedName.entityName
 
         if flags.rule.disable {
             _, _, err := client.Rules.SetState(ruleName, "inactive")
@@ -421,7 +298,7 @@ var ruleDeleteCmd = &cobra.Command{
             }
         }
 
-        _, err = client.Rules.Delete(ruleName)
+        _, err := client.Rules.Delete(ruleName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Delete(%s) error: %s\n", ruleName, err)
             errStr := fmt.Sprintf(
@@ -445,28 +322,9 @@ var ruleListCmd = &cobra.Command{
     SilenceErrors:  true,
     PreRunE: setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
-        var err error
-        qName := qualifiedName{}
-
         if len(args) == 1 {
-            qName, err = parseQualifiedName(args[0])
-            if err != nil {
-                whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Namespace '{{.name}}' is invalid: {{.err}}\n",
-                        map[string]interface{}{"name": args[0], "err": err}))
-                werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-                return werr
-            }
-            ns := qName.namespace
-            if len(ns) == 0 {
-                whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-                errStr := fmt.Sprintf(
-                    wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
-                werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-                return werr
-            }
-            client.Namespace = ns
+            qualifiedName := parseQualifiedName(args[0])
+            client.Namespace = qualifiedName.namespace
         } else if whiskErr := checkArgs(args, 0, 1, "Rule list",
                 wski18n.T("An optional namespace is the only valid argument.")); whiskErr != nil {
             return whiskErr

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -35,13 +35,13 @@ import (
     "net/url"
 )
 
-type qualifiedName struct {
+type QualifiedName struct {
     namespace   string
     packageName string
     entityName  string
 }
 
-func (qName qualifiedName) String() string {
+func (qName QualifiedName) String() string {
     output := []string{}
 
     if len(qName.namespace) > 0 {
@@ -68,33 +68,41 @@ Examples:
       /ns/foo => qName {namespace: ns, entityName: foo}
       /ns/pkg/foo => qName {namespace: ns, entityName: pkg/foo}
 */
-func parseQualifiedName(name string) (qName qualifiedName, err error) {
+func parseQualifiedName(name string) (QualifiedName) {
+    var qualifedName QualifiedName
 
     // If name has a preceding delimiter (/), it contains a namespace. Otherwise the name does not specify a namespace,
     // so default the namespace to the namespace value set in the properties file; if that is not set, use "_"
     if len(name) > 0  && name[0] == '/' {
         parts := strings.Split(name, "/")
-        qName.namespace = parts[1]
+        qualifedName.namespace = parts[1]
+
+        if len(qualifedName.namespace) == 0 {
+            qualifedName.namespace = getNamespace()
+        }
 
         if len(parts) > 2 {
-            qName.entityName = strings.Join(parts[2:], "/")
-        } else {
-            qName.entityName = ""
+            qualifedName.entityName = strings.Join(parts[2:], "/")
         }
     } else {
-        qName.entityName = name
-
-        if Properties.Namespace != "" {
-            qName.namespace = Properties.Namespace
-        } else {
-            qName.namespace = "_"
-        }
+        qualifedName.entityName = name
+        qualifedName.namespace = getNamespace()
     }
 
-    whisk.Debug(whisk.DbgInfo, "Qualified entityName: %s\n", qName.entityName)
-    whisk.Debug(whisk.DbgInfo, "Qaulified namespace: %s\n", qName.namespace)
+    whisk.Debug(whisk.DbgInfo, "Qualified entityName '%s'\n", qualifedName.entityName)
+    whisk.Debug(whisk.DbgInfo, "Qaulified namespace '%s'\n", qualifedName.namespace)
 
-    return qName, err
+    return qualifedName
+}
+
+func getNamespace() (string) {
+    namespace := "_"
+
+    if Properties.Namespace != "" {
+        namespace = Properties.Namespace
+    }
+
+    return namespace
 }
 
 /*

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -70,9 +70,13 @@ type Log struct {
     Time   string `json:"time,omitempty"`
 }
 
+const USE_DEFAULT_NAMESPACE = true
+
 func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, *http.Response, error) {
-    // TODO :: for some reason /activations only works with "_" as namespace
-    s.client.Namespace = "_"
+    if USE_DEFAULT_NAMESPACE {
+        s.client.Namespace = "_"
+    }
+
     route := "activations"
     routeUrl, err := addRouteOptions(route, options)
     if err != nil {
@@ -106,8 +110,9 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
 }
 
 func (s *ActivationService) Get(activationID string) (*Activation, *http.Response, error) {
-    // TODO :: for some reason /activations/:id only works with "_" as namespace
-    s.client.Namespace = "_"
+    if USE_DEFAULT_NAMESPACE {
+        s.client.Namespace = "_"
+    }
 
     // Encode resource name as a path (with no query params) before inserting it into the URI
     // This way any '?' chars in the name won't be treated as the beginning of the query params
@@ -136,8 +141,10 @@ func (s *ActivationService) Get(activationID string) (*Activation, *http.Respons
 }
 
 func (s *ActivationService) Logs(activationID string) (*Activation, *http.Response, error) {
-    // TODO :: for some reason /activations/:id/logs only works with "_" as namespace
-    s.client.Namespace = "_"
+    if USE_DEFAULT_NAMESPACE {
+        s.client.Namespace = "_"
+    }
+
     // Encode resource name as a path (with no query params) before inserting it into the URI
     // This way any '?' chars in the name won't be treated as the beginning of the query params
     activationID = (&url.URL{Path: activationID}).String()
@@ -165,8 +172,10 @@ func (s *ActivationService) Logs(activationID string) (*Activation, *http.Respon
 }
 
 func (s *ActivationService) Result(activationID string) (*Response, *http.Response, error) {
-    // TODO :: for some reason /activations only works with "_" as namespace
-    s.client.Namespace = "_"
+    if USE_DEFAULT_NAMESPACE {
+        s.client.Namespace = "_"
+    }
+
     // Encode resource name as a path (with no query params) before inserting it into the URI
     // This way any '?' chars in the name won't be treated as the beginning of the query params
     activationID = (&url.URL{Path: activationID}).String()


### PR DESCRIPTION
- Add a toggle to use the namespace passed for activation commands
- Refactor qualified name parsing
- Remove dead code
- Fixes https://github.com/openwhisk/openwhisk/issues/1344
