### PR TITLE
Dynamically generate swift compile and link script, fix Whisk Object

### DIFF
--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -31,7 +31,7 @@ RUN wget --no-verbose -O - https://swift.org/keys/all-keys.asc | gpg --import - 
 # Install Swift Ubuntu 14.04 Snapshot
 #https://swift.org/builds/swift-3.0.1-preview-1/ubuntu1404/swift-3.0.1-PREVIEW-1/swift-3.0.1-PREVIEW-1-ubuntu14.04.tar.gz
 ENV SWIFT_VERSION 3.0.1
-ENV SWIFT_RELEASE_TYPE PREVIEW-1
+ENV SWIFT_RELEASE_TYPE PREVIEW-3
 ENV SWIFT_PLATFORM ubuntu14.04
 
 RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_RELEASE_TYPE-$SWIFT_PLATFORM && \
@@ -47,16 +47,18 @@ RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_RELEASE_TYPE-$SWIFT_PLATFORM 
 RUN mkdir -p /actionProxy
 ADD actionproxy.py /actionProxy
 
-# Add swift3 action runner
+# Add files needed to build and run action
 RUN mkdir -p /swift3Action
 ADD epilogue.swift /swift3Action
+ADD buildandrecord.py /swift3Action
 ADD swift3runner.py /swift3Action
 ADD spm-build /swift3Action/spm-build
 
+
 # Build kitura net
 RUN touch /swift3Action/spm-build/main.swift
-RUN cd /swift3Action/spm-build; swift build; rm .build/debug/Action
-
+RUN python /swift3Action/buildandrecord.py; rm /swift3Action/spm-build/.build/release/Action
+#RUN cd /swift3Action/spm-build; swift build -c release; rm /swift3Action/spm-build/.build/release/Action
 ENV FLASK_PROXY_PORT 8080
 
 CMD ["/bin/bash", "-c", "cd swift3Action && python -u swift3runner.py"]

--- a/core/swift3Action/buildandrecord.py
+++ b/core/swift3Action/buildandrecord.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2015-2016 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os,sys
+from subprocess import check_output
+
+#Settings
+COMPILE_PREFIX = "/usr/bin/swiftc -module-name Action "
+LINKER_PREFIX = "/usr/bin/swiftc -Xlinker '-rpath=$ORIGIN' '-L/swift3Action/spm-build/.build/release' -o '/swift3Action/spm-build/.build/release/Action'\
+"
+GENERATED_BUILD_SCRIPT = "/swift3Action/spm-build/swiftbuildandlink.sh"
+SPM_DIRECTORY = "/swift3Action/spm-build"
+BUILD_COMMAND = ["swift","build","-v","-c","release"]
+
+## Build Swift package and capture step trace
+print "Building action"
+out = check_output(BUILD_COMMAND, cwd=SPM_DIRECTORY)
+print "action built. Decoding compile and link commands"
+
+## Look for compile and link commands in step trace
+compileCommand = None
+linkCommand = None
+
+buildInstructions = out.decode("utf-8").splitlines()
+
+for instruction in buildInstructions:
+    if instruction.startswith(COMPILE_PREFIX):
+        compileCommand = instruction
+
+        ## add flag to quiet warnings
+        compileCommand += " -suppress-warnings"
+
+    elif instruction.startswith(LINKER_PREFIX):
+        linkCommand = instruction
+
+## if found, create build script, otherwise exit with error
+if compileCommand != None and linkCommand != None:
+    print "Generated OpenWhisk Compile command: %s" % compileCommand
+    print "========="
+    print "Generated OpenWhisk Link command: %s" % linkCommand
+
+    with open(GENERATED_BUILD_SCRIPT, "a") as buildScript:
+      buildScript.write("#!/bin/bash\n")
+      buildScript.write("echo \"Compiling\"\n")
+      buildScript.write("%s\n" % compileCommand)
+      buildScript.write("swiftStatus=$?\n")
+      buildScript.write("echo swiftc status is $swiftStatus\n")
+      buildScript.write("if [[ \"$swiftStatus\" -eq \"0\" ]]; then\n")
+      buildScript.write("echo \"Linking\"\n")
+      buildScript.write("%s\n" % linkCommand)
+      buildScript.write("else\n")
+      buildScript.write(">2& echo \"Action did not compile\"\n")
+      buildScript.write("exit 1\n")
+      buildScript.write("fi")
+
+    os.chmod(GENERATED_BUILD_SCRIPT, 0777)
+    sys.exit(0)
+else:
+    print("Cannot generate build script: compile or link command not found")
+    sys.exit(1)
+
+

