### PR TITLE
Display Better Error When API Host is not Set

### DIFF
--- a/tests/src/system/basic/WskActionTests.scala
+++ b/tests/src/system/basic/WskActionTests.scala
@@ -243,7 +243,8 @@ class WskActionTests
         (wp, assetHelper) =>
             val fullQualifiedName = s"/$guestNamespace/samples/helloWorld"
             val payload = "bob"
-            val rr = wsk.cli(Seq("action", "invoke", fullQualifiedName, payload), expectedExitCode = TestUtils.ERROR_EXIT)
+            val rr = wsk.cli(Seq("action", "invoke", fullQualifiedName, payload) ++ wskprops.overrides,
+                expectedExitCode = TestUtils.ERROR_EXIT)
             rr.stderr should include("Run 'wsk --help' for usage.")
             rr.stderr should include(s"error: Invalid argument(s): $payload")
     }

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -20,7 +20,6 @@ import (
     "errors"
     "fmt"
     "net/http"
-    "net/url"
     "os"
 
     "../../go-whisk/whisk"
@@ -34,22 +33,20 @@ var client *whisk.Client
 func setupClientConfig(cmd *cobra.Command, args []string) (error){
     baseURL, err := getURLBase(Properties.APIHost)
 
-    // Don't display the 'invalid apihost' error if this CLI invocation is setting that value
-    isApiHostPropSetCmd := cmd.Parent().Name() == "property" && cmd.Name() == "set" && len(flags.property.apihostSet) > 0
-    if err != nil && !isApiHostPropSetCmd {
-        whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s\n", Properties.APIHost, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("error: The configured API host property value '{{.apihost}}' is invalid : {{.err}}",
-                map[string]interface{}{"apihost": Properties.APIHost, "err": err}))
-        fmt.Fprintln(os.Stderr, errMsg)
-        errMsg = fmt.Sprintf(
-            wski18n.T("A default API host value of 'localhost' will be used"))
-        fmt.Fprintln(os.Stderr, errMsg)
-        errMsg = fmt.Sprintf(
-            wski18n.T("Run 'wsk property set --apihost HOST' to set a valid API host value"))
-        fmt.Fprintln(os.Stderr, errMsg)
+    // Determine if the parent command will require the API host to be set
+    apiHostRequired := (cmd.Parent().Name() == "property" && cmd.Name() == "get" && (flags.property.auth ||
+      flags.property.apihost || flags.property.namespace || flags.property.apiversion || flags.property.cliversion)) ||
+      (cmd.Parent().Name() == "property" && cmd.Name() == "set" && (len(flags.property.apihostSet) > 0 ||
+        len(flags.property.apiversionSet) > 0 || len(flags.global.auth) > 0)) ||
+      (cmd.Parent().Name() == "sdk" && cmd.Name() == "install" && len(args) > 0 && args[0] == "bashauto")
 
-        baseURL, _ = url.Parse("https://localhost/api/")
+    // Display an error if the parent command requires an API host to be set, and the current API host is not valid
+    if err != nil && !apiHostRequired {
+        whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s\n", Properties.APIHost, err)
+        errMsg := wski18n.T("The API host is not valid: {{.err}}", map[string]interface{}{"err": err})
+        whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+        return whiskErr
     }
 
     clientConfig := &whisk.Config{

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -787,6 +787,13 @@ func checkArgs(args []string, minimumArgNumber int, maximumArgNumber int, comman
 }
 
 func getURLBase(host string) (*url.URL, error)  {
+    if len(host) == 0 {
+        errMsg := wski18n.T("An API host must be provided.")
+        whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+        return nil, whiskErr
+    }
+
     urlBase := fmt.Sprintf("%s/api/", host)
     url, err := url.Parse(urlBase)
 

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -44,10 +44,6 @@
     "translation": "bypass certificate checking"
   },
   {
-    "id": "error: The configured API host property value '{{.apihost}}' is invalid : {{.err}}",
-    "translation": "error: The configured API host property value '{{.apihost}}' is invalid : {{.err}}"
-  },
-  {
     "id": "Unable to initialize server connection: {{.err}}",
     "translation": "Unable to initialize server connection: {{.err}}"
   },
@@ -1122,5 +1118,13 @@
   {
     "id": "An argument must be provided for '{{.arg}}'",
     "translation": "An argument must be provided for '{{.arg}}'"
+  },
+  {
+    "id": "The API host is not valid: {{.err}}",
+    "translation": "The API host is not valid: {{.err}}"
+  },
+  {
+    "id": "An API host must be provided.",
+    "translation": "An API host must be provided."
   }
 ]


### PR DESCRIPTION
- Display an error message informing the user to set the API host if it is not set
- Add test to ensure error message is displayed
- Fixes https://github.com/openwhisk/openwhisk/issues/979