### PR TITLE
Issue 1308 docker12 dev env

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -59,7 +59,7 @@ db:
   - whisk.system
 
 linux:
-  version: 3.19.0-25
+  version: 4.4.0-31
 
 docker_image_prefix: whisk
 docker_image_tag: latest
@@ -67,7 +67,7 @@ docker:
   # The user to install docker for. Defaults to the ansible user if not set. This will be the user who is able to run 
   # docker commands on a machine setup with prereq_build.yml
   #user:
-  version: 1.9.1-0~trusty
+  version: 1.12.0-0~trusty
   storagedriver: overlay
   port: 4243
   restart:

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -7,7 +7,7 @@ One way to develop or deploy OpenWhisk on a Mac is to use [docker-machine](https
 The following are required to build and deploy OpenWhisk from a Mac host:
 
 - [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-- [Docker 1.9.1](https://docs.docker.com/engine/installation/mac/) (including `docker-machine`)
+- [Docker 1.12.0](https://docs.docker.com/engine/installation/mac/) (including `docker-machine`)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - [Scala 2.11](http://scala-lang.org/download/)
 - [Ansible 2.1.2.0](http://docs.ansible.com/ansible/intro_installation.html)
@@ -25,8 +25,8 @@ echo '
 brew tap caskroom/cask
 # install virtualbox
 brew cask install virtualbox
-# install docker 1.9.1
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7702619bb7c1a42dc1ed83a57128727a1a1f5d9f/Formula/docker.rb
+# install docker 1.12.0
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/33301827c3d770bfd49f0e50d84e0b125b06b0b7/Formula/docker.rb
 # install docker-machine
 brew install docker-machine
 # install java 8
@@ -48,7 +48,7 @@ It is recommended that you create a virtual machine `whisk` with at least 4GB of
 ```
 docker-machine create -d virtualbox \
    --virtualbox-memory 4096 \
-   --virtualbox-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v1.9.1/boot2docker.iso \
+   --virtualbox-boot2docker-url=https://github.com/boot2docker/boot2docker/releases/download/v1.12.0/boot2docker.iso \
     whisk # the name of your docker machine
 ```
 

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -17,7 +17,7 @@ sudo apt-get -y install linux-image-extra-$(uname -r)
 sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
 
 # enable (security - use 127.0.0.1)
-sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay"'\'' >> /etc/default/docker'
+sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=aufs"'\'' >> /etc/default/docker'
 sudo gpasswd -a `whoami` docker
 
 # Set DOCKER_HOST as an environment variable

--- a/tools/ubuntu-setup/docker.sh
+++ b/tools/ubuntu-setup/docker.sh
@@ -14,10 +14,10 @@ sudo apt-cache policy docker-engine
 sudo apt-get -y install linux-image-extra-$(uname -r)
 
 # DOCKER
-sudo apt-get install -y --force-yes docker-engine=1.9.1-0~trusty
+sudo apt-get install -y --force-yes docker-engine=1.12.0-0~trusty
 
 # enable (security - use 127.0.0.1)
-sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' >> /etc/default/docker'
+sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --storage-driver=overlay"'\'' >> /etc/default/docker'
 sudo gpasswd -a `whoami` docker
 
 # Set DOCKER_HOST as an environment variable


### PR DESCRIPTION
update dev envs to docker 1.12.

leave vagrant base image untouched due to issues with moving to xenial for kernel 4.4.
(see https://bugs.launchpad.net/cloud-images/+bug/1569237 and others)

we will stick to trusty until travis supports xenial, too.