### PR TITLE
Add flush statements to Swift 3 runner

### DIFF
--- a/core/swift3Action/swift3runner.py
+++ b/core/swift3Action/swift3runner.py
@@ -43,9 +43,11 @@ class Swift3Runner(ActionRunner):
 
         if o is not None:
             sys.stdout.write(o)
+            sys.stdout.flush()
 
         if e is not None:
             sys.stderr.write(e)
+            sys.stderr.flush()
 
     def env(self, message):
         env = ActionRunner.env(self, message)


### PR DESCRIPTION
This PR fixes #1434 - add flush statements to the swift 3 runner to force output to stdout and stderr. PG2 476