### PR TITLE
Migrate Controller's authentication to the new schema

### DIFF
--- a/ansible/files/auth_index.json
+++ b/ansible/files/auth_index.json
@@ -1,6 +1,13 @@
 {
   "_id":"_design/subjects",
-  "views": { "uuids": { "map": "function (doc) {\n  emit([doc.uuid], {secret: doc.key});\n}" } },
+  "views": {
+    "uuids": {
+      "map": "function (doc) {\n  emit([doc.uuid], {secret: doc.key});\n}"
+    },
+    "identities": {
+      "map": "function (doc) {\n  if(doc.uuid && doc.key) {\n    emit([doc.uuid, doc.key], {namespace: doc.subject, uuid: doc.uuid, key: doc.key});\n  }\n  if(doc.namespaces) {\n    doc.namespaces.forEach(function(namespace) {\n      emit([namespace.uuid, namespace.key], {namespace: namespace.name, uuid: namespace.uuid, key: namespace.key});\n    });\n  }\n}"
+    }
+  },
   "language":"javascript",
   "indexes": {}
 }

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+import scala.concurrent.Future
+
+import spray.json._
+import types.AuthStore
+import whisk.common.Logging
+import whisk.common.TransactionId
+import whisk.core.database.MultipleReadersSingleWriterCache
+import whisk.core.database.NoDocumentException
+import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Privilege.Privilege
+
+protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege])
+
+object Identities extends MultipleReadersSingleWriterCache[Identity, DocInfo] {
+
+    private val viewName = "subjects/identities"
+
+    override val cacheEnabled = true
+    override def cacheKeyForUpdate(i: Identity) = i.authkey
+
+    def get(datastore: AuthStore, authkey: AuthKey)(
+        implicit transid: TransactionId): Future[Identity] = {
+        implicit val logger: Logging = datastore
+        implicit val ec = datastore.executionContext
+
+        cacheLookup(authkey, {
+            list(datastore, authkey) map { list =>
+                list.length match {
+                    case 1 =>
+                        val row = list.head
+                        row.getFields("id", "value") match {
+                            case Seq(JsString(id), JsObject(value)) =>
+                                val subject = Subject(id)
+                                val JsString(uuid) = value("uuid")
+                                val JsString(secret) = value("key")
+                                val JsString(namespace) = value("namespace")
+                                Identity(subject, EntityName(namespace), AuthKey(UUID(uuid), Secret(secret)), Privilege.ALL)
+                            case _ =>
+                                logger.error(this, s"$viewName[${authkey.uuid}] has malformed view '${row.compactPrint}'")
+                                throw new IllegalStateException("identities view malformed")
+                        }
+                    case 0 =>
+                        logger.info(this, s"$viewName[${authkey.uuid}] does not exist")
+                        throw new NoDocumentException("uuid does not exist")
+                    case _ =>
+                        logger.error(this, s"$viewName[${authkey.uuid}] is not unique")
+                        throw new IllegalStateException("uuid is not unique")
+                }
+            }
+        })
+    }
+
+    def list(datastore: AuthStore, authkey: AuthKey)(
+        implicit transid: TransactionId): Future[List[JsObject]] = {
+        val key = List(authkey.uuid.toString, authkey.key.toString)
+        datastore.query(viewName,
+            startKey = key,
+            endKey = key,
+            skip = 0,
+            limit = 2,
+            includeDocs = false,
+            descending = true,
+            reduce = false)
+    }
+}

--- a/common/scala/src/main/scala/whisk/core/entity/Subject.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Subject.scala
@@ -23,7 +23,6 @@ import spray.json.JsValue
 import spray.json.RootJsonFormat
 import spray.json.deserializationError
 import whisk.core.entitlement.Privilege