--- a/core/swift3Action/epilogue.swift
+++ b/core/swift3Action/epilogue.swift
@@ -30,7 +30,7 @@ import Foundation
 func _whisk_json2dict(txt: String) -> [String:Any]? {
     if let data = txt.data(using: String.Encoding.utf8, allowLossyConversion: true) {
         do {
-            return try JSONSerialization.jsonObject(with: data) as? [String:Any]
+            return WhiskJsonUtils.jsonDataToDictionary(jsonData: data)
         } catch {
             return nil
         }
@@ -49,14 +49,19 @@ func _run_main() -> Void {
         
         if result is [String:Any] {
             do {
-                let resp = try JSONSerialization.data(withJSONObject: result, options: [])
-                
-                if let string = String(data: resp, encoding: String.Encoding.utf8) {
-                    // send response to stdout
-                    print("\(string)")
+                if let respString = WhiskJsonUtils.dictionaryToJsonString(jsonDict: result) {
+                    print("\(respString)")
+                } else {
+                    print("Error converting \(result) to JSON string")
+                    #if os(Linux)
+                        fputs("Error converting \(result) to JSON string", stderr)
+                    #endif
                 }
             } catch {
                 print("Error serializing response \(error)")
+                #if os(Linux)
+                    fputs("Error serializing response \(error)", stderr)
+                #endif
             }
         } else {
             print("Cannot serialize response: \(result)")
@@ -66,6 +71,9 @@ func _run_main() -> Void {
         }
     } else {
         print("Error: couldn't parse JSON input.")
+        #if os(Linux)
+            fputs("Error: couldn't parse JSON input.", stderr)
+        #endif
     }
 }
 

--- a/core/swift3Action/spm-build/WhiskJsonUtils.swift
+++ b/core/swift3Action/spm-build/WhiskJsonUtils.swift
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import Foundation
+import SwiftyJSON
+
+enum WhiskJsonType {
+    case Dictionary
+    case Array
+    case Undefined
+}
+
+class WhiskJsonUtils {
+    
+    class func getJsonType(jsonData: Data) -> WhiskJsonType {
+        do {
+            let json = try JSONSerialization.jsonObject(with: jsonData, options: [])
+            if json is [String:Any] {
+                return .Dictionary
+            } else if json is [Any] {
+                return .Array
+            } else {
+                return .Undefined
+            }
+            
+        } catch {
+            print("Error converting json data")
+            return .Undefined
+        }
+        
+    }
+    
+    class func jsonDataToArray(jsonData: Data) -> [Any]? {
+        do {
+            let arr = try JSONSerialization.jsonObject(with: jsonData, options: [])
+            return (arr as! [Any])
+        } catch {
+            print("Error converting json data to dictionary \(error)")
+            return nil
+        }
+    }
+    
+    class func jsonDataToDictionary(jsonData: Data) -> [String:Any]? {
+        do {
+            let dic = try JSONSerialization.jsonObject(with: jsonData, options: [])
+            return dic as! [String:Any]
+        } catch {
+            print("Error converting json data to dictionary \(error)")
+            return nil
+        }
+    }
+    
+    // use SwiftyJSON to serialize JSON object because of bug in Linux Swift 3.0
+    // https://github.com/IBM-Swift/SwiftRuntime/issues/230
+    class func dictionaryToJsonString(jsonDict: [String:Any]) -> String? {
+        let json: JSON = JSON(jsonDict)
+        
+        if let jsonStr = json.rawString() {
+            var trimmed = jsonStr.replacingOccurrences(of: "\n", with: "")
+            return trimmed
+        } else {
+            print("Could not convert dictionary \(jsonDict) to JSON")
+            return nil
+        }
+    }
+    
+    class func dictionaryToData(jsonDict: [String:Any]) -> Data? {
+        let json: JSON = JSON(jsonDict)
+        
+        do {
+            let data: Data = try json.rawData()
+            return data
+        } catch {
+            print("Cannot convert Dictionary to Data")
+            return nil
+        }
+    }
+    
+    class func arrayToJsonString(jsonArray: [Any]) -> String? {
+        let json: JSON = JSON(jsonArray)
+        
+        if let jsonStr = json.rawString() {
+            return jsonStr
+        } else {
+            return nil
+        }
+    }
+    
+    class func arrayToData(jsonArray: [Any]) -> Data? {
+        let json: JSON = JSON(jsonArray)
+        
+        do {
+            let data: Data = try json.rawData()
+            return data
+        } catch {
+            print("Cannot convert Array to Data")
+            return nil
+        }
+    }
+}

--- a/core/swift3Action/swift3runner.py
+++ b/core/swift3Action/swift3runner.py
@@ -24,9 +24,9 @@ from actionproxy import ActionRunner, main, setRunner
 SRC_EPILOGUE_FILE = "./epilogue.swift"
 DEST_SCRIPT_FILE = "/swift3Action/spm-build/main.swift"
 DEST_SCRIPT_DIR = "/swift3Action/spm-build"
-DEST_BIN_FILE = "/swift3Action/spm-build/.build/debug/Action"
+DEST_BIN_FILE = "/swift3Action/spm-build/.build/release/Action"
 
-BUILD_PROCESS = [ "swift", "build"]
+BUILD_PROCESS = [ "./swiftbuildandlink.sh"]
 
 class Swift3Runner(ActionRunner):
 

--- a/tests/src/actionContainers/Swift3ActionContainerTests.scala
+++ b/tests/src/actionContainers/Swift3ActionContainerTests.scala
@@ -71,8 +71,12 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
                 |                   HTTP.get(url, callback: { response in
                 |                       if let response = response {
                 |                           do {
-                |                               if let str = try response.readString() {
-                |                                   resp["serverResp"] = str
+                |                               var jsonData = Data()
+                |                               try response.readAllData(into: &jsonData)
+                |                               if let dic = WhiskJsonUtils.jsonDataToDictionary(jsonData: jsonData) {
+                |                                   resp = dic
+                |                               } else {
+                |                                   resp = ["error":"response from server is not JSON"]
                 |                               }
                 |                           } catch {
                 |                              resp["error"] = error.localizedDescription

--- a/tests/src/actionContainers/SwiftActionContainerTests.scala
+++ b/tests/src/actionContainers/SwiftActionContainerTests.scala
@@ -66,13 +66,16 @@ class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSyst
 
     behavior of swiftContainerImageName
 
-    testNotReturningJson(
+    // remove this test: it will not even compile under Swift 3 anymore
+    // so it should not be possible to write an action that does not return
+    // a [String:Any]
+    /*testNotReturningJson(
         """
         |func main(args: [String: Any]) -> String {
         |    return "not a json object"
         |}
         """.stripMargin)
-
+    */
     testEcho(Seq {
         ("swift", """
          |import Glibc


### PR DESCRIPTION
#This PR fixes issues #1377 and #1371 

- dynamically generate build and link script used to create Swift 3 Actions.  This script records the output of the Swift Package Manager when the container is created, and bypasses unneeded build steps during action initialization

- Provide workaround from bug caused by Foundation JSONSerialization bug that causes seg faults in Linux when dictionary contains booleans

- Fix bug in Whisk Object due to unneeded casting and update to use the above workaround

- Update Swift 3 container tests

- remove test that checks to see if JSON object is returned.  Swift 3 compiler appears to do type checks on call graphs and won't compile if an object is not the expected type. Test assumes action will compile but not return a JSON object when it is run.  As of now, action doesn't even compile.

I've been getting "blue-ish" PG builds, with single tests failing on either alarms feed or cloudant feed.  see (PG 678 and 408).  Would like to push this thru because of the bug fixes.