### PR TITLE
Remove invoker tracking/publishing per-subject activation counts.

### DIFF
--- a/common/scala/src/main/scala/whisk/common/ConsulClient.scala
+++ b/common/scala/src/main/scala/whisk/common/ConsulClient.scala
@@ -271,14 +271,6 @@ object ConsulKV {
         val startKey = "start"
         def start(instance: Int) = s"${instancePath(instance)}/$startKey"
 
-        // Invokers store how many activations they have processed here.
-        val activationCountKey = "activationCount"
-        def activationCount(instance: Int) = s"${instancePath(instance)}/$activationCountKey"
-
-        // Invokers store how many activations they have processed per user here.
-        private val userActivationCountKey = "userActivationCount"
-        def userActivationCount(instance: Int) = s"${instanceDataPath(instance)}/${userActivationCountKey}"
-
         // Invokers store their most recent check in time here
         val statusKey = "status"
         def status(instance: Int) = s"${instancePath(instance)}/${statusKey}"

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -53,12 +53,6 @@ import whisk.core.entity.ActivationId
 import whisk.core.entity.WhiskActivation
 
 trait LoadBalancer {
-    /**
-     * Retrieves a snapshot of activation counts issued per subject by load balancer
-     *
-     * @return a map where the key is the subject and the long is total issued activations by that user
-     */
-    def getIssuedUserActivationCounts: Map[String, Long]
 
     /**
      * Retrieves a per subject map of counts representing in-flight activations as seen by the load balancer
@@ -104,13 +98,6 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
      * @return index of invoker to receive request
      */
     def getInvoker(message: ActivationMessage): Option[Int] = invokerHealth.getInvoker(message)
-
-    /**
-     * Retrieves a snapshot of activation counts issued per subject by load balancer
-     *
-     * @return a map where the key is the subject and the long is total issued activations by that user
-     */
-    override def getIssuedUserActivationCounts: Map[String, Long] = userActivationCounter.toMap mapValues { _.cur }
 
     /**
      * Retrieves a per subject map of counts representing in-flight activations as seen by the load balancer

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -155,22 +155,12 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
         LoadBalancerKeys.startKey,
         LoadBalancerKeys.statusKey,
         { count =>
-            // Get counts as seen by the loadbalancer
-            val issuedCounts = getIssueCountByInvoker()
-            val issuedCount = issuedCounts.values.sum
-
-            // Get counts as seen by the invokers
-            val invokerCounts = invokerHealth.getInvokerActivationCounts()
-            val completedCount = invokerCounts.values.sum
-
-            val inFlight = issuedCount - completedCount
-
+            val activeCounts = getActiveCountByInvoker()
+            val totalActiveCount = activeCounts.values.sum
             val health = invokerHealth.getInvokerHealth()
             if (count % 10 == 0) {
                 implicit val sid = TransactionId.loadbalancer
-                info(this, s"In flight: $issuedCount - $completedCount = $inFlight")
-                info(this, s"Issued counts: [${issuedCounts.mkString(", ")}]")
-                info(this, s"Completion counts: [${invokerCounts.mkString(", ")}]")
+                info(this, s"In flight: $totalActiveCount = [${activeCounts.mkString(", ")}]")
                 info(this, s"Invoker health: [${health.mkString(", ")}]")
             }
             Map(LoadBalancerKeys.invokerHealth -> getInvokerHealth())
@@ -236,7 +226,6 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
       */
     private def invokerChangeCallback(invokerIndices: Array[Int]) = {
         invokerIndices.foreach { index =>
-            invokerActivationCounter(index) = new Counter()
             val actSet = activationByInvoker.getOrElseUpdate(index, new TrieSet[ActivationEntry])
             actSet.keySet map { case actEntry @ ActivationEntry(activationId, subject, invokerIndex, _, promise) =>
                 promise.tryFailure(new LoadBalancerException(s"Invoker $invokerIndex restarted"))
@@ -248,15 +237,13 @@ class LoadBalancerService(config: WhiskConfig, verbosity: LogLevel)(
     }
 
     private def updateActivationCount(user: String, invokerIndex: Int): Long = {
-        invokerActivationCounter.getOrElseUpdate(invokerIndex, new Counter()).next()
         userActivationCounter.getOrElseUpdate(user, new Counter()).next()
     }
 
     // Make a new immutable map so caller cannot mess up the state
-    private def getIssueCountByInvoker(): Map[Int, Long] = invokerActivationCounter.readOnlySnapshot.mapValues(_.cur).toMap
+    private def getActiveCountByInvoker(): Map[Int, Long] = activationByInvoker.toMap mapValues { _.size.toLong }
 
     // A count of how many activations have been posted to Kafka based on invoker index or user/subject.
-    private val invokerActivationCounter = new TrieMap[Int, Counter]
     private val userActivationCounter = new TrieMap[String, Counter]
 
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -406,7 +406,7 @@ class Invoker(
             InvokerKeys.hostname(instance),
             InvokerKeys.start(instance),
             InvokerKeys.status(instance),
-            { index => Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson) })
+            { _ => Map() })
 
     setVerbosity(verbosity)
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -19,7 +19,6 @@ package whisk.core.invoker
 import java.time.{ Clock, Instant }
 
 import scala.Vector
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.{ Duration, DurationInt }
 import scala.language.postfixOps
@@ -28,7 +27,7 @@ import scala.util.{ Failure, Success, Try }
 import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
 import akka.event.Logging.{ InfoLevel, LogLevel }
 import akka.japi.Creator
-import spray.json.{ JsArray, JsNumber, JsObject, JsValue, pimpAny, pimpString }
+import spray.json.{ JsArray, JsObject, pimpAny, pimpString }
 import spray.json.DefaultJsonProtocol._
 import spray.json.DefaultJsonProtocol
 import whisk.common.{ ConsulKVReporter, Counter, Logging, LoggingMarkers, PrintStreamEmitter, SimpleExec, TransactionId }
@@ -41,7 +40,7 @@ import whisk.core.connector.{ ActivationMessage => Message, CompletionMessage }
 import whisk.core.container.{ BlackBoxContainerError, ContainerPool, Interval, RunResult, WhiskContainer, WhiskContainerError }
 import whisk.core.dispatcher.{ Dispatcher, MessageHandler }
 import whisk.core.dispatcher.ActivationFeed.{ ActivationNotification, ContainerReleased, FailedActivation }
-import whisk.core.entity.{ ActionLimits, ActivationLogs, ActivationResponse, AuthKey, DocId, DocInfo, DocRevision, EntityPath, Exec, LogLimit, Parameters, SemVer, Subject, WhiskAction, WhiskActivation, WhiskActivationStore, WhiskAuthStore, WhiskEntity, WhiskEntityStore }
+import whisk.core.entity.{ ActionLimits, ActivationLogs, ActivationResponse, AuthKey, DocId, DocInfo, DocRevision, EntityPath, Exec, LogLimit, Parameters, SemVer, WhiskAction, WhiskActivation, WhiskActivationStore, WhiskAuthStore, WhiskEntity, WhiskEntityStore }
 import whisk.core.entity.size.{ SizeInt, SizeString }
 import whisk.http.BasicHttpService
 import whisk.utils.ExecutionContextFactory
@@ -147,7 +146,6 @@ class Invoker(
                 case Some(res) => res
                 case None => {
                     activationCounter.next() // this is the global invoker counter
-                    incrementUserActivationCounter(tran.msg.subject)
                     // Send a message to the activation feed indicating there is a free resource to handle another activation.
                     // Since all transaction completions flow through this method and the invariant is that the transaction is
                     // completed only once, there is only one completion message sent to the feed as a result.
@@ -332,24 +330,6 @@ class Invoker(
         }
     }
 
-    private def incrementUserActivationCounter(user: Subject)(implicit transid: TransactionId): Long = {
-        val counter = userActivationCounter.getOrElseUpdate(user(), new Counter())
-        val count = counter.next()
-        info(this, s"'${user}' has $count activations processed")
-        count
-    }
-
-    private def getUserActivationCounts(): Map[String, JsObject] = {
-        val subjects = userActivationCounter.keySet toList
-        val groups = subjects.groupBy { user => user.substring(0, 1) } // Any sort of partitioning will be ok wrt load balancer
-        groups.keySet map { prefix =>
-            val key = InvokerKeys.userActivationCount(instance) + "/" + prefix
-            val users = groups.getOrElse(prefix, Set())
-            val items = users map { u => (u, JsNumber(userActivationCounter.get(u) map { c => c.cur } getOrElse 0L)) }
-            key -> JsObject(items toMap)
-        } toMap
-    }
-
     // -------------------------------------------------------------------------------------------------------------
 
     /**
@@ -418,39 +398,15 @@ class Invoker(
     private val activationStore = WhiskActivationStore.datastore(config)
     private val pool = new ContainerPool(config, instance, verbosity)
     private val activationCounter = new Counter() // global activation counter
-    private val userActivationCounter = new TrieMap[String, Counter]
 
     private val consul = new ConsulClient(config.consulServer)
 
-    // Restore old state from the same invoker instance
-    consul.kv.getRecurse(InvokerKeys.userActivationCount(instance)).map { partitioned =>
-        val flattened = partitioned.values.map { userCounts =>
-            userCounts.parseJson.convertTo[Map[String, Int]]
-        }.reduce(_ ++ _)
-
-        val readActivationCounter = flattened.mapValues { readCount =>
-            val cnt = new Counter()
-            cnt.set(readCount)
-            cnt
-        }
-
-        info(this, s"restored old counts from consul: $flattened")
-
-        userActivationCounter.clear()
-        userActivationCounter ++= readActivationCounter
-
-        activationCounter.set(flattened.values.sum)
-    } onComplete { _ =>
-        // Repeatedly updates the KV store as to the invoker's last check-in.
-        new ConsulKVReporter(consul, 3 seconds, 2 seconds,
+    // Repeatedly updates the KV store as to the invoker's last check-in.
+    new ConsulKVReporter(consul, 3 seconds, 2 seconds,
             InvokerKeys.hostname(instance),
             InvokerKeys.start(instance),
             InvokerKeys.status(instance),
-            { index =>
-                (if (index % 5 == 0) getUserActivationCounts() else Map[String, JsValue]()) ++
-                    Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson)
-            })
-    }
+            { index => Map(InvokerKeys.activationCount(instance) -> activationCounter.cur.toJson) })
 
     setVerbosity(verbosity)
 }

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -166,8 +166,6 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
 
     override def getActiveUserActivationCounts: Map[String, Long] = Map()
 
-    override def getActiveUserActivationCounts: Map[String, Long] = Map()
-
     override def publish(msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
         (Future.successful {},
          whiskActivationStub map {

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -164,7 +164,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
     // unit tests that need an activation via active ack/fast path should set this to value expected
     var whiskActivationStub: Option[WhiskActivation] = None
 
-    override def getIssuedUserActivationCounts: Map[String, Long] = Map()
+    override def getActiveUserActivationCounts: Map[String, Long] = Map()
 
     override def getActiveUserActivationCounts: Map[String, Long] = Map()
 


### PR DESCRIPTION
Switch to information already available in load balancer's new activation maps.  This is a followup to the activation maps we recently begin maintaining.