### PR TITLE
Extend load balancer to track activations.  Switch activation throttler from consul to this.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -100,7 +100,7 @@ class ActivationThrottler(consulServer: String, loadBalancer: LoadBalancer, conc
     }
 
     Scheduler.scheduleWaitAtLeast(healthCheckInterval) { () =>
-        val loadbalancerActivationCount = loadBalancer.getUserActivationCounts
+        val loadbalancerActivationCount = loadBalancer.getIssuedUserActivationCounts
         debug(this, s"loadbalancerActivationCount = $loadbalancerActivationCount")
         getInvokerActivationCount() map { invokerActivationCount =>
             debug(this, s"invokerActivationCount = $invokerActivationCount")

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerHealth.scala
@@ -48,7 +48,7 @@ object InvokerHealth {
 }
 
 /**
- * Monitors the health of the invokers. The number of invokers is dynamic, and preferably a power of 2.
+ * Monitors the health of the invokers. The number of invokers is dynamic.
  *
  * We are starting to put real load-balancer logic in here too.  Should probably be moved out at some point.
  */

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -58,7 +58,7 @@ trait LoadBalancer {
      *
      * @return a map where the key is the subject and the long is total issued activations by that user
      */
-    def getUserActivationCounts: Map[String, Long]
+    def getIssuedUserActivationCounts: Map[String, Long]
 
     /**
      * Publishes activation message on internal bus for the invoker to pick up.
@@ -103,7 +103,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
      *
      * @return a map where the key is the subject and the long is total issued activations by that user
      */
-    override def getUserActivationCounts: Map[String, Long] = userActivationCounter.toMap mapValues { _.cur }
+    override def getIssuedUserActivationCounts: Map[String, Long] = userActivationCounter.toMap mapValues { _.cur }
 
     /**
      * Publishes message on kafka bus for the invoker to pick up.
@@ -118,7 +118,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
             invokerIndex =>
                 val topic = ActivationMessage.invoker(invokerIndex)
                 val subject = msg.subject()
-                val entry = setupActivation(msg.activationId, timeout, transid)
+                val entry = setupActivation(msg.activationId, subject, invokerIndex, timeout, transid)
                 info(this, s"posting topic '$topic' with activation id '${msg.activationId}'")
                 (producer.send(topic, msg) map { status =>
                     val counter = updateActivationCount(subject, invokerIndex)
@@ -133,7 +133,7 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
     /** Gets a producer which can publish messages to the kafka bus. */
     private val producer = new KafkaProducerConnector(config.kafkaHost, executionContext)
 
-    private val invokerHealth = new InvokerHealth(config, resetIssueCountByInvoker, () => producer.sentCount())
+    private val invokerHealth = new InvokerHealth(config, invokerChangeCallback, () => producer.sentCount())
 
     // this must happen after certain instance members are defined
     setVerbosity(verbosity)
@@ -142,8 +142,11 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
      * A map storing current activations based on ActivationId.
      * The promise value represents the obligation of writing the answer back.
      */
-    case class ActivationEntry(created: Instant, promise: Promise[WhiskActivation])
-    private val activationMap = new TrieMap[ActivationId, ActivationEntry]
+    case class ActivationEntry(id: ActivationId, subject: String, invokerIndex: Int, created: Instant, promise: Promise[WhiskActivation])
+    type ActivationSet = TrieMap[ActivationEntry, Unit]
+    private val activationById = new TrieMap[ActivationId, ActivationEntry]
+    private val activationByInvoker = new TrieMap[Int, ActivationSet]
+    private val activationBySubject = new TrieMap[String, ActivationSet]
 
     private val kv = new ConsulClient(config.consulServer)
     private val reporter = new ConsulKVReporter(kv, 3 seconds, 2 seconds,
@@ -193,8 +196,10 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
         val aid = msg.response.activationId
         info(this, s"received active ack for '$aid'")
         val response = msg.response
-        activationMap.remove(aid) match {
-            case Some(ActivationEntry(_, p)) =>
+        activationById.remove(aid) match {
+            case Some(entry @ ActivationEntry(_, subject, invokerIndex, _, p)) =>
+                activationByInvoker.getOrElseUpdate(invokerIndex, new ActivationSet).remove(entry)
+                activationBySubject.getOrElseUpdate(subject, new ActivationSet).remove(entry)
                 p.trySuccess(response)
                 info(this, s"processed active response for '$aid'")
             case None =>
@@ -203,34 +208,47 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
     }
 
     /**
-     * Creates an entry in the activation map where we note the time of publishing and establishes a place to store the result.
+     * Creates an activation entry and insert into various maps.
      */
-    private def setupActivation(activationId: ActivationId, timeout: FiniteDuration, transid: TransactionId): ActivationEntry = {
+    private def setupActivation(activationId: ActivationId, subject: String, invokerIndex: Int, timeout: FiniteDuration, transid: TransactionId): ActivationEntry = {
         // either create a new promise or reuse a previous one for this activation if it exists
-        activationMap.getOrElseUpdate(activationId, {
+        val entry = activationById.getOrElseUpdate(activationId, {
             val promise = Promise[WhiskActivation]
-            // store the promise to complete on success, or fail with ActiveAckTimeout
-            // if the time runs out
+            // store the promise to complete on success, or fail with ActiveAckTimeout if time is up
+            // however, do not remove the entry as this is done only by processCompletion
             actorSystem.scheduler.scheduleOnce(timeout) {
-                activationMap.remove(activationId).foreach { _ =>
-                    val failedit = promise.tryFailure(new ActiveAckTimeout(activationId))
-                    if (failedit) info(this, "active response timed out")
+                activationById.get(activationId).foreach { _ =>
+                    if (promise.tryFailure(new ActiveAckTimeout(activationId))) {
+                        info(this, "active response timed out")
+                    }
                 }
             }
-
-            ActivationEntry(Instant.now(Clock.systemUTC()), promise)
+            ActivationEntry(activationId, subject, invokerIndex, Instant.now(Clock.systemUTC()), promise)
         })
+        activationByInvoker.getOrElseUpdate(invokerIndex, new ActivationSet).put(entry, {})
+        activationBySubject.getOrElseUpdate(subject, new ActivationSet).put(entry, {})
+        entry
+    }
+
+    /**
+      * When invoker health detects a new invoker has come up, this callback is called.
+      */
+    private def invokerChangeCallback(invokerIndices: Array[Int]) = {
+        invokerIndices.foreach { index =>
+            invokerActivationCounter(index) = new Counter()
+            val actSet = activationByInvoker.getOrElseUpdate(index, new ActivationSet)
+            actSet.keySet map { case ActivationEntry(activationId, subject, _, _, promise) =>
+                promise.tryFailure(new ActiveAckTimeout(activationId))
+                activationById.remove(activationId)
+                activationBySubject.remove(subject)
+            }
+            actSet.clear()
+        }
     }
 
     private def updateActivationCount(user: String, invokerIndex: Int): Long = {
         invokerActivationCounter.getOrElseUpdate(invokerIndex, new Counter()).next()
         userActivationCounter.getOrElseUpdate(user, new Counter()).next()
-    }
-
-    private def resetIssueCountByInvoker(invokerIndices: Array[Int]) = {
-        invokerIndices.foreach {
-            invokerActivationCounter(_) = new Counter()
-        }
     }
 
     // Make a new immutable map so caller cannot mess up the state

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -166,6 +166,8 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
 
     override def getIssuedUserActivationCounts: Map[String, Long] = Map()
 
+    override def getActiveUserActivationCounts: Map[String, Long] = Map()
+
     override def publish(msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
         (Future.successful {},
          whiskActivationStub map {

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -164,7 +164,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
     // unit tests that need an activation via active ack/fast path should set this to value expected
     var whiskActivationStub: Option[WhiskActivation] = None
 
-    override def getUserActivationCounts: Map[String, Long] = Map()
+    override def getIssuedUserActivationCounts: Map[String, Long] = Map()
 
     override def publish(msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
         (Future.successful {},


### PR DESCRIPTION
The first commit extends data structures in the load balancer to track activations in different ways.  We may twiddle these data structures in the future as we enhance load balancing strategy.  The important thing is that we consistently add/remove ActivationEntry into/out of these data structures.  Note that though there are multiple maps, they share the same underlying ActivationEntry.  Because we limit the global number of activations accepted by the controller, these structures are limited.

The second commit exposes an endpoint from the load balancer for Activation Throttle to use so that it no longer has to consult consul for per-invoker and per-subject activation counts which is a big dictionary that is hurting our performance since we must collect it even for inactive subjects.

Note:  I am deliberately deferring the following from this PR for a followup:  1) Remove the unused endpoints from the load balancer 2) Stop invoker from putting these values to consul.

PG2-419 is green.
