### PR TITLE
tweak top level invoker flow for error handling

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -143,7 +143,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                             triggerActivationId,
                             Instant.now(Clock.systemUTC()),
                             Instant.EPOCH,
-                            response = ActivationResponse.success(payload),
+                            response = ActivationResponse.success(payload orElse Some(JsObject())),
                             version = trigger.version)
                         info(this, s"[POST] trigger activated, writing activation record to datastore")
                         val saveTriggerActivation = WhiskActivation.put(activationStore, triggerActivation) map {

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -616,7 +616,6 @@ class ContainerPool(
 
     // We send the payload here but eventually must also handle morphing a pre-allocated container into the right state.
     private def initWhiskContainer(action: WhiskAction, con: WhiskContainer)(implicit transid: TransactionId): RunResult = {
-        con.boundParams = action.parameters.toJsObject
         // Then send it the init payload which is code for now
         val initArg = action.containerInitializer
         con.init(initArg, action.limits.timeout.duration)

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -66,17 +66,8 @@ class WhiskContainer(
     logLevel: LogLevel)
     extends Container(originalId, dockerhost, mounted, key, Some(containerName), image, network, cpuShare, policy, limits, env, args, logLevel) {
 
-    var boundParams = JsObject() // Mutable to support pre-alloc containers
     var lastLogSize = 0L
     private implicit val emitter: PrintStreamEmitter = this
-
-    /**
-     * Merges previously bound parameters with arguments form payload.
-     */
-    def mergeParams(payload: JsObject, recurse: Boolean = true)(implicit transid: TransactionId): JsObject = {
-        //debug(this, s"merging ${boundParams.compactPrint} with ${payload.compactPrint}")
-        JsObject(boundParams.fields ++ payload.fields)
-    }
 
     /**
      * Sends initialization payload to container.

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -169,7 +169,8 @@ class Invoker(
 
         pool.getAction(action, auth) match {
             case Some((con, initResultOpt)) => Future {
-                val params = con.mergeParams(payload)
+                val boundParams = action.parameters.toJsObject
+                val params = JsObject(boundParams.fields ++ payload.fields)
                 val timeout = action.limits.timeout.duration
                 def run() = con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName, msg.activationId.toString)
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -20,6 +20,7 @@ import java.time.{ Clock, Instant }
 
 import scala.Vector
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Promise
 import scala.concurrent.duration.{ Duration, DurationInt }
 import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
@@ -40,7 +41,7 @@ import whisk.core.connector.{ ActivationMessage => Message, CompletionMessage }
 import whisk.core.container.{ BlackBoxContainerError, ContainerPool, Interval, RunResult, WhiskContainer, WhiskContainerError }
 import whisk.core.dispatcher.{ Dispatcher, MessageHandler }
 import whisk.core.dispatcher.ActivationFeed.{ ActivationNotification, ContainerReleased, FailedActivation }
-import whisk.core.entity.{ ActionLimits, ActivationLogs, ActivationResponse, AuthKey, DocId, DocInfo, DocRevision, EntityPath, Exec, LogLimit, Parameters, SemVer, WhiskAction, WhiskActivation, WhiskActivationStore, WhiskAuthStore, WhiskEntity, WhiskEntityStore }
+import whisk.core.entity._
 import whisk.core.entity.size.{ SizeInt, SizeString }
 import whisk.http.BasicHttpService
 import whisk.utils.ExecutionContextFactory
@@ -93,43 +94,59 @@ class Invoker(
         val actionid = DocId(WhiskEntity.qualifiedName(namespace, name)).asDocInfo(msg.revision)
         val tran = Transaction(msg)
         val subject = msg.subject
-        val payload = msg.content getOrElse JsObject()
 
         info(this, s"${actionid.id} $subject ${msg.activationId}")
+
+        // the activation must terminate with only one attempt to write an activation record to the datastore
+        // hence when the transaction is fully processed, this method will complete a promise with the datastore
+        // future writing back the activation record and for which there are three cases:
+        // 1. success: there were no exceptions and hence the invoke path operated normally,
+        // 2. error during invocation: an exception occurred while trying to run the action,
+        // 3. error fetching action: an exception occurred reading from the db, didn't get to run.
+        val transactionPromise = Promise[DocInfo]
 
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;
         // if the doc revision is missing, then bypass cache
-        WhiskAction.get(entityStore, actionid.id, actionid.rev, actionid.rev != DocRevision()) recoverWith {
-            case t =>
-                error(this, s"failed to fetch action from db: ${t.getMessage}")
-                Future.failed(ActivationException(s"Failed to fetch action."))
-        } flatMap {
-            invokeAction(_, msg.authkey, payload, tran)
-        } recoverWith {
-            case t =>
-                val failure = t match {
-                    // in case of container pull/run operations that fail to execute, assign an appropriate error response
-                    case BlackBoxContainerError(msg) => ActivationException(msg, internalError = false)
-                    case WhiskContainerError(msg)    => ActivationException(msg)
-                    case _ =>
-                        error(this, s"failed during invoke: $t")
-                        ActivationException(s"Failed to run action '${actionid.id}': ${t.getMessage}")
+        WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()) onComplete {
+            case Success(action) =>
+                invokeAction(tran, action) onComplete {
+                    case Success(activation) =>
+                        transactionPromise.completeWith {
+                            // this completes the successful activation case (1)
+                            completeTransaction(tran, activation, ContainerReleased(transid))
+                        }
+
+                    case Failure(t) =>
+                        info(this, s"activation failed")
+                        val failure = disambiguateActivationException(t, action)
+                        transactionPromise.completeWith {
+                            // this completes the failed activation case (2)
+                            completeTransactionWithError(action.docid, action.version, tran, failure.activationResponse, Some(action.limits))
+                        }
                 }
-                info(this, s"activation failed")
-                completeTransactionWithError(actionid.id, msg.action.version.get, tran, failure.activationResponse)
+
+            case Failure(t) =>
+                error(this, s"failed to fetch action from db: ${t.getMessage}")
+                val failureResponse = ActivationResponse.whiskError(s"Failed to fetch action.")
+                transactionPromise.completeWith {
+                    // this completes the failed to fetch case (3)
+                    completeTransactionWithError(actionid.id, msg.action.version.get, tran, failureResponse, None)
+                }
         }
+
+        transactionPromise.future
     }
 
     /*
      * Creates a whisk activation out of the errorMsg and finish the transaction.
      * Failing with an error can involve multiple futures but the effecting call is completeTransaction which is guarded.
      */
-    protected def completeTransactionWithError(name: DocId, version: SemVer, tran: Transaction, response: ActivationResponse)(
+    protected def completeTransactionWithError(name: DocId, version: SemVer, tran: Transaction, response: ActivationResponse, limits: Option[ActionLimits])(
         implicit transid: TransactionId): Future[DocInfo] = {
         val msg = tran.msg
         val interval = computeActivationInterval(tran)
-        val activation = makeWhiskActivation(msg, EntityPath(name.id), version, response, interval, None)
+        val activation = makeWhiskActivation(msg, EntityPath(name.id), version, response, interval, limits)
         completeTransaction(tran, activation, FailedActivation(transid))
     }
 
@@ -163,70 +180,86 @@ class Invoker(
         }
     }
 
-    protected def invokeAction(action: WhiskAction, auth: AuthKey, payload: JsObject, tran: Transaction)(
-        implicit transid: TransactionId): Future[DocInfo] = {
-        val msg = tran.msg
+    /**
+     * Executes the action: gets a container (new or recycled), initializes it if necessary, and runs the action.
+     *
+     * @return WhiskActivation
+     */
+    protected def invokeAction(tran: Transaction, action: WhiskAction)(
+        implicit transid: TransactionId): Future[WhiskActivation] = {
+        Future { pool.getAction(action, tran.msg.authkey) } map {
+            case (con, initResultOpt) => runAction(tran, action, con, initResultOpt)
+        } map {
+            case (failedInit, con, result) =>
+                // process the result and send active ack message
+                val activationResult = sendActiveAck(tran, action, failedInit, result)
 
-        pool.getAction(action, auth) match {
-            case Some((con, initResultOpt)) => Future {
-                val boundParams = action.parameters.toJsObject
-                val params = JsObject(boundParams.fields ++ payload.fields)
-                val timeout = action.limits.timeout.duration
-                def run() = con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName, msg.activationId.toString)
+                // after sending active ack, drain logs and return container
+                val contents = getContainerLogs(con, action.exec.sentinelledLogs, action.limits.logs)
 
-                initResultOpt match {
-                    // cached container
-                    case None => (false, run())
+                /* Force delete the container instead of just pausing it iff the initialization failed or the container
+                 * failed otherwise. An example of a ContainerError is the timeout of an action in which case the
+                 * container is to be removed to prevent leaking.  Since putting back the container involves pausing,
+                 * we run this in a Future so as not to block transaction completion but also return resources promptly.
+                 * Note: using infinite thread pool so using a future here for a long/blocking operation is acceptable.
+                 */
+                Future { pool.putBack(con, failedInit) }
 
-                    // new container
-                    case Some(RunResult(interval, response)) =>
-                        tran.initInterval = Some(interval)
-                        response match {
-                            // successful init
-                            case Some((200, _)) => (false, run())
-                            // unsuccessful initialization
-                            case _              => (true, initResultOpt.get)
-                        }
-                }
-            } flatMap {
-                case (failedInit, RunResult(interval, response)) =>
-                    // it is possible for response to be None if the container timed out
-                    if (!failedInit) tran.runInterval = Some(interval)
-
-                    val activationInterval = computeActivationInterval(tran)
-                    val activationResponse = getActivationResponse(activationInterval, action.limits.timeout.duration, response, failedInit)
-                    val activationResult = makeWhiskActivation(msg, EntityPath(action.docid.id), action.version, activationResponse, activationInterval, Some(action.limits))
-                    val completeMsg = CompletionMessage(transid, activationResult)
-
-                    producer.send("completed", completeMsg) map { status =>
-                        info(this, s"posted completion of activation ${msg.activationId}")
-                    }
-
-                    val contents = getContainerLogs(con, action.exec.sentinelledLogs, action.limits.logs)
-
-                    /* Force delete the container instead of just pausing it iff the initialization failed or the container
-                     * failed otherwise. An example of a ContainerError is the timeout of an action in which case the
-                     * container is to be removed to prevent leaking.  Since putting back the container involves pausing,
-                     * we run this in a Future so as not to block transaction completion but also return resources promptly.
-                     * Note: using infinite thread pool so using a future here for a long/blocking operation is acceptable.
-                     */
-                    Future { pool.putBack(con, failedInit) }
-
-                    completeTransaction(tran, activationResult withLogs ActivationLogs.serdes.read(contents), ContainerReleased(transid))
-            }
-
-            case None => { // this corresponds to the container not even starting - not /init failing
-                info(this, s"failed to start or get a container")
-                val response = if (action.exec.kind == Exec.BLACKBOX) {
-                    ActivationResponse.containerError("The container did to start.")
-                } else {
-                    ActivationResponse.whiskError("Error starting container to run action.")
-                }
-                val interval = computeActivationInterval(tran)
-                val activation = makeWhiskActivation(msg, EntityPath(action.docid.id), action.version, response, interval, Some(action.limits))
-                completeTransaction(tran, activation, FailedActivation(transid))
-            }
+                activationResult withLogs ActivationLogs.serdes.read(contents)
         }
+    }
+
+    /**
+     * Runs the action in the container if the initialization succeeded and returns a triple
+     * (initialization failed?, the container, the init result if initialization failed else the run result)
+     */
+    private def runAction(tran: Transaction, action: WhiskAction, con: WhiskContainer, initResultOpt: Option[RunResult])(
+        implicit transid: TransactionId): (Boolean, WhiskContainer, RunResult) = {
+        def run() = {
+            val msg = tran.msg
+            val auth = msg.authkey
+            val payload = msg.content getOrElse JsObject()
+            val boundParams = action.parameters.toJsObject
+            val params = JsObject(boundParams.fields ++ payload.fields)
+            val timeout = action.limits.timeout.duration
+            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName, msg.activationId.toString)
+        }
+
+        initResultOpt match {
+            // cached container
+            case None => (false, con, run())
+
+            // new container
+            case Some(RunResult(interval, response)) =>
+                tran.initInterval = Some(interval)
+                response match {
+                    case Some((200, _)) => (false, con, run()) // successful init
+                    case _              => (true, con, initResultOpt.get) // unsuccessful initialization
+                }
+        }
+    }
+
+    /**
+     * Creates WhiskActivation for the "run result" (which could be a failed initialization) and send
+     * ActiveAck message.
+     *
+     * @return WhiskActivation
+     */
+    private def sendActiveAck(tran: Transaction, action: WhiskAction, failedInit: Boolean, result: RunResult)(
+        implicit transid: TransactionId): WhiskActivation = {
+        if (!failedInit) tran.runInterval = Some(result.interval)
+
+        val msg = tran.msg
+        val activationInterval = computeActivationInterval(tran)
+        val activationResponse = getActivationResponse(activationInterval, action.limits.timeout.duration, result.response, failedInit)
+        val activationResult = makeWhiskActivation(msg, EntityPath(action.docid.id), action.version, activationResponse, activationInterval, Some(action.limits))
+        val completeMsg = CompletionMessage(transid, activationResult)
+
+        producer.send("completed", completeMsg) map { status =>
+            info(this, s"posted completion of activation ${msg.activationId}")
+        }
+
+        activationResult
     }
 
     // The nodeJsAction runner inserts this line in the logs at the end
@@ -338,6 +371,7 @@ class Invoker(
 
     /**
      * Interprets the responses from the container and maps it to an appropriate ActivationResponse.
+     * Note: it is possible for result.response to be None if the container timed out.
      */
     private def getActivationResponse(
         interval: Interval,
@@ -376,7 +410,10 @@ class Invoker(
             end = interval.end,
             response = activationResponse,
             logs = ActivationLogs(),
-            annotations = Parameters("limits", limits.toJson) ++ Parameters("path", actionName.toJson))
+            annotations = {
+                limits.map(l => Parameters("limits", l.toJson)).getOrElse(Parameters()) ++
+                    Parameters("path", actionName.toJson)
+            })
     }
 
     /**
@@ -397,6 +434,21 @@ class Invoker(
         }
     }
 
+    /**
+     * Rewrites exceptions during invocation into new exceptions.
+     */
+    private def disambiguateActivationException(t: Throwable, action: WhiskAction)(
+        implicit transid: TransactionId): ActivationException = {
+        t match {
+            // in case of container pull/run operations that fail to execute, assign an appropriate error response
+            case BlackBoxContainerError(msg) => ActivationException(msg, internalError = false)
+            case WhiskContainerError(msg)    => ActivationException(msg)
+            case _ =>
+                error(this, s"failed during invoke: $t")
+                ActivationException(s"Failed to run action '${action.docid}': ${t.getMessage}")
+        }
+    }
+
     private val entityStore = WhiskEntityStore.datastore(config)
     private val authStore = WhiskAuthStore.datastore(config)
     private val activationStore = WhiskActivationStore.datastore(config)
@@ -407,10 +459,10 @@ class Invoker(
 
     // Repeatedly updates the KV store as to the invoker's last check-in.
     new ConsulKVReporter(consul, 3 seconds, 2 seconds,
-            InvokerKeys.hostname(instance),
-            InvokerKeys.start(instance),
-            InvokerKeys.status(instance),
-            { _ => Map() })
+        InvokerKeys.hostname(instance),
+        InvokerKeys.start(instance),
+        InvokerKeys.status(instance),
+        { _ => Map() })
 
     setVerbosity(verbosity)
 }

--- a/tests/src/common/WskTestHelpers.scala
+++ b/tests/src/common/WskTestHelpers.scala
@@ -113,9 +113,18 @@ trait WskTestHelpers extends Matchers {
     /**
      * Activation record as it is returned by the CLI.
      */
-    case class CliActivation(activationId: String, logs: Option[List[String]], response: CliActivationResponse, start: Long, end: Long, cause: Option[String], annotations: Option[List[JsObject]])
+    case class CliActivation(
+        activationId: String,
+        logs: Option[List[String]],
+        response: CliActivationResponse,
+        start: Long,
+        end: Long,
+        duration: Long,
+        cause: Option[String],
+        annotations: Option[List[JsObject]])
+
     object CliActivation extends DefaultJsonProtocol {
-        implicit val serdes = jsonFormat7(CliActivation.apply)
+        implicit val serdes = jsonFormat8(CliActivation.apply)
     }
 
     /**

--- a/tests/src/common/WskTestHelpers.scala
+++ b/tests/src/common/WskTestHelpers.scala
@@ -106,6 +106,7 @@ trait WskTestHelpers extends Matchers {
      * structure of "result" is not defined.
      */
     case class CliActivationResponse(result: Option[JsObject], status: String, success: Boolean)
+
     object CliActivationResponse extends DefaultJsonProtocol {
         implicit val serdes = jsonFormat3(CliActivationResponse.apply)
     }

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -388,7 +388,16 @@ class WskBasicTests
             withActivation(wsk.activation, run) {
                 activation =>
                     activation.response.result shouldBe Some(dynamicParams.toJson)
-                    activation.end shouldBe Instant.EPOCH.toEpochMilli
+                    activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+                    activation.end shouldBe Instant.EPOCH.toEpochMilli // shouldn't exist but CLI generates it
+            }
+
+            val runWithNoParams = wsk.trigger.fire(name, Map())
+            withActivation(wsk.activation, runWithNoParams) {
+                activation =>
+                    activation.response.result shouldBe Some(JsObject())
+                    activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+                    activation.end shouldBe Instant.EPOCH.toEpochMilli // shouldn't exist but CLI generates it
             }
 
             wsk.trigger.list().stdout should include(name)

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -457,6 +457,12 @@ class WskBasicUsageTests
                 activation =>
                     activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
                     activation.response.result.get.fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
+                    activation.annotations shouldBe defined
+                    val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
+                    withClue(limits) {
+                        limits.length should be > 0
+                        limits(0).fields("value") should not be JsNull
+                    }
             }
     }
 
@@ -697,8 +703,7 @@ class WskBasicUsageTests
             TestUtils.getTestActionFilename("invalidInput1.json"),
             TestUtils.getTestActionFilename("invalidInput2.json"),
             TestUtils.getTestActionFilename("invalidInput3.json"),
-            TestUtils.getTestActionFilename("invalidInput4.json")
-        )
+            TestUtils.getTestActionFilename("invalidInput4.json"))
         val paramCmds = Seq(
             Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
             Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
@@ -708,8 +713,7 @@ class WskBasicUsageTests
             Seq("package", "bind", "packageName", "boundPackageName"),
             Seq("trigger", "create", "triggerName"),
             Seq("trigger", "update", "triggerName"),
-            Seq("trigger", "fire", "triggerName")
-        )
+            Seq("trigger", "fire", "triggerName"))
         val annotCmds = Seq(
             Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js")),
             Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js")),
@@ -717,18 +721,17 @@ class WskBasicUsageTests
             Seq("package", "update", "packageName"),
             Seq("package", "bind", "packageName", "boundPackageName"),
             Seq("trigger", "create", "triggerName"),
-            Seq("trigger", "update", "triggerName")
-        )
+            Seq("trigger", "update", "triggerName"))
 
         for (cmd <- paramCmds) {
             for (invalid <- invalidJSONInputs) {
                 wsk.cli(cmd ++ Seq("-p", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                  .stderr should include("Invalid parameter argument")
+                    .stderr should include("Invalid parameter argument")
             }
 
             for (invalid <- invalidJSONFiles) {
                 wsk.cli(cmd ++ Seq("-P", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                  .stderr should include("Invalid parameter argument")
+                    .stderr should include("Invalid parameter argument")
 
             }
         }
@@ -736,12 +739,12 @@ class WskBasicUsageTests
         for (cmd <- annotCmds) {
             for (invalid <- invalidJSONInputs) {
                 wsk.cli(cmd ++ Seq("-a", "key", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                  .stderr should include("Invalid annotation argument")
+                    .stderr should include("Invalid annotation argument")
             }
 
             for (invalid <- invalidJSONFiles) {
                 wsk.cli(cmd ++ Seq("-A", invalid) ++ wskprops.overrides, expectedExitCode = ERROR_EXIT)
-                  .stderr should include("Invalid annotation argument")
+                    .stderr should include("Invalid annotation argument")
             }
         }
     }
@@ -753,9 +756,9 @@ class WskBasicUsageTests
         val missingFileMsg = s"File '$missingFile' is not a valid file or it does not exist"
         val invalidArgs = Seq(
             (Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
-              emptyFileMsg),
+                emptyFileMsg),
             (Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-P", emptyFile),
-              emptyFileMsg),
+                emptyFileMsg),
             (Seq("action", "invoke", "actionName", "-P", emptyFile), emptyFileMsg),
             (Seq("action", "create", "actionName", "-P", emptyFile), emptyFileMsg),
             (Seq("action", "update", "actionName", "-P", emptyFile), emptyFileMsg),
@@ -773,9 +776,9 @@ class WskBasicUsageTests
             (Seq("trigger", "update", "triggerName", "-P", emptyFile), emptyFileMsg),
             (Seq("trigger", "fire", "triggerName", "-P", emptyFile), emptyFileMsg),
             (Seq("action", "create", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
-              missingFileMsg),
+                missingFileMsg),
             (Seq("action", "update", "actionName", TestUtils.getTestActionFilename("hello.js"), "-A", missingFile),
-              missingFileMsg),
+                missingFileMsg),
             (Seq("action", "invoke", "actionName", "-A", missingFile), missingFileMsg),
             (Seq("action", "create", "actionName", "-A", missingFile), missingFileMsg),
             (Seq("action", "update", "actionName", "-A", missingFile), missingFileMsg),
@@ -791,14 +794,13 @@ class WskBasicUsageTests
             (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg),
             (Seq("trigger", "create", "triggerName", "-A", missingFile), missingFileMsg),
             (Seq("trigger", "update", "triggerName", "-A", missingFile), missingFileMsg),
-            (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg)
-        )
+            (Seq("trigger", "fire", "triggerName", "-A", missingFile), missingFileMsg))
 
         invalidArgs foreach {
             case (cmd, err) =>
-            val stderr = wsk.cli(cmd, expectedExitCode = MISUSE_EXIT).stderr
-            stderr should include(err)
-            stderr should include("Run 'wsk --help' for usage.")
+                val stderr = wsk.cli(cmd, expectedExitCode = MISUSE_EXIT).stderr
+                stderr should include(err)
+                stderr should include("Run 'wsk --help' for usage.")
         }
     }
 
