### PR TITLE
Directly access loadbalancer from ActivationThrottler so we can skip consul

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Counter.scala
+++ b/common/scala/src/main/scala/whisk/common/Counter.scala
@@ -16,31 +16,31 @@
 
 package whisk.common
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * A simple thread-safe counter.
  */
 class Counter {
-    private val cnt = new AtomicInteger(0)
+    private val cnt = new AtomicLong(0L)
     def cur = cnt.get()
 
     /**
      * Increments and gets the current value.
      */
-    def next(): Int = {
+    def next(): Long = {
         cnt.incrementAndGet()
     }
 
     /**
      * Decrements and gets the current value.
      */
-    def prev(): Int = {
+    def prev(): Long = {
         cnt.decrementAndGet()
     }
 
     /**
      * Sets the value
      */
-    def set(i: Int) = cnt.set(i)
+    def set(i: Long) = cnt.set(i)
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaProducerConnector.scala
@@ -42,7 +42,7 @@ class KafkaProducerConnector(
     id: String = UUID.randomUUID().toString)
     extends MessageProducer with Logging {
 
-    override def sentCount() = sentCounter.cur
+    override def sentCount() = sentCounter.cur.toInt
 
     /** Sends msg to topic. This is an asynchronous operation. */
     override def send(topic: String, msg: Message): Future[RecordMetadata] = {

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -163,8 +163,11 @@ protected[controller] class RestAPIVersion_v1(
 
     // initialize backend services
     protected implicit val consulServer = WhiskServices.consulServer(config)
-    protected implicit val entitlementService = WhiskServices.entitlementService(config)
-    protected implicit val (performLoadBalancerRequest, getInvokerHealth, queryActivationResponse) = WhiskServices.makeLoadBalancerComponent(config)
+    protected implicit val loadBalancer = WhiskServices.makeLoadBalancerComponent(config)
+    protected implicit val performLoadBalancerRequest = loadBalancer.acceptRequest _
+    protected implicit val getInvokerHealth = loadBalancer.getInvokerHealth _
+    protected implicit val queryActiavtionResponse = loadBalancer.queryActivationResponse _
+    protected implicit val entitlementService = WhiskServices.entitlementService(config, loadBalancer)
     protected implicit val activationId = new ActivationIdGenerator {}
 
     // register collections and set verbosities on datastores and backend services

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -100,11 +100,9 @@ class ActivationThrottler(consulServer: String, loadBalancer: LoadBalancerServic
     }
 
     Scheduler.scheduleWaitAtLeast(healthCheckInterval) { () =>
-        val loadbalancerActivationCount = loadBalancer.getUserActivationCounts()
-        for {
-            invokerActivationCount <- getInvokerActivationCount()
-        } yield {
-            debug(this, s"loadbalancerActivationCount = $loadbalancerActivationCount")
+        val loadbalancerActivationCount = loadBalancer.getUserActivationCounts
+        debug(this, s"loadbalancerActivationCount = $loadbalancerActivationCount")
+        getInvokerActivationCount() map { invokerActivationCount =>
             debug(this, s"invokerActivationCount = $invokerActivationCount")
             userActivationCounter = invokerActivationCount map {
                 case (subject, invokerCount) =>

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -95,7 +95,7 @@ protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalan
 
     private val invokeRateThrottler = new RateThrottler(config.actionInvokePerMinuteLimit.toInt)
     private val triggerRateThrottler = new RateThrottler(config.triggerFirePerMinuteLimit.toInt)
-    private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, config.actionInvokeConcurrentLimit.toInt, config.actionInvokeSystemOverloadLimit.toInt)
+    private val concurrentInvokeThrottler = new ActivationThrottler(config.consulServer, loadBalancer, config.actionInvokeConcurrentLimit.toInt, config.actionInvokeSystemOverloadLimit.toInt)
 
     private val consul = new ConsulClient(config.consulServer)
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -39,6 +39,7 @@ import whisk.core.entity.Identity
 import whisk.core.entity.Parameters
 import whisk.core.entity.Subject
 import whisk.core.entity.Identity
+import whisk.core.loadBalancer.LoadBalancerService
 import whisk.http.ErrorResponse
 import whisk.http.Messages._
 
@@ -87,7 +88,7 @@ protected[core] object EntitlementService {
 /**
  * A trait for entitlement service. This is a WIP.
  */
-protected[core] abstract class EntitlementService(config: WhiskConfig)(
+protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalancer: LoadBalancerService)(
     implicit actorSystem: ActorSystem) extends Logging {
 
     private implicit val executionContext = actorSystem.dispatcher

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -24,6 +24,7 @@ import akka.actor.ActorSystem
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.entity.Subject
+import whisk.core.loadBalancer.LoadBalancerService
 
 private object LocalEntitlementService {
     /** Poor mans entitlement matrix. Must persist to datastore eventually. */
@@ -31,9 +32,10 @@ private object LocalEntitlementService {
 }
 
 protected[core] class LocalEntitlementService(
-    private val config: WhiskConfig)(
+    private val config: WhiskConfig,
+    private val loadBalancer: LoadBalancerService)(
         implicit actorSystem: ActorSystem)
-    extends EntitlementService(config) {
+    extends EntitlementService(config, loadBalancer) {
 
     private implicit val executionContext = actorSystem.dispatcher
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -45,12 +45,14 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.controller.RejectRequest
 import whisk.core.entity.Subject
+import whisk.core.loadBalancer.LoadBalancerService
 
 protected[core] class RemoteEntitlementService(
     private val config: WhiskConfig,
+    private val loadBalancer: LoadBalancerService,
     private val timeout: FiniteDuration = 5 seconds)(
         private implicit val actorSystem: ActorSystem)
-    extends EntitlementService(config) {
+    extends EntitlementService(config, loadBalancer) {
 
     private implicit val executionContext = actorSystem.dispatcher
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -96,8 +96,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
                 info(this, s"Completion counts: [${invokerCounts.mkString(", ")}]")
                 info(this, s"Invoker health: [${health.mkString(", ")}]")
             }
-            Map(LoadBalancerKeys.invokerHealth -> getInvokerHealth()) ++
-                getUserActivationCounts()
+            Map(LoadBalancerKeys.invokerHealth -> getInvokerHealth())
         })
 
     /**

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -43,7 +43,6 @@ import whisk.core.WhiskConfig.consulServer
 import whisk.core.WhiskConfig.kafkaHost
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.CompletionMessage
-import whisk.core.controller.WhiskServices.LoadBalancerReq
 import whisk.core.entity.ActivationId
 import whisk.core.entity.WhiskActivation
 
@@ -98,11 +97,6 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
             }
             Map(LoadBalancerKeys.invokerHealth -> getInvokerHealth())
         })
-
-    /**
-     * A bridge method to impedance match against RestAPI.
-     */
-    def acceptRequest(lbr: LoadBalancerReq) = publish(lbr._1)(lbr._2)
 
     /**
      * Tries to fill in the result slot (i.e., complete the promise) when a completion message arrives.

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -43,6 +43,7 @@ import whisk.core.WhiskConfig.consulServer
 import whisk.core.WhiskConfig.kafkaHost
 import whisk.core.connector.ActivationMessage
 import whisk.core.connector.CompletionMessage
+import whisk.core.controller.WhiskServices.LoadBalancerReq
 import whisk.core.entity.ActivationId
 import whisk.core.entity.WhiskActivation
 
@@ -98,6 +99,11 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
             Map(LoadBalancerKeys.invokerHealth -> getInvokerHealth()) ++
                 getUserActivationCounts()
         })
+
+    /**
+     * A bridge method to impedance match against RestAPI.
+     */
+    def acceptRequest(lbr: LoadBalancerReq) = publish(lbr._1)(lbr._2)
 
     /**
      * Tries to fill in the result slot (i.e., complete the promise) when a completion message arrives.

--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -48,7 +48,7 @@ class Container(
 
     implicit var transid = originalId
 
-    val id: Int = Container.idCounter.next()
+    val id = Container.idCounter.next()
     val nameAsString = containerName.map(_.name).getOrElse("anon")
 
     val (containerId, containerHostAndPort) = bringup(containerName, image, network, cpuShare, env, args, limits, policy)

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -219,7 +219,7 @@ class ContainerPool(
      * This method will apply retry so that the caller is blocked until retry succeeds.
      */
     @tailrec
-    final def getContainer(tryCount: Int, position: Int, key: ActionContainerId, conMaker: () => WhiskContainer)(implicit transid: TransactionId): ContainerResult = {
+    final def getContainer(tryCount: Int, position: Long, key: ActionContainerId, conMaker: () => WhiskContainer)(implicit transid: TransactionId): ContainerResult = {
         val positionInLine = position - completedPosition.cur // Indicates queue position.  1 means front of the line
         val available = slack()
         if (tryCount % 100 == 0) {

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -332,7 +332,7 @@ class Invoker(
         }
     }
 
-    private def incrementUserActivationCounter(user: Subject)(implicit transid: TransactionId): Int = {
+    private def incrementUserActivationCounter(user: Subject)(implicit transid: TransactionId): Long = {
         val counter = userActivationCounter.getOrElseUpdate(user(), new Counter())
         val count = counter.next()
         info(this, s"'${user}' has $count activations processed")
@@ -345,7 +345,7 @@ class Invoker(
         groups.keySet map { prefix =>
             val key = InvokerKeys.userActivationCount(instance) + "/" + prefix
             val users = groups.getOrElse(prefix, Set())
-            val items = users map { u => (u, JsNumber(userActivationCounter.get(u) map { c => c.cur } getOrElse 0)) }
+            val items = users map { u => (u, JsNumber(userActivationCounter.get(u) map { c => c.cur } getOrElse 0L)) }
             key -> JsObject(items toMap)
         } toMap
     }

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -55,6 +55,7 @@ import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskPackage
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
+import whisk.core.loadBalancer.LoadBalancerService
 import scala.concurrent.duration.FiniteDuration
 
 protected trait ControllerTestCommon
@@ -78,15 +79,15 @@ protected trait ControllerTestCommon
     override val whiskConfig = new WhiskConfig(WhiskActionsApi.requiredProperties)
     assert(whiskConfig.isValid)
 
-    override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig)
+    val loadBalancer = new LoadBalancerService(whiskConfig, InfoLevel)
+    override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig, loadBalancer)
+    override val performLoadBalancerRequest = (lbr: WhiskServices.LoadBalancerReq) => Future.successful {}
 
     override val activationId = new ActivationIdGenerator() {
         // need a static activation id to test activations api
         private val fixedId = ActivationId()
         override def make = fixedId
     }
-
-    override val performLoadBalancerRequest = (lbr: WhiskServices.LoadBalancerReq) => Future.successful {}
 
     override val queryActivationResponse = (activationId: ActivationId, timeout: FiniteDuration, transid: TransactionId) => {
         whiskActivationStub map {

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -34,6 +34,7 @@ import whisk.common.Logging
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
+import whisk.core.connector.ActivationMessage
 import whisk.core.controller.WhiskActionsApi
 import whisk.core.controller.WhiskServices
 import whisk.core.database.test.DbUtils
@@ -81,7 +82,7 @@ protected trait ControllerTestCommon
 
     val loadBalancer = new LoadBalancerService(whiskConfig, InfoLevel)
     override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig, loadBalancer)
-    override val performLoadBalancerRequest = (lbr: WhiskServices.LoadBalancerReq) => Future.successful {}
+    override val performLoadBalancerRequest = (msg: ActivationMessage, tid: TransactionId) => Future.successful {}
 
     override val activationId = new ActivationIdGenerator() {
         // need a static activation id to test activations api

--- a/tests/src/whisk/core/dispatcher/test/TestConnector.scala
+++ b/tests/src/whisk/core/dispatcher/test/TestConnector.scala
@@ -91,7 +91,7 @@ class TestConnector(
             }
         }
         def close() = {}
-        def sentCount() = counter.next()
+        def sentCount() = counter.next().toInt
         val counter = new Counter()
     }
 


### PR DESCRIPTION
We stop the loadbalancer from publishing to consul counts of issued invocations.  Since only the controller is consuming this count and they are now in the same process, the data can be communicated locally.