### PR TITLE
Using ansible's local variables to compute db_prefix

### DIFF
--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -6,7 +6,7 @@ cli_nginx_dir: "{{ nginx_conf_dir }}/cli/go/download"
 docker_registry: ""
 docker_dns: ""
 
-db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
+db_prefix: "{{ hostvars['ansible']['ansible_user_id'] }}_{{ hostvars['ansible']['ansible_hostname']|lower }}_"
 db_auth: "subjects"
 
 # Auto lookup to find the db credentials


### PR DESCRIPTION
`ansible_user_id` correctly yields `docker` in a docker-machine environment, but all other databases are created with my local username due to the host where the specific playbooks are executed. This aims to make everything even.