### PR TITLE
Omit Exec Code if Empty

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -442,6 +442,17 @@ class WskBasicTests
             }
 
             res.stdout shouldBe ""
+
+    }
+
+    it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {
+        val name = "dockerContainer"
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some("fakeContainer"), kind = Some("docker"))
+            }
+
+            wsk.action.get(name).stdout should not include (""""code"""")
     }
 
     behavior of "Wsk Trigger CLI"

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -43,7 +43,7 @@ type Action struct {
 
 type Exec struct {
     Kind        string      `json:"kind,omitempty"`
-    Code        string      `json:"code"`
+    Code        *string      `json:"code,omitempty"`
     Image       string      `json:"image,omitempty"`
     Init        string      `json:"init,omitempty"`
     Jar         string      `json:"jar,omitempty"`


### PR DESCRIPTION
- Do not send or display the exec.code if it is empty for Docker actions

Closes https://github.com/openwhisk/openwhisk/issues/1465