### PR TITLE
read seriaseriadockerPull instead of invokerSerializeDockerOp for pull

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -82,7 +82,7 @@ class ContainerPool(
     val mounted = !standalone
     val dockerhost = config.selfDockerEndpoint
     val serializeDockerOp = config.invokerSerializeDockerOp.toBoolean
-    val serializeDockerPull = config.invokerSerializeDockerOp.toBoolean
+    val serializeDockerPull = config.invokerSerializeDockerPull.toBoolean
     info(this, s"dockerhost = $dockerhost    serializeDockerOp = $serializeDockerOp   serializeDockerPull = $serializeDockerPull")
 
     // Eventually, we will have a more sophisticated warmup strategy that does multiple sizes


### PR DESCRIPTION
```
[2016-11-10T02:16:51.769Z] [INFO] [??] [WhiskConfig] reading properties from consul at xxxxx
[2016-11-10T02:16:53.676Z] [INFO] [??] [ContainerPool] dockerhost = xxxx    serializeDockerOp = false   serializeDockerPull = false
```

@perryibm fyi - minor fix.