### PR TITLE
up socket timeout of python action to 120 seconds

### DIFF
--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -163,12 +163,14 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |from scrapy.item import Item, Field
                 |import simplejson as json
                 |from twisted.internet import protocol, reactor, endpoints
+                |import socket
                 |
                 |def main(args):
+                |    socket.setdefaulttimeout(120)
                 |    b = BeautifulSoup('<html><head><title>python action test</title></head></html>', 'html.parser')
-                |    h = httplib2.Http().request('https://httpbin.org/status/201')[0]
+                |    h = httplib2.Http().request('https://openwhisk.ng.bluemix.net/api/v1')[0]
                 |    t = parse('2016-02-22 11:59:00 EST')
-                |    r = requests.get('https://httpbin.org/status/418')
+                |    r = requests.get('https://openwhisk.ng.bluemix.net/api/v1')
                 |    j = json.dumps({'foo':'bar'}, separators = (',', ':'))
                 |
                 |    return {
@@ -190,11 +192,11 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
             runRes shouldBe defined
             runRes should be(Some(JsObject(
                 "bs4" -> "<title>python action test</title>".toJson,
-                "httplib2" -> 201.toJson,
+                "httplib2" -> 200.toJson,
                 "dateutil" -> "Monday".toJson,
                 "lxml" -> "root".toJson,
                 "json" -> JsObject("foo" -> "bar".toJson).compactPrint.toJson,
-                "request" -> 418.toJson)))
+                "request" -> 200.toJson)))
         }
 
         checkStreams(out, err, {

--- a/tests/src/actionContainers/Swift3ActionContainerTests.scala
+++ b/tests/src/actionContainers/Swift3ActionContainerTests.scala
@@ -103,7 +103,7 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
             initCode should be(200)
 
             val argss = List(
-                JsObject("getUrl" -> JsString("https://httpbin.org/get")))
+                JsObject("getUrl" -> JsString("https://openwhisk.ng.bluemix.net/api/v1")))
 
             for (args <- argss) {
                 val (runCode, out) = c.run(runPayload(args))


### PR DESCRIPTION

python test url is now openwhisk.ng.bluemix.net/api/v1

swift test url is now openwhisk.ng.bluemix.net/api/v1