@@ -861,8 +863,7 @@ class WskBasicUsageTests
             (Seq("trigger", "update", "triggerName", "-A"), invalidAnnotFileMsg),
             (Seq("trigger", "fire", "triggerName", "-a"), invalidAnnotMsg),
             (Seq("trigger", "fire", "triggerName", "-a", "key"), invalidAnnotMsg),
-            (Seq("trigger", "fire", "triggerName", "-A"), invalidAnnotFileMsg)
-        )
+            (Seq("trigger", "fire", "triggerName", "-A"), invalidAnnotFileMsg))
 
         invalidArgs foreach {
             case (cmd, err) =>

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -46,6 +46,7 @@ import scala.language.postfixOps
 
 import common.WskActorSystem
 
+
 /**
  * Unit tests for ContainerPool and, by association, Container and WhiskContainer.
  *
@@ -203,8 +204,7 @@ class ContainerPoolTests extends FlatSpec
             val name = "foobar" + i
             val action = makeHelloAction(name, i)
             pool.getAction(action, defaultAuth) match {
-                case None => assert(false)
-                case Some((con, initResult)) => {
+                case (con, initResult) => {
                     val str = "QWERTY" + i.toString()
                     con.run(str, (20000 + i).toString()) // payload + activationId
                     if (i == max - 1) {
@@ -233,7 +233,7 @@ class ContainerPoolTests extends FlatSpec
         ensureClean()
         val action = makeHelloAction("foobar", 0)
         // Make a whisk container and test init and a push
-        val Some((con, initRes)) = pool.getAction(action, defaultAuth)
+        val (con, initRes) = pool.getAction(action, defaultAuth)
         Thread.sleep(1000)
         assert(con.getLogs().contains("ABCXYZ"))
         con.run("QWERTY", "55555") // payload + activationId
@@ -241,7 +241,7 @@ class ContainerPoolTests extends FlatSpec
         assert(con.getLogs().contains("QWERTY"))
         pool.putBack(con)
         // Test container reuse
-        val Some((con2, _)) = pool.getAction(action, defaultAuth)
+        val (con2, _) = pool.getAction(action, defaultAuth)
         assert(con == con2) // check re-use
         con.run("ASDFGH", "4444") // payload + activationId
         Thread.sleep(1000)

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -37,7 +37,8 @@ type Activation struct {
     ActivationID    string `json:"activationId"`
     Cause           string `json:"cause,omitempty"`
     Start           int64  `json:"start"`        // When action started (in milliseconds since January 1, 1970 UTC)
-    End             int64  `json:"end"`                    // Since a 0 is a valid value from server, don't omit
+    End             int64  `json:"end"`          // Since a 0 is a valid value from server, don't omit
+    Duration        int64  `json:"duration"`     // Only available for actions
     Response        `json:"response"`
     Logs            []string `json:"logs"`
     Annotations     KeyValueArr `json:"annotations"`


### PR DESCRIPTION
Several bug fixes and some code refactoring - organized as 3 independent commits.

1. remove unnecessary vars and simplify types
2. when activation fails (for docker actions in particular), set annotations correctly (previous was null)
3. reorganize invoke action flow to avoid unintended recovery attempts.
4. added some tests to checks proper annotations on failed docker actions
5. while at it, added duration for activations