### PR TITLE
Use tid -102 for unpausing the container before removing it.

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -62,7 +62,7 @@ class Container(
 
     def pause(): Unit = pauseContainer(containerId)
 
-    def unpause(): Unit = unpauseContainer(containerId)
+    def unpause()(implicit transid: TransactionId): Unit = unpauseContainer(containerId)
 
     /**
      * A prefix of the container id known to be displayed by docker ps.


### PR DESCRIPTION
The unpause of the warm container still uses the tid of the activation.