### PR TITLE
'undefined' is displayed when using whisk.invoke

### DIFF
--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -264,6 +264,7 @@ function post(packet, logger, acceptStatusCode) {
           logger && logger.info('[whisk]', 'response body', body);
 
           var activation = undefined;
+          var result = (body.response || {}).result;
 
           error = error || undefined;
           response = response || {};
@@ -272,11 +273,16 @@ function post(packet, logger, acceptStatusCode) {
           if (acceptStatusCode(response.statusCode)) {
               activation = {
                  activationId: body.activationId, // id always present
-                 result: (body.response || {}).result // may not exist
+                 result: result// may not exist
               };
           } else if (!error) {
               // activation failed, set error to API host error response.
-              error = body.error + ' (' + body.errorCode + ')';
+              if (!body.error) {
+                  error = result.error === undefined ? 'an error has occurred' : result.error;
+              }
+              else {
+                  error = body.error + ' (code ' + body.code + ')';
+              }
           }
 
           resolve({

--- a/tests/dat/actions/invokeCallback.js
+++ b/tests/dat/actions/invokeCallback.js
@@ -23,9 +23,9 @@ function main(params) {
                 } else {
                     if (err !== undefined) {
                         // this is what we were expecting
-                        resolve(err);
-                    } else {
                         reject(err);
+                    } else {
+                        resolve(err);
                     }
                 }
             }

--- a/tests/src/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/system/basic/WskBasicNodeTests.scala
@@ -156,7 +156,9 @@ class WskBasicNodeTests
                 activation =>
                     val result = activation.response.result.get
                     result.fields.get("activationId") should not be defined
-                    result.fields.get("error") shouldBe defined
+                    result.getFieldPath("error", "message") should be(Some {
+                        "Three second rule!".toJson
+                    })
 
                     val duration = System.currentTimeMillis() - start
                     duration should be >= expectedDuration.toMillis
@@ -205,7 +207,9 @@ class WskBasicNodeTests
                 activation =>
                     val result = activation.response.result.get
                     result.fields.get("activationId") should not be defined
-                    result.fields.get("error") shouldBe defined
+                    result.getFieldPath("error", "message") should be(Some {
+                        "Three second rule!".toJson
+                    })
 
                     val duration = System.currentTimeMillis() - start
                     duration should be >= expectedDuration.toMillis

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -303,7 +303,7 @@ class WskBasicTests
             }
 
             wsk.action.invoke(name, blocking = true, expectedExitCode = 246)
-              .stderr should include regex (""""error": "name '!' contains illegal characters \(.+\)"""")
+              .stderr should include regex (""""error": "name '!' contains illegal characters \(code \d+\)"""")
     }
 
     it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) {


### PR DESCRIPTION
'undefined' is being shown for two different scenarios.  It is currently being shown as the transaction code when errors are thrown attempting to invoke another action.
It is also being shown as the error value when the invoked action returns an error via a rejected promise or whisk.error().

Resolves issue #1421 
Resolves issue #1353