### PR TITLE
Thread poll limit through correctly

### DIFF
--- a/tests/src/common/WskTestHelpers.scala
+++ b/tests/src/common/WskTestHelpers.scala
@@ -149,7 +149,7 @@ trait WskTestHelpers extends Matchers {
             check: Seq[CliActivation] => Unit)(
                 implicit wskprops: WskProps): Unit = {
 
-        val activationIds = wsk.pollFor(N, Some(entity), since = since)
+        val activationIds = wsk.pollFor(N, Some(entity), since = since, retries = (totalWait / pollPeriod).toInt, pollPeriod = pollPeriod)
         withClue(s"did not find $N activations for $entity since $since") {
             activationIds.length shouldBe N
         }


### PR DESCRIPTION
This did fallback to the standards set in in `pollFor` which are quite a bit lower than what we have for the outer helpers.