### PR TITLE
Track whether to unpause on container removal.

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -83,7 +83,7 @@ class Container(
      * Unpauses and removes a container (it may be running).
      */
     @tailrec
-    final def remove(tryCount: Int = Container.removeContainerRetryCount)(implicit transid: TransactionId): Unit = {
+    final def remove(needUnpause: Boolean, tryCount: Int = Container.removeContainerRetryCount)(implicit transid: TransactionId): Unit = {
         if (tryCount <= 0) {
             error(this, s"Failed to remove container ${containerId.id}")
         } else {
@@ -92,9 +92,9 @@ class Container(
             } else {
                 warn(this, s"Retrying to remove container ${containerId.id}")
             }
-            unpause() // a paused container cannot be removed
+            if (needUnpause) unpause() // a paused container cannot be removed
             rmContainer(containerId).toOption match {
-                case None => remove(tryCount - 1)
+                case None => remove(needUnpause, tryCount - 1)
                 case _    => ()
             }
         }

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -42,7 +42,7 @@ package object container {
     /**
      * Special case for stem cell containers
      */
-    val WarmNodeJsActionContainerId = new ActionContainerId("warm.nodejs")
+    val StemCellNodeJsActionContainerId = new ActionContainerId("stemcell.nodejs")
 
     /**
      * Represents a time interval, which can be viewed as a duration for which


### PR DESCRIPTION
Also clean up warm vs pre-allocated nomenclature.