### PR TITLE
Consistently omit logs for blocking calls.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -528,7 +528,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         // check if promise already completed due to timeout expiration (abort polling if so)
         if (!promise.isCompleted) {
             WhiskActivation.get(activationStore, docid) map {
-                activation => promise.trySuccess(activation) // activation may have logs, do not strip them
+                activation => promise.trySuccess(activation.withoutLogs) // Logs always not provided on blocking call
             } onFailure {
                 case e: NoDocumentException =>
                     Thread.sleep(500)

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -107,6 +107,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
     def processCompletion(msg: CompletionMessage) = {
         implicit val tid = msg.transid
         val aid = msg.response.activationId
+        info(this, s"received active ack for aid '$aid'")
         val response = msg.response
         val promise = queryMap.remove(aid)
         promise map { p =>


### PR DESCRIPTION
Note all active acks unconditionally in kafka handler.  PG2-353