-import whisk.core.entitlement.Privilege.Privilege
 
 protected[core] class Subject private (private val subject: String) extends AnyVal {
     protected[core] def apply() = subject
@@ -69,5 +68,3 @@ protected[core] object Subject extends ArgNormalizer[Subject] {
 
     private val rand = new scala.util.Random()
 }
-
-protected[core] case class Identity(subject: Subject, namespace: EntityName, authkey: AuthKey, rights: Set[Privilege])

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -98,7 +98,6 @@ object WhiskAuth extends DocumentFactory[WhiskAuth] {
         // hence it is safe to cache the result of this query result since a put
         // on the auth record will invalidate the cached query result as well
         cacheLookup(uuid, {
-            implicit val ec = datastore.executionContext
             list(datastore, uuid) map { list =>
                 list.length match {
                     case 1 =>

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuthV2.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuthV2.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+import spray.json._
+import scala.util.Try
+
+/**
+ * Represents a namespace for a subject as stored in the authentication
+ * database. Each namespace has its own key which is used to determine
+ * the {@ Identity} of the user calling.
+ */
+case class WhiskNamespace(name: EntityName, authkey: AuthKey)
+
+object WhiskNamespace extends DefaultJsonProtocol {
+    implicit val serdes = new RootJsonFormat[WhiskNamespace] {
+        def write(w: WhiskNamespace) = JsObject(
+            "name" -> w.name.toJson,
+            "uuid" -> w.authkey.uuid.toJson,
+            "key" -> w.authkey.key.toJson)
+
+        def read(value: JsValue) = Try {
+            value.asJsObject.getFields("name", "uuid", "key") match {
+                case Seq(JsString(n), JsString(u), JsString(k)) =>
+                    WhiskNamespace(EntityName(n), AuthKey(UUID(u), Secret(k)))
+            }
+        } getOrElse deserializationError("namespace record malformed")
+    }
+}
+
+/**
+ * Represents the new version of entries in the subjects database. No
+ * top-level authkey is given but each subject has a set of namespaces,
+ * which in turn have the keys.
+ */
+case class WhiskAuthV2(
+    subject: Subject,
+    namespaces: Set[WhiskNamespace])
+    extends WhiskDocument {
+
+    override def docid = DocId(subject())
+
+    def toJson = JsObject(
+        "subject" -> subject.toJson,
+        "namespaces" -> namespaces.toJson)
+}
+
+object WhiskAuthV2 extends DefaultJsonProtocol {
+    // Need to explicitly set field names since WhiskAuthV2 extends WhiskDocument
+    // which defines more than the 2 "standard" fields
+    implicit val serdes = jsonFormat(WhiskAuthV2.apply, "subject", "namespaces")
+}

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -28,9 +28,9 @@ import whisk.core.entity.AuthKey
 import whisk.core.entity.Identity
 import whisk.core.entity.Secret
 import whisk.core.entity.UUID
-import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.types.AuthStore
+import whisk.core.entity.Identities
 
 object Authenticate {
     /** Required properties for this component */
@@ -56,10 +56,10 @@ trait Authenticate extends Logging {
                 // authkey deserialization is wrapped in a try to guard against malformed values
                 val authkey = AuthKey(UUID(pw.user), Secret(pw.pass))
                 info(this, s"authenticate: ${authkey.uuid}")
-                val future = WhiskAuth.get(authStore, authkey.uuid) map { result =>
+                val future = Identities.get(authStore, authkey) map { result =>
                     if (authkey == result.authkey) {
                         info(this, s"authentication valid")
-                        Some(result.subject.toIdentity(result.authkey))
+                        Some(result)
                     } else {
                         info(this, s"authentication not valid")
                         None

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -25,7 +25,6 @@ import spray.routing.Directive1
 import spray.http.HttpMethod
 import whisk.common.TransactionId
 import whisk.core.entity.EntityPath
-import whisk.core.entity.Subject
 import whisk.core.entitlement.EntitlementService
 import whisk.core.entitlement.Collection
 import whisk.core.entitlement.Privilege.Privilege
@@ -97,9 +96,9 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
             implicit transid: TransactionId): RequestContext => Unit
 
     /** Extracts namespace for user from the matched path segment. */
-    protected def namespace(user: Subject, ns: String) = {
+    protected def namespace(user: Identity, ns: String) = {
         validate(isNamespace(ns), "namespace contains invalid characters") &
-            extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user() else ns))
+            extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace() else ns))
     }
 
     /** Extracts the HTTP method which is used to determine privilege for resource. */
@@ -139,7 +138,7 @@ trait AuthorizedRouteProvider extends BasicAuthorizedRouteProvider {
      */
     def routes(user: Identity)(implicit transid: TransactionId) = {
         collectionPrefix { segment =>
-            namespace(user.subject, segment) { ns =>
+            namespace(user, segment) { ns =>
                 (collectionOps & requestMethod) {
                     // matched /namespace/collection
                     authorizeAndDispatch(_, user, Resource(ns, collection, None))

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -28,7 +28,7 @@ import whisk.core.entitlement.RemoteEntitlementService
 import whisk.core.loadBalancer.{ LoadBalancer, LoadBalancerService }
 import scala.language.postfixOps
 import whisk.core.entity.ActivationId.ActivationIdGenerator
-import whisk.core.iam.Identities
+import whisk.core.iam.NamespaceProvider
 
 object WhiskServices {
 
@@ -39,7 +39,7 @@ object WhiskServices {
     /**
      * Creates instance of an entitlement service.
      */
-    def entitlementService(config: WhiskConfig, loadBalancer: LoadBalancer, iam: Identities, timeout: FiniteDuration = 5 seconds)(
+    def entitlementService(config: WhiskConfig, loadBalancer: LoadBalancer, iam: NamespaceProvider, timeout: FiniteDuration = 5 seconds)(
         implicit as: ActorSystem) = {
         // remote entitlement service requires a host:port definition. If not given,
         // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
@@ -54,7 +54,7 @@ object WhiskServices {
      * Creates instance of an identity provider.
      */
     def iamProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds)(implicit as: ActorSystem) = {
-        new Identities(config, timeout)
+        new NamespaceProvider(config, timeout)
     }
 
     /**
@@ -78,7 +78,7 @@ trait WhiskServices {
     protected val entitlementService: EntitlementService
 
     /** An identity provider. */
-    protected val iam: Identities
+    protected val iam: NamespaceProvider
 
     /** A generator for new activation ids. */
     protected val activationId: ActivationIdGenerator

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -40,7 +40,7 @@ import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
 import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
 import whisk.core.entity.Identity
-import whisk.core.iam.Identities
+import whisk.core.iam.NamespaceProvider
 
 object WhiskNamespacesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
@@ -64,7 +64,7 @@ trait WhiskNamespacesApi
     protected val entityStore: EntityStore
 
     /** An identity provider. */
-    protected val iam: Identities
+    protected val iam: NamespaceProvider
 
     /**
      * Rest API for managing namespaces. Defines all the routes handled by this API. They are:
@@ -80,7 +80,7 @@ trait WhiskNamespacesApi
             (collectionOps & requestMethod) { m =>
                 getNamespaces(user.subject)
             } ~ (entityOps & entityPrefix & pathEndOrSingleSlash & requestMethod) { (segment, m) =>
-                namespace(user.subject, segment) { ns =>
+                namespace(user, segment) { ns =>
                     val resource = Resource(ns, collection, None)
                     authorizeAndDispatch(m, user, resource)
                 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -41,7 +41,7 @@ import whisk.core.entity.types.{ ActivationStore, EntityStore }
 import whisk.core.loadBalancer.LoadBalancerService
 import akka.event.Logging.LogLevel
 import whisk.core.entity.ActivationId.ActivationIdGenerator
-import whisk.core.iam.Identities
+import whisk.core.iam.NamespaceProvider
 
 /**
  * Abstract class which provides basic Directives which are used to construct route structures
@@ -187,7 +187,7 @@ protected[controller] class RestAPIVersion_v1(
         val apiversion: String,
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
-            override val iam: Identities,
+            override val iam: NamespaceProvider,
             override val entitlementService: EntitlementService,
             override val executionContext: ExecutionContext)
         extends WhiskNamespacesApi {
@@ -201,7 +201,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
             override val activationStore: ActivationStore,
-            override val iam: Identities,
+            override val iam: NamespaceProvider,
             override val entitlementService: EntitlementService,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
@@ -220,7 +220,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val actorSystem: ActorSystem,
             implicit override val entityStore: EntityStore,
-            override val iam: Identities,
+            override val iam: NamespaceProvider,
             override val entitlementService: EntitlementService,
             override val activationStore: ActivationStore,
             override val activationId: ActivationIdGenerator,
@@ -238,7 +238,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
-            override val iam: Identities,
+            override val iam: NamespaceProvider,
             override val entitlementService: EntitlementService,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
@@ -265,7 +265,7 @@ protected[controller] class RestAPIVersion_v1(
         val apiversion: String,
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
-            override val iam: Identities,
+            override val iam: NamespaceProvider,
             override val entitlementService: EntitlementService,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -25,7 +25,7 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.entity.Subject
 import whisk.core.loadBalancer.LoadBalancer
-import whisk.core.iam.Identities
+import whisk.core.iam.NamespaceProvider
 
 private object LocalEntitlementService {
     /** Poor mans entitlement matrix. Must persist to datastore eventually. */
@@ -35,7 +35,7 @@ private object LocalEntitlementService {
 protected[core] class LocalEntitlementService(
     private val config: WhiskConfig,
     private val loadBalancer: LoadBalancer,
-    private val iam: Identities)(
+    private val iam: NamespaceProvider)(
         implicit actorSystem: ActorSystem)
     extends EntitlementService(config, loadBalancer, iam) {
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -39,12 +39,12 @@ import whisk.core.WhiskConfig
 import whisk.core.controller.RejectRequest
 import whisk.core.entity.Subject
 import whisk.core.loadBalancer.LoadBalancer
-import whisk.core.iam.Identities
+import whisk.core.iam.NamespaceProvider
 
 protected[core] class RemoteEntitlementService(
     private val config: WhiskConfig,
     private val loadBalancer: LoadBalancer,
-    private val iam: Identities,
+    private val iam: NamespaceProvider,
     private val timeout: FiniteDuration = 5 seconds)(
         private implicit val actorSystem: ActorSystem)
     extends EntitlementService(config, loadBalancer, iam) {

--- a/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
+++ b/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
@@ -31,7 +31,7 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.entity.Subject
 
-object Identities {
+object NamespaceProvider {
     /**
      * An identity provider host (optional).
      * Note: using entitlement host now for compatibility but will need to change to an iam provider in the future
@@ -44,7 +44,7 @@ object Identities {
     protected[core] def defaultNamespaces(subject: Subject) = Set(subject())
 }
 
-protected[core] class Identities(config: WhiskConfig, timeout: FiniteDuration = 5 seconds, forceLocal: Boolean = false)(
+protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds, forceLocal: Boolean = false)(
     implicit actorSystem: ActorSystem)
     extends Logging {
 
@@ -75,7 +75,7 @@ protected[core] class Identities(config: WhiskConfig, timeout: FiniteDuration = 
             pipeline(Get(url))
         } else {
             info(this, s"assuming default namespaces")
-            Future.successful(Identities.defaultNamespaces(subject))
+            Future.successful(NamespaceProvider.defaultNamespaces(subject))
         }
     }
 }

--- a/tests/src/whisk/core/controller/test/AuthenticateV2Tests.scala
+++ b/tests/src/whisk/core/controller/test/AuthenticateV2Tests.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.controller.test
+
+import scala.concurrent.Await
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import spray.routing.authentication.UserPass
+import whisk.core.controller.Authenticate
+import whisk.core.entity.AuthKey
+import whisk.core.entity.Subject
+import whisk.core.entity.WhiskAuthV2
+import whisk.core.entity.WhiskNamespace
+import whisk.core.entitlement.Privilege
+import whisk.core.entity.Identity
+import whisk.core.entity.Util
+
+/**
+ * Tests authentication handler which guards API.
+ *
+ * Unit tests of the controller service as a standalone component.
+ * These tests exercise a fresh instance of the service object in memory -- these
+ * tests do NOT communication with a whisk deployment.
+ *
+ *
+ * @Idioglossia
+ * "using Specification DSL to write unit tests, as in should, must, not, be"
+ * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
+ */
+@RunWith(classOf[JUnitRunner])
+class AuthenticateV2Tests extends ControllerTestCommon with Authenticate {
+    // Interface to store WhiskAuthV2 entries
+    val authStoreV2 = Util.makeStore[WhiskAuthV2](whiskConfig, _.dbAuths)
+
+    // Creates a new unique name each time its called
+    def aname = MakeName.next("authenticatev2_tests")
+
+    behavior of "Authenticate V2"
+
+    it should "authorize a known user using the new database schema in different namespaces" in {
+        implicit val tid = transid()
+        val subject = Subject()
+
+        val namespaces = Set(
+            WhiskNamespace(aname, AuthKey()),
+            WhiskNamespace(aname, AuthKey()))
+
+        val entry = WhiskAuthV2(subject, namespaces)
+
+        put(authStoreV2, entry)
+
+        // Try to login with each specific namespace
+        namespaces.foreach { ns =>
+            println(s"Trying to login to $ns")
+            val pass = UserPass(ns.authkey.uuid(), ns.authkey.key())
+            val user = Await.result(validateCredentials(Some(pass)), dbOpTimeout)
+            user.get shouldBe Identity(subject, ns.name, ns.authkey, Privilege.ALL)
+        }
+    }
+}

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -39,8 +39,7 @@ import whisk.core.database.test.DbUtils
 import whisk.core.entitlement.{ Collection, EntitlementService, LocalEntitlementService }
 import whisk.core.entity._
 import whisk.core.loadBalancer.LoadBalancer
-import whisk.core.iam.Identities
-
+import whisk.core.iam.NamespaceProvider
 
 protected trait ControllerTestCommon
     extends FlatSpec
@@ -64,7 +63,7 @@ protected trait ControllerTestCommon
     assert(whiskConfig.isValid)
 
     override val loadBalancer = new DegenerateLoadBalancerService(whiskConfig, InfoLevel)
-    override val iam = new Identities(whiskConfig, forceLocal = true)
+    override val iam = new NamespaceProvider(whiskConfig, forceLocal = true)
     override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig, loadBalancer, iam)
 
     override val activationId = new ActivationId.ActivationIdGenerator() {
@@ -174,8 +173,8 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
 
     override def publish(msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
         (Future.successful {},
-         whiskActivationStub map {
-            activation => Future.successful(activation)
-        } getOrElse Future.failed(new IllegalArgumentException("Unit test does not need fast path")))
+            whiskActivationStub map {
+                activation => Future.successful(activation)
+            } getOrElse Future.failed(new IllegalArgumentException("Unit test does not need fast path")))
 
 }


### PR DESCRIPTION
1. Add the new view
2. Make the Controller read from the view
3. Thread the namespace extracted from the view through the API

The general "_" case now resolves to the namespace infered from the key vs. defaulting to the subject's name. For migration of the API, the "old" keys' namespace default to the subject name which preserves previous behaviour.