### PR TITLE
Compute referenced entities in common trait

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -85,6 +85,7 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat9(ActivationMessage.apply)
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -41,7 +41,7 @@ import whisk.http.Messages
  *
  * @param path the sequence of parts that make up a namespace path
  */
-protected[core] class EntityPath private (val path: Seq[String]) extends AnyVal {
+protected[core] class EntityPath private (private val path: Seq[String]) extends AnyVal {
     def namespace: String = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
     def addpath(e: EntityName) = EntityPath(path :+ e.name)
     def relpath: Option[EntityPath] = Try(EntityPath(path.drop(1))).toOption

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -42,11 +42,12 @@ import whisk.http.Messages
  * @param path the sequence of parts that make up a namespace path
  */
 protected[core] class EntityPath private (val path: Seq[String]) extends AnyVal {
-    def namespace = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
+    def namespace: String = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
     def addpath(e: EntityName) = EntityPath(path :+ e.name)
-    def root = EntityPath(Seq(path(0)))
-    def last = EntityName(path.last)
-    def defaultPackage = path.size == 1 // if only one element in the path, then it's the namespace with a default package
+    def relpath: Option[EntityPath] = Try(EntityPath(path.drop(1))).toOption
+    def root: EntityName = EntityName(path.head)
+    def last: EntityName = EntityName(path.last)
+    def defaultPackage: Boolean = path.size == 1 // if only one element in the path, then it's the namespace with a default package
     def toJson = JsString(namespace)
     def apply() = namespace
     override def toString = namespace
@@ -57,7 +58,7 @@ protected[core] class EntityPath private (val path: Seq[String]) extends AnyVal 
      */
     def resolveNamespace(newNamespace: EntityName): EntityPath = {
         // check if namespace is default
-        if (root == EntityPath.DEFAULT) {
+        if (root.toPath == EntityPath.DEFAULT) {
             val newPath = path.updated(0, newNamespace.name)
             EntityPath(newPath)
         } else this

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -61,6 +61,21 @@ case class WhiskActionPut(
     protected[core] def replace(exec: Exec) = {
         WhiskActionPut(Some(exec), parameters, limits, version, publish, annotations)
     }
+
+    /**
+     * Resolves sequence components if they contain default namespace.
+     */
+    protected[core] def resolve(namespace: EntityName): WhiskActionPut = {
+        val newExec = exec map {
+            case SequenceExec(code, components) =>
+                SequenceExec(code, components map {
+                    c => FullyQualifiedEntityName(c.path.resolveNamespace(namespace), c.name)
+                })
+            case e => e
+        }
+
+        WhiskActionPut(newExec, parameters, limits, version, publish, annotations)
+    }
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -60,10 +60,10 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
      * The name of the entity qualified with its namespace and version for
      * creating unique keys in backend services.
      */
-    final def fullyQualifiedName = WhiskEntity.fullyQualifiedName(namespace, en, version)
+    final def fullyQualifiedName(withVersion: Boolean) = FullyQualifiedEntityName(namespace, en, if (withVersion) Some(version) else None)
 
     /** The primary key for the entity in the datastore */
-    override final def docid = DocId(WhiskEntity.qualifiedName(namespace, en))
+    override final def docid = fullyQualifiedName(false).toDocId
 
     /**
      * Returns a JSON object with the fields specific to this abstract class.
@@ -83,7 +83,7 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
     /**
      * @return the primary key (name) of the entity as a pithy description
      */
-    override def toString = s"${this.getClass.getSimpleName}/$fullyQualifiedName"
+    override def toString = s"${this.getClass.getSimpleName}/${fullyQualifiedName(true)}"
 
     /**
      * A JSON view of the entity, that should match the result returned in a list operation.
@@ -102,31 +102,10 @@ object WhiskEntity {
     val sharedFieldName = "publish"
 
     /**
-     * Gets fully qualified name of an entity based on its namespace and entity name.
-     */
-    def qualifiedName(namespace: EntityPath, name: EntityName) = {
-        s"$namespace${EntityPath.PATHSEP}$name"
-    }
-
-    /**
      * Gets fully qualified name of an activation based on its namespace and activation id.
      */
     def qualifiedName(namespace: EntityPath, activationId: ActivationId) = {
         s"$namespace${EntityPath.PATHSEP}$activationId"
-    }
-
-    /**
-     * Gets fully qualified name of an entity based on its namespace, entity name and version.
-     */
-    def fullyQualifiedName(namespace: EntityPath, name: EntityName, version: SemVer) = {
-        s"$namespace${EntityPath.PATHSEP}${versionedName(name, version)}"
-    }
-
-    /**
-     * Gets versioned name of an entity based on its entity name and version.
-     */
-    def versionedName(name: EntityName, version: SemVer) = {
-        s"$name${EntityPath.PATHSEP}$version"
     }
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -21,8 +21,6 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.Try
 
-import spray.json.DefaultJsonProtocol
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 import whisk.common.TransactionId
 import whisk.core.database.DocumentFactory
@@ -33,11 +31,19 @@ import whisk.core.entity.types.EntityStore
  * that are auto-assigned or derived from URI: namespace and name.
  */
 case class WhiskPackagePut(
-    binding: Option[Binding] = None,
+    binding: Option[FullyQualifiedEntityName] = None,
     parameters: Option[Parameters] = None,
     version: Option[SemVer] = None,
     publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None)
+    annotations: Option[Parameters] = None) {
+
+    /**
+     * Resolves the binding if it contains the default namespace.
+     */
+    protected[core] def resolve(namespace: EntityName): WhiskPackagePut = {
+        WhiskPackagePut(binding.map(_.resolve(namespace)), parameters, version, publish, annotations)
+    }
+}
 
 /**
  * A WhiskPackage provides an abstraction of the meta-data for a whisk package
@@ -59,7 +65,7 @@ case class WhiskPackagePut(
 case class WhiskPackage(
     namespace: EntityPath,
     override val name: EntityName,
-    binding: Option[Binding] = None,
+    binding: Option[FullyQualifiedEntityName] = None,
     parameters: Parameters = Parameters(),
     version: SemVer = SemVer(),
     publish: Boolean = false,
@@ -82,7 +88,7 @@ case class WhiskPackage(
     /**
      * Gets binding for package iff this is not already a package reference.
      */
-    def bind = binding map { _ => None } getOrElse Some { Binding(namespace, name) }
+    def bind = binding map { _ => None } getOrElse Some { FullyQualifiedEntityName(namespace, name) }
 
     /**
      * Adds actions to package. The actions list is filtered so that only actions that
@@ -90,7 +96,7 @@ case class WhiskPackage(
      */
     def withActions(actions: List[WhiskAction] = List()) = {
         withPackageActions(actions filter { a =>
-            val pkgns = binding map { b => b.namespace.addpath(b.name) } getOrElse { namespace.addpath(name) }
+            val pkgns = binding map { b => b.path.addpath(b.name) } getOrElse { namespace.addpath(name) }
             a.namespace == pkgns
         } map { a =>
             WhiskPackageAction(a.name, a.version, a.annotations)
@@ -115,7 +121,7 @@ case class WhiskPackage(
 
     override def summaryAsJson = {
         val JsObject(fields) = super.summaryAsJson
-        JsObject(fields + (WhiskPackage.bindingFieldName -> binding.isDefined.toJson))
+        JsObject(fields + (WhiskPackage.bindingFieldName -> JsBoolean(binding.isDefined)))
     }
 }
 
@@ -150,28 +156,48 @@ object WhiskPackage
         implicit ec: ExecutionContext, transid: TransactionId): Future[WhiskPackage] = {
         WhiskPackage.get(db, pkg) flatMap { wp =>
             // if there is a binding resolve it
-            val resolved = wp.binding map { binding => resolveBinding(db, binding.docid) }
+            val resolved = wp.binding map { binding => resolveBinding(db, binding.toDocId) }
             resolved getOrElse Future.successful(wp)
         }
     }
 
-    override implicit val serdes = {
-        // This is to conform to the old style where {} represents None.
-        val tolerantOptionBindingFormat: JsonFormat[Option[Binding]] = {
-            val bs = Binding.serdes // helps the compiler
-            val base = implicitly[JsonFormat[Option[Binding]]]
-            new JsonFormat[Option[Binding]] {
-                override def write(ob: Option[Binding]) = ob match {
-                    case None => JsObject()
-                    case _    => base.write(ob)
-                }
-                override def read(js: JsValue) = {
-                    if (js == JsObject()) None else base.read(js)
-                }
-            }
+    /**
+     * Custom serdes for a binding - this property must be present in the datastore records for
+     * packages so that views can map over packages vs bindings.
+     */
+    val bindingSerializer = new JsonWriter[Option[FullyQualifiedEntityName]] {
+        override def write(b: Option[FullyQualifiedEntityName]) = b match {
+            case None    => JsObject()
+            case Some(n) => FullyQualifiedEntityName.serdes.write(n)
         }
+    }
 
-        implicit val bindingOverride = tolerantOptionBindingFormat
+    val bindingDeserializer = new JsonReader[Option[FullyQualifiedEntityName]] {
+        override def read(js: JsValue) = js match {
+            case JsObject(fields) =>
+                if (fields.isEmpty) None else {
+                    // in previous schema, Binding(namespace, name)
+                    // in new schema, FullyQualifiedEntityName(path, name, [version])
+                    // cannot have both defined
+                    val hasPath = fields.contains("path")
+                    val hasNamespace = fields.contains("namespace")
+                    if (hasPath && !hasNamespace) {
+                        Some(FullyQualifiedEntityName.serdes.read(js))
+                    } else if (hasNamespace && !hasPath) {
+                        val path = fields.get("namespace")
+                        Some(FullyQualifiedEntityName.serdes.read(JsObject(fields - "namespace" + ("path" -> path.toJson))))
+                    } else deserializationError("binding is malformed")
+                }
+            case JsNull => None
+            case _      => Some(FullyQualifiedEntityName.serdes.read(js))
+        }
+    }
+
+    override implicit val serdes = {
+        implicit val br = new JsonFormat[Option[FullyQualifiedEntityName]] {
+            override def write(b: Option[FullyQualifiedEntityName]) = bindingSerializer.write(b)
+            override def read(js: JsValue) = bindingDeserializer.read(js)
+        }
         jsonFormat7(WhiskPackage.apply)
     }
 
@@ -179,33 +205,16 @@ object WhiskPackage
     override def cacheKeyForUpdate(w: WhiskPackage) = w.docid.asDocInfo
 }
 
-/**
- * A package binding holds a reference to the providing package
- * namespace and package name.
- */
-case class Binding(namespace: EntityPath, name: EntityName) {
-    private def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
-    def docid = fullyQualifiedName.toDocId
-    override def toString = fullyQualifiedName.toString
-
-    /**
-     * Returns a Binding namespace if it is the default namespace
-     * to the given one, otherwise this is an identity.
-     */
-    def resolve(ns: EntityPath): Binding = {
-        namespace match {
-            case EntityPath.DEFAULT => Binding(ns, name)
-            case _                  => this
-        }
-    }
-}
-
-object Binding extends ArgNormalizer[Binding] with DefaultJsonProtocol {
-    override protected[core] implicit val serdes = jsonFormat2(Binding.apply)
-}
-
 object WhiskPackagePut extends DefaultJsonProtocol {
-    implicit val serdes = jsonFormat5(WhiskPackagePut.apply)
+    implicit val serdes = {
+        implicit val base = FullyQualifiedEntityName.serdes
+        implicit val bindingSerdes = new OptionFormat[FullyQualifiedEntityName] {
+            override def write(n: Option[FullyQualifiedEntityName]) = WhiskPackage.bindingSerializer.write(n)
+            override def read(js: JsValue) = WhiskPackage.bindingDeserializer.read(js)
+        }
+
+        jsonFormat5(WhiskPackagePut.apply)
+    }
 }
 
 object WhiskPackageAction extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -184,8 +184,9 @@ object WhiskPackage
  * namespace and package name.
  */
 case class Binding(namespace: EntityPath, name: EntityName) {
-    def docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-    override def toString = WhiskEntity.qualifiedName(namespace, name)
+    private def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
+    def docid = fullyQualifiedName.toDocId
+    override def toString = fullyQualifiedName.toString
 
     /**
      * Returns a Binding namespace if it is the default namespace

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -43,7 +43,7 @@ case class WhiskRulePut(
     /**
      * Resolves the trigger and action name if they contains the default namespace.
      */
-    def resolve(namespace: EntityName): WhiskRulePut = {
+    protected[core] def resolve(namespace: EntityName): WhiskRulePut = {
         val t = trigger map { _.resolve(namespace) }
         val a = action map { _.resolve(namespace) }
         WhiskRulePut(t, a, version, publish, annotations)

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -21,6 +21,7 @@ import scala.util.Success
 import scala.util.Try
 
 import spray.json.DefaultJsonProtocol
+import spray.json.DeserializationException
 import spray.json.JsObject
 import spray.json.JsString
 import spray.json.JsValue
@@ -33,11 +34,21 @@ import whisk.core.database.DocumentFactory
  * that are auto-assigned or derived from URI: namespace, name, status.
  */
 case class WhiskRulePut(
-    trigger: Option[EntityName] = None,
-    action: Option[EntityName] = None,
+    trigger: Option[FullyQualifiedEntityName] = None,
+    action: Option[FullyQualifiedEntityName] = None,
     version: Option[SemVer] = None,
     publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None)
+    annotations: Option[Parameters] = None) {
+
+    /**
+     * Resolves the trigger and action name if they contains the default namespace.
+     */
+    def resolve(namespace: EntityName): WhiskRulePut = {
+        val t = trigger map { _.resolve(namespace) }
+        val a = action map { _.resolve(namespace) }
+        WhiskRulePut(t, a, version, publish, annotations)
+    }
+}
 
 /**
  * A WhiskRule provides an abstraction of the meta-data for a whisk rule.
@@ -61,8 +72,8 @@ case class WhiskRulePut(
 case class WhiskRule(
     namespace: EntityPath,
     override val name: EntityName,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: FullyQualifiedEntityName,
+    action: FullyQualifiedEntityName,
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters())
@@ -91,8 +102,8 @@ case class WhiskRuleResponse(
     namespace: EntityPath,
     name: EntityName,
     status: Status,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: FullyQualifiedEntityName,
+    action: FullyQualifiedEntityName,
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters()) {
@@ -189,16 +200,47 @@ object WhiskRule
     with DefaultJsonProtocol {
 
     override val collectionName = "rules"
-    override implicit val serdes = jsonFormat7(WhiskRule.apply)
+
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+    private val caseClassSerdes = jsonFormat7(WhiskRule.apply)
+
+    override implicit val serdes = new RootJsonFormat[WhiskRule] {
+        def write(r: WhiskRule) = caseClassSerdes.write(r)
+
+        def read(value: JsValue) = Try {
+            caseClassSerdes.read(value)
+        } recover {
+            case DeserializationException(_, _, List("trigger")) | DeserializationException(_, _, List("action")) =>
+                val namespace = value.asJsObject.fields("namespace").convertTo[EntityPath]
+                val actionName = value.asJsObject.fields("action")
+                val triggerName = value.asJsObject.fields("trigger")
+
+                val refs = Seq(actionName, triggerName).map { name =>
+                    Try {
+                        FullyQualifiedEntityName(namespace, EntityName.serdes.read(name))
+                    } match {
+                        case Success(n) => n
+                        case Failure(t) => deserializationError(t.getMessage)
+                    }
+                }
+                val fields = value.asJsObject.fields + ("action" -> refs(0).toDocId.toJson) + ("trigger" -> refs(1).toDocId.toJson)
+                caseClassSerdes.read(JsObject(fields))
+        } match {
+            case Success(r) => r
+            case Failure(t) => deserializationError(t.getMessage)
+        }
+    }
 
     override val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskRule) = w.docid.asDocInfo
 }
 
 object WhiskRuleResponse extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat8(WhiskRuleResponse.apply)
 }
 
 object WhiskRulePut extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat5(WhiskRulePut.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -44,12 +44,6 @@ package object types {
     type AuthStore = ArtifactStore[WhiskAuth]
     type EntityStore = ArtifactStore[WhiskEntity]
     type ActivationStore = ArtifactStore[WhiskActivation]
-
-    // A placeholder type should we change the trigger and action references
-    // to a type that more explicitly captures the namespace, name, and version
-    // which are currently encoded in one string as DocId.id
-    type Trigger = EntityName
-    type Action = EntityName
 }
 
 protected[core] trait WhiskDocument

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -18,6 +18,7 @@ package whisk.core.entity
 
 import spray.json.DefaultJsonProtocol
 import whisk.core.database.DocumentFactory
+import spray.json._
 
 /**
  * WhiskTriggerPut is a restricted WhiskTrigger view that eschews properties
@@ -39,7 +40,7 @@ case class WhiskTriggerPut(
  * @param status status of the rule
  */
 case class ReducedRule(
-    action: EntityPath,
+    action: FullyQualifiedEntityName,
     status: Status)
 
 /**
@@ -68,7 +69,7 @@ case class WhiskTrigger(
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters(),
-    rules: Option[Map[EntityPath, ReducedRule]] = None)
+    rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
     extends WhiskEntity(name) {
 
     require(limits != null, "limits undefined")
@@ -84,9 +85,9 @@ case class WhiskTrigger(
      * @param rule The rule, that will be fired by this trigger. It's from type ReducedRule. This type
      * contains the fully qualified name of the action to be fired by the rule and the status of the rule.
      */
-    def addRule(rulename: EntityPath, rule: ReducedRule) = {
+    def addRule(rulename: FullyQualifiedEntityName, rule: ReducedRule) = {
         val entry = rulename -> rule
-        val links = rules getOrElse Map[EntityPath, ReducedRule]()
+        val links = rules getOrElse Map[FullyQualifiedEntityName, ReducedRule]()
         WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
     }
 
@@ -96,12 +97,13 @@ case class WhiskTrigger(
      * @param rule The fully qualified name of the rule, that should be removed from the
      * trigger. After removing the rule, it won't be fired anymore by this trigger.
      */
-    def removeRule(rule: EntityPath) = {
+    def removeRule(rule: FullyQualifiedEntityName) = {
         WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
     }
 }
 
 object ReducedRule extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat2(ReducedRule.apply)
 }
 
@@ -111,6 +113,8 @@ object WhiskTrigger
     with DefaultJsonProtocol {
 
     override val collectionName = "triggers"
+
+    private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
     override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
     override val cacheEnabled = true

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -38,7 +38,7 @@ object Messages {
      * Standard message for reporting resource conformance error when trying to access
      * a resource from a different collection.
      */
-    val conformanceMessage = "Resource by this name already exists but is not in this collection."
+    val conformanceMessage = "Resource by this name exists but is not in this collection."
     val corruptedEntity = "Resource exists by is corrupted."
 
     val systemOverloaded = "System is overloaded, try again later."

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -23,15 +23,8 @@ import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
 import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.json.DefaultJsonProtocol.LongJsonFormat
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsNumber
-import spray.json.JsObject
-import spray.json.JsString
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.pimpAny
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import spray.routing.Directives
 import spray.routing.Rejection
 import spray.routing.StandardRoute
@@ -46,6 +39,7 @@ object Messages {
      * a resource from a different collection.
      */
     val conformanceMessage = "Resource by this name already exists but is not in this collection."
+    val corruptedEntity = "Resource exists by is corrupted."
 
     val systemOverloaded = "System is overloaded, try again later."
 

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -74,6 +74,7 @@ object Messages {
     val packageCannotBecomeBinding = "Resource is a package and cannot be converted into a binding."
     val bindingCannotReferenceBinding = "Cannot bind to another package binding."
     val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
+    val notAllowedOnBinding = "Operation not permitted on package binding."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -19,6 +19,7 @@ package whisk.http
 import scala.util.Try
 
 import spray.http.StatusCode
+import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
 import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
@@ -58,7 +59,7 @@ object Messages {
     val tooManyConcurrentRequests = "The user has sent too many concurrent requests."
 
     /** Standard message when supplied authkey is not authorized for an operation. */
-    val notAuthorizedtoOperateOnResource = "The supplied authentication token is not authorized to perform operation resource."
+    val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
 
     /** Standard error message for malformed fully qualified entity names. */
     val malformedFullyQualifiedEntityName = "The fully qualified name of the entity must contain at least the namespace and the name of the entity."
@@ -67,6 +68,12 @@ object Messages {
     val sequenceIsTooLong = "Too many actions in the sequence."
     val sequenceIsCyclic = "Sequence may not refer to itself."
     val sequenceComponentNotFound = "Sequence component does not exist."
+
+    /** Error message for packages. */
+    val bindingDoesNotExist = "Binding references a package that does not exist."
+    val packageCannotBecomeBinding = "Resource is a package and cannot be converted into a binding."
+    val bindingCannotReferenceBinding = "Cannot bind to another package binding."
+    val requestedBindingIsNotValid = "Cannot bind to a resource that is not a package."
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */
@@ -88,8 +95,9 @@ object ErrorResponse extends Directives {
     }
 
     def response(status: StatusCode)(implicit transid: TransactionId): ErrorResponse = status match {
-        case NotFound => ErrorResponse(Messages.resourceDoesNotExist, transid)
-        case _        => ErrorResponse(status.defaultMessage, transid)
+        case NotFound  => ErrorResponse(Messages.resourceDoesNotExist, transid)
+        case Forbidden => ErrorResponse(Messages.notAuthorizedtoOperateOnResource, transid)
+        case _         => ErrorResponse(status.defaultMessage, transid)
     }
 
     implicit val serializer = new RootJsonFormat[ErrorResponse] {

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -598,7 +598,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         getEntity(WhiskPackage, entityStore, docid, Some { (wp: WhiskPackage) =>
             val pkgns = wp.binding map { b =>
                 info(this, s"list actions in package binding '${wp.name}' -> '$b'")
-                b.namespace.addpath(b.name)
+                b.path.addpath(b.name)
             } getOrElse {
                 info(this, s"list actions in package '${wp.name}'")
                 ns.addpath(wp.name)
@@ -620,7 +620,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
     private def mergeActionWithPackageAndDispatch(method: HttpMethod, user: Identity, action: EntityName, ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
         implicit transid: TransactionId): RequestContext => Unit = {
         wp.binding map {
-            case Binding(ns, n) =>
+            case FullyQualifiedEntityName(ns, n , _) =>
                 val docid = FullyQualifiedEntityName(ns, n).toDocId
                 info(this, s"fetching package '$docid' for reference")
                 // already checked that subject is authorized for package and binding;

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -34,6 +34,7 @@ import spray.http.HttpMethods.PUT
 import spray.http.StatusCodes.BadGateway
 import spray.http.StatusCodes.BadRequest
 import spray.http.StatusCodes.InternalServerError
+import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
 import spray.http.StatusCodes.Accepted
 import spray.http.StatusCodes.RequestEntityTooLarge
@@ -81,6 +82,8 @@ import whisk.core.WhiskConfig
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages._
 import whisk.utils.ExecutionContextFactory.FutureExtensions
+import whisk.http.Messages
+import whisk.core.database.DocumentTypeMismatchException
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -151,9 +154,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                     // matched GET /namespace/collection/package-name/
                     // list all actions in package iff subject is entitled to READ package
                     val resource = Resource(ns, Collection(Collection.PACKAGES), Some(outername))
-                    authorizeAndContinue(Privilege.READ, user, resource, next = () => {
-                        listPackageActions(user.subject, ns, EntityName(outername))
-                    })
+                    authorizeAndContinue(Privilege.READ, user, resource, next = listPackageActions(user.subject, ns, EntityName(outername)))
                 } ~ (entityPrefix & pathEnd) { segment =>
                     entityname(segment) { innername =>
                         // matched /namespace/collection/package-name/action-name
@@ -173,7 +174,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                                 // it may be desirable to separate these but currently the PACKAGES collection
                                 // does not allow ACTIVATE since it does not make sense to activate a package
                                 // but rather an action in the package
-                                authorizeAndContinue(Privilege.READ, user, packageResource, next = () => {
+                                authorizeAndContinue(Privilege.READ, user, packageResource, next = {
                                     getEntity(WhiskPackage, entityStore, packageDocId, Some {
                                         mergeActionWithPackageAndDispatch(m, user, EntityName(innername)) _
                                     })
@@ -183,10 +184,10 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                                 // but may not be permitted if this is a binding, or if the subject does
                                 // not have PUT and DELETE rights to the package itself
                                 val right = collection.determineRight(m, Some { innername })
-                                authorizeAndContinue(right, user, packageResource, next = () => {
+                                authorizeAndContinue(right, user, packageResource, next = {
                                     getEntity(WhiskPackage, entityStore, packageDocId, Some { wp: WhiskPackage =>
                                         wp.binding map {
-                                            _ => terminate(BadRequest, "Operation not permitted on package binding")
+                                            _ => terminate(BadRequest, Messages.notAllowedOnBinding)
                                         } getOrElse {
                                             val actionResource = Resource(wp.path, collection, Some { innername })
                                             dispatchOp(user, right, actionResource)
@@ -217,7 +218,24 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskActionPut]) { content =>
                 val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-                putEntity(WhiskAction, entityStore, docid, overwrite, update(user, content)_, () => { make(user, namespace, content, name) })
+                def doput = {
+                    putEntity(WhiskAction, entityStore, docid, overwrite,
+                        update(user, content)_, () => { make(user, namespace, content, name) })
+                }
+
+                content.exec match {
+                    case Some(seq @ SequenceExec(_, components)) =>
+                        info(this, "checking if sequence components are accessible")
+                        val referencedEntities = resolveDefaultNamespace(seq, user).components.map {
+                            c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name()))
+                        }.toSet
+                        authorizeAndContinue(Privilege.READ, user, referencedEntities, doput) {
+                            case authorizationFailure: Throwable =>
+                                val r = rewriteFailure(authorizationFailure)
+                                terminate(r.code, r.message)
+                        }
+                    case _ => doput
+                }
             }
         }
     }
@@ -239,39 +257,55 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                 val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
                 getEntity(WhiskAction, entityStore, docid, Some {
                     action: WhiskAction =>
-                        transid.started(this, if (blocking) LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING else LoggingMarkers.CONTROLLER_ACTIVATION)
-                        val postToLoadBalancer = postInvokeRequest(user, action, env, payload, blocking)
-                        onComplete(postToLoadBalancer) {
-                            case Success((activationId, None)) =>
-                                // non-blocking invoke or blocking invoke which got queued instead
-                                complete(Accepted, activationId.toJsObject)
-                            case Success((activationId, Some(activation))) =>
-                                val response = if (result) activation.resultAsJson else activation.toExtendedJson
+                        def doActivate = {
+                            transid.started(this, if (blocking) LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING else LoggingMarkers.CONTROLLER_ACTIVATION)
+                            val postToLoadBalancer = postInvokeRequest(user, action, env, payload, blocking)
+                            onComplete(postToLoadBalancer) {
+                                case Success((activationId, None)) =>
+                                    // non-blocking invoke or blocking invoke which got queued instead
+                                    complete(Accepted, activationId.toJsObject)
+                                case Success((activationId, Some(activation))) =>
+                                    val response = if (result) activation.resultAsJson else activation.toExtendedJson
 
-                                if (activation.response.isSuccess) {
-                                    complete(OK, response)
-                                } else if (activation.response.isApplicationError) {
-                                    // actions that result is ApplicationError status are considered a 'success'
-                                    // and will have an 'error' property in the result - the HTTP status is OK
-                                    // and clients must check the response status if it exists
-                                    // NOTE: response status will not exist in the JSON object if ?result == true
-                                    // and instead clients must check if 'error' is in the JSON
-                                    // PRESERVING OLD BEHAVIOR and will address defect in separate change
-                                    complete(BadGateway, response)
-                                } else if (activation.response.isContainerError) {
-                                    complete(BadGateway, response)
-                                } else {
-                                    complete(InternalServerError, response)
+                                    if (activation.response.isSuccess) {
+                                        complete(OK, response)
+                                    } else if (activation.response.isApplicationError) {
+                                        // actions that result is ApplicationError status are considered a 'success'
+                                        // and will have an 'error' property in the result - the HTTP status is OK
+                                        // and clients must check the response status if it exists
+                                        // NOTE: response status will not exist in the JSON object if ?result == true
+                                        // and instead clients must check if 'error' is in the JSON
+                                        // PRESERVING OLD BEHAVIOR and will address defect in separate change
+                                        complete(BadGateway, response)
+                                    } else if (activation.response.isContainerError) {
+                                        complete(BadGateway, response)
+                                    } else {
+                                        complete(InternalServerError, response)
+                                    }
+                                case Failure(t: BlockingInvokeTimeout) =>
+                                    info(this, s"[POST] action activation waiting period expired")
+                                    complete(Accepted, t.activationId.toJsObject)
+                                case Failure(t: RecordTooLargeException) =>
+                                    info(this, s"[POST] action payload was too large")
+                                    terminate(RequestEntityTooLarge)
+                                case Failure(t: Throwable) =>
+                                    error(this, s"[POST] action activation failed: ${t.getMessage}")
+                                    terminate(InternalServerError, t.getMessage)
+                            }
+                        }
+
+                        action.exec match {
+                            case seq @ SequenceExec(_, components) =>
+                                info(this, "checking if sequence components are accessible")
+                                val referencedEntities = resolveDefaultNamespace(seq, user).components.map {
+                                    c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name()))
+                                }.toSet
+                                authorizeAndContinue(Privilege.ACTIVATE, user, referencedEntities, doActivate) {
+                                    case authorizationFailure: Throwable =>
+                                        val r = rewriteFailure(authorizationFailure)
+                                        terminate(r.code, r.message)
                                 }
-                            case Failure(t: BlockingInvokeTimeout) =>
-                                info(this, s"[POST] action activation waiting period expired")
-                                complete(Accepted, t.activationId.toJsObject)
-                            case Failure(t: RecordTooLargeException) =>
-                                info(this, s"[POST] action payload was too large")
-                                terminate(RequestEntityTooLarge)
-                            case Failure(t: Throwable) =>
-                                error(this, s"[POST] action activation failed: ${t.getMessage}")
-                                terminate(InternalServerError, t.getMessage)
+                            case _ => doActivate
                         }
                 })
             }
@@ -719,6 +753,17 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
             // sum up all individual action counts per component
             val totalActionCount = actionCountsFuture map { actionCounts => actionCounts.foldLeft(0)(_ + _) }
             totalActionCount
+        }
+    }
+
+    private def rewriteFailure(failure: Throwable)(implicit transid: TransactionId) = {
+        info(this, s"rewriting failure $failure")
+        failure match {
+            case RejectRequest(NotFound, _)       => RejectRequest(NotFound)
+            case RejectRequest(c, m)              => RejectRequest(c, m)
+            case _: NoDocumentException           => RejectRequest(BadRequest)
+            case _: DocumentTypeMismatchException => RejectRequest(BadRequest)
+            case _                                => RejectRequest(BadRequest, failure)
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -49,24 +49,27 @@ import whisk.core.entity.WhiskEntity
 import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages._
+import spray.http.StatusCode
 
 
 /** An exception to throw inside a Predicate future. */
-protected[core] case class RejectRequest(code: ClientError, message: Option[ErrorResponse]) extends Throwable
+protected[core] case class RejectRequest(code: StatusCode, message: Option[ErrorResponse]) extends Throwable {
+    override def toString = s"RejectRequest($code)" + message.map(" "+_.error).getOrElse("")
+}
 
 protected[core] object RejectRequest {
     /** Creates rejection with default message for status code. */
-    protected[core] def apply(code: ClientError)(implicit transid: TransactionId): RejectRequest = {
+    protected[core] def apply(code: StatusCode)(implicit transid: TransactionId): RejectRequest = {
         RejectRequest(code, Some(ErrorResponse.response(code)(transid)))
     }
 
     /** Creates rejection with custom message for status code. */
-    protected[core] def apply(code: ClientError, m: String)(implicit transid: TransactionId): RejectRequest = {
+    protected[core] def apply(code: StatusCode, m: String)(implicit transid: TransactionId): RejectRequest = {
         RejectRequest(code, Some(ErrorResponse(m, transid)))
     }
 
     /** Creates rejection with custom message for status code derived from reason for throwable. */
-    protected[core] def apply(code: ClientError, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
+    protected[core] def apply(code: StatusCode, t: Throwable)(implicit transid: TransactionId): RejectRequest = {
         val reason = t.getMessage
         RejectRequest(code, if (reason != null) reason else "Rejected")
     }

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -20,7 +20,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
-import spray.http.StatusCodes.ClientError
 import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.InternalServerError
 import spray.http.StatusCodes.NotFound

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -66,7 +66,7 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         resource: Resource)(
             implicit transid: TransactionId): RequestContext => Unit = {
         val right = collection.determineRight(method, resource.entity)
-        authorizeAndContinue(right, user, resource, () => dispatchOp(user, right, resource))
+        authorizeAndContinue(right, user, resource, dispatchOp(user, right, resource))
     }
 
     /** Checks entitlement and if authorized, continues with next handler. */
@@ -74,17 +74,36 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         right: Privilege,
         user: Identity,
         resource: Resource,
-        next: () => RequestContext => Unit,
-        recover: Option[Throwable => RequestContext => Unit] = None)(
+        next: RequestContext => Unit)(
             implicit transid: TransactionId): RequestContext => Unit = {
-        onComplete(entitlementService.check(user, right, resource)) {
+        authorizeAndContinue(right, user, Set(resource), next, None)
+    }
+
+    protected def authorizeAndContinue(
+        right: Privilege,
+        user: Identity,
+        resources: Set[Resource],
+        next: RequestContext => Unit)(
+            recover: Throwable => RequestContext => Unit)(
+                implicit transid: TransactionId): RequestContext => Unit = {
+        authorizeAndContinue(right, user, resources, next, Some(recover))
+    }
+
+    private def authorizeAndContinue(
+        right: Privilege,
+        user: Identity,
+        resources: Set[Resource],
+        next: RequestContext => Unit,
+        recover: Option[Throwable => RequestContext => Unit])(
+            implicit transid: TransactionId): RequestContext => Unit = {
+        onComplete(entitlementService.check(user, right, resources)) {
             // do not use "authorize" directive here because it does not compose
             // hence for nested authorizations the rejection list will end up empty
-            case Success(true)                       => next()
-            case Success(false)                      => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
-            case Failure(t) if recover.isDefined     => recover.get(t)
-            case Failure(r: RejectRequest)           => terminate(r.code, r.message)
-            case Failure(t)                          => terminate(InternalServerError, t.getMessage)
+            case Success(true)                   => next
+            case Success(false)                  => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
+            case Failure(t) if recover.isDefined => recover.get(t)
+            case Failure(r: RejectRequest)       => terminate(r.code, r.message)
+            case Failure(t)                      => terminate(InternalServerError, t.getMessage)
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -31,7 +31,7 @@ import spray.routing.RequestContext
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.entitlement.Collection
-import whisk.core.entitlement.EntitlementService
+import whisk.core.entitlement.EntitlementProvider
 import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath
@@ -45,7 +45,7 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
     protected implicit val executionContext: ExecutionContext
 
     /** An entitlement service to check access rights. */
-    protected val entitlementService: EntitlementService
+    protected val entitlementProvider: EntitlementProvider
 
     /** The collection type for this trait. */
     protected val collection: Collection
@@ -66,44 +66,20 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         resource: Resource)(
             implicit transid: TransactionId): RequestContext => Unit = {
         val right = collection.determineRight(method, resource.entity)
-        authorizeAndContinue(right, user, resource, dispatchOp(user, right, resource))
+
+        onComplete(entitlementProvider.check(user, right, resource)) {
+            case Success(true) => dispatchOp(user, right, resource)
+            case t             => handleEntitlementFailure(t)
+        }
     }
 
-    /** Checks entitlement and if authorized, continues with next handler. */
-    protected def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resource: Resource,
-        next: RequestContext => Unit)(
-            implicit transid: TransactionId): RequestContext => Unit = {
-        authorizeAndContinue(right, user, Set(resource), next, None)
-    }
-
-    protected def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resources: Set[Resource],
-        next: RequestContext => Unit)(
-            recover: Throwable => RequestContext => Unit)(
-                implicit transid: TransactionId): RequestContext => Unit = {
-        authorizeAndContinue(right, user, resources, next, Some(recover))
-    }
-
-    private def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resources: Set[Resource],
-        next: RequestContext => Unit,
-        recover: Option[Throwable => RequestContext => Unit])(
-            implicit transid: TransactionId): RequestContext => Unit = {
-        onComplete(entitlementService.check(user, right, resources)) {
-            // do not use "authorize" directive here because it does not compose
-            // hence for nested authorizations the rejection list will end up empty
-            case Success(true)                   => next
-            case Success(false)                  => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
-            case Failure(t) if recover.isDefined => recover.get(t)
-            case Failure(r: RejectRequest)       => terminate(r.code, r.message)
-            case Failure(t)                      => terminate(InternalServerError, t.getMessage)
+    protected def handleEntitlementFailure(failure: Try[Boolean])(
+        implicit transid: TransactionId): RequestContext => Unit = {
+        failure match {
+            case Success(false)            => terminate(Forbidden)
+            case Failure(r: RejectRequest) => terminate(r.code, r.message)
+            case Failure(t)                => terminate(InternalServerError, t.getMessage)
+            case _ /*Success(true)*/       => terminate(InternalServerError, "Should not reach here.")
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -17,26 +17,27 @@
 package whisk.core.controller
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
-import spray.routing.RequestContext
-import spray.http.StatusCodes.InternalServerError
-import spray.routing.Directives
-import spray.routing.Directive1
-import spray.http.HttpMethod
-import whisk.common.TransactionId
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Subject
-import whisk.core.entitlement.EntitlementService
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege.Privilege
-import whisk.core.entitlement.Resource
-import whisk.core.entitlement.ThrottleRejectRequest
-import whisk.common.Logging
+import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
-import whisk.http.ErrorResponse.terminate
-import scala.language.postfixOps
+import scala.util.Try
+
+import spray.http.HttpMethod
+import spray.http.StatusCodes.Forbidden
+import spray.http.StatusCodes.InternalServerError
+import spray.routing.Directive1
+import spray.routing.Directives
+import spray.routing.RequestContext
+import whisk.common.Logging
+import whisk.common.TransactionId
+import whisk.core.entitlement.Collection
+import whisk.core.entitlement.EntitlementService
+import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entitlement.Resource
+import whisk.core.entity.EntityPath
 import whisk.core.entity.Identity
+import whisk.core.entity.Subject
+import whisk.http.ErrorResponse.terminate
 
 /** A trait for routes that require entitlement checks. */
 trait BasicAuthorizedRouteProvider extends Directives with Logging {
@@ -73,19 +74,17 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         right: Privilege,
         user: Identity,
         resource: Resource,
-        next: () => RequestContext => Unit)(
+        next: () => RequestContext => Unit,
+        recover: Option[Throwable => RequestContext => Unit] = None)(
             implicit transid: TransactionId): RequestContext => Unit = {
         onComplete(entitlementService.check(user, right, resource)) {
-            case Success(entitlement) =>
-                authorize(entitlement) {
-                    next()
-                }
-            case Failure(r: RejectRequest) =>
-                terminate(r.code, r.message)
-            case Failure(r: ThrottleRejectRequest) =>
-                terminate(r.code, r.message)
-            case Failure(t) =>
-                terminate(InternalServerError, t.getMessage)
+            // do not use "authorize" directive here because it does not compose
+            // hence for nested authorizations the rejection list will end up empty
+            case Success(true)                       => next()
+            case Success(false)                      => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
+            case Failure(t) if recover.isDefined     => recover.get(t)
+            case Failure(r: RejectRequest)           => terminate(r.code, r.message)
+            case Failure(t)                          => terminate(InternalServerError, t.getMessage)
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -22,9 +22,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.ActorSystem
 import akka.event.Logging.InfoLevel
 import whisk.core.WhiskConfig
-import whisk.core.entitlement.EntitlementService
-import whisk.core.entitlement.LocalEntitlementService
-import whisk.core.entitlement.RemoteEntitlementService
+import whisk.core.entitlement._
 import whisk.core.loadBalancer.{ LoadBalancer, LoadBalancerService }
 import scala.language.postfixOps
 import whisk.core.entity.ActivationId.ActivationIdGenerator
@@ -32,7 +30,7 @@ import whisk.core.iam.Identities
 
 object WhiskServices {
 
-    def requiredProperties = WhiskConfig.loadbalancerHost ++ WhiskConfig.consulServer ++ EntitlementService.requiredProperties
+    def requiredProperties = WhiskConfig.loadbalancerHost ++ WhiskConfig.consulServer ++ EntitlementProvider.requiredProperties
 
     def consulServer(config: WhiskConfig) = config.consulServer
 
@@ -44,7 +42,7 @@ object WhiskServices {
         // remote entitlement service requires a host:port definition. If not given,
         // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
         if (config.entitlementHost.startsWith(":")) {
-            new LocalEntitlementService(config, loadBalancer, iam)
+            new LocalEntitlementProvider(config, loadBalancer, iam)
         } else {
             new RemoteEntitlementService(config, loadBalancer, iam, timeout)
         }
@@ -75,7 +73,7 @@ trait WhiskServices {
     protected val whiskConfig: WhiskConfig
 
     /** An entitlement service to check access rights. */
-    protected val entitlementService: EntitlementService
+    protected val entitlementProvider: EntitlementProvider
 
     /** An identity provider. */
     protected val iam: Identities

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -29,7 +29,7 @@ import spray.routing.Route
 import akka.actor.ActorContext
 import akka.event.Logging.InfoLevel
 import akka.event.Logging.LogLevel
-import whisk.core.entitlement.EntitlementService
+import whisk.core.entitlement.EntitlementProvider
 
 /**
  * The Controller is the service that provides the REST API for OpenWhisk.
@@ -90,9 +90,9 @@ object Controller {
     def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
         RestAPIVersion_v1.requiredProperties ++
         LoadBalancerService.requiredProperties ++
-        EntitlementService.requiredProperties
+        EntitlementProvider.requiredProperties
 
-    def optionalProperties = EntitlementService.optionalProperties
+    def optionalProperties = EntitlementProvider.optionalProperties
 
     // akka-style factory to create a Controller object
     private class ServiceBuilder(config: WhiskConfig, instance: Int) extends Creator[Controller] {

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -21,37 +21,15 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.InternalServerError
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.OK
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
-import spray.json.JsBoolean
-import spray.json.JsObject
+import spray.json._
 import spray.routing.Directive.pimpApply
 import spray.routing.RequestContext
-import spray.routing.directives.OnCompleteFutureMagnet.apply
-import spray.routing.directives.ParamDefMagnet.apply
 import whisk.common.TransactionId
-import whisk.core.database.DocumentTypeMismatchException
 import whisk.core.database.NoDocumentException
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.Privilege
-import whisk.core.entitlement.Resource
-import whisk.core.entity.Binding
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Identity
-import whisk.core.entity.Parameters
-import whisk.core.entity.SemVer
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.WhiskPackage
-import whisk.core.entity.WhiskPackageAction
-import whisk.core.entity.WhiskPackagePut
+import whisk.core.entitlement._
+import whisk.core.entity._
 import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
@@ -93,9 +71,9 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
     override def create(user: Identity, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskPackagePut]) { content =>
-                val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+                val docid = FullyQualifiedEntityName(namespace, name).toDocId
 
-                def doput = {
+                def doput() = {
                     putEntity(WhiskPackage, entityStore, docid, overwrite,
                         update(content) _, () => create(content, namespace, name))
                 }
@@ -104,14 +82,13 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
                     case binding =>
                         info(this, "checking if package is accessible")
                         val referencedPackage = Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name()))
-                        authorizeAndContinue(Privilege.READ, user, Set(referencedPackage), doput) {
-                            case authorizationFailure: Throwable =>
-                                val r = rewriteFailure(authorizationFailure)
-                                terminate(r.code, r.message)
+                        onComplete(entitlementProvider.check(user, Privilege.READ, Set(referencedPackage))) {
+                            case Success(true) => doput()
+                            case failure       => handleEntitlementFailure(failure)
                         }
                 } getOrElse {
                     info(this, "no binding specified")
-                    doput
+                    doput()
                 }
             }
         }
@@ -138,7 +115,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def remove(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         deleteEntity(WhiskPackage, entityStore, docid, (wp: WhiskPackage) => {
             wp.binding map {
                 // this is a binding, it is safe to remove
@@ -166,7 +143,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def fetch(namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         getEntity(WhiskPackage, entityStore, docid, Some { mergePackageWithBinding() _ })
     }
 
@@ -298,14 +275,12 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
         }
     }
 
-    private def rewriteFailure(failure: Throwable)(implicit transid: TransactionId) = {
+    override protected def handleEntitlementFailure(failure: Try[Boolean])(
+        implicit transid: TransactionId): RequestContext => Unit = {
         info(this, s"rewriting failure $failure")
         failure match {
-            case RejectRequest(NotFound, _)       => RejectRequest(NotFound, Messages.bindingDoesNotExist)
-            case RejectRequest(c, m)              => RejectRequest(c, m)
-            case _: NoDocumentException           => RejectRequest(BadRequest, Messages.bindingDoesNotExist)
-            case _: DocumentTypeMismatchException => RejectRequest(BadRequest, Messages.requestedBindingIsNotValid)
-            case _                                => RejectRequest(BadRequest, failure)
+            case Failure(RejectRequest(NotFound, _)) => terminate(NotFound, Messages.bindingDoesNotExist)
+            case _                                   => super.handleEntitlementFailure(failure)
         }
     }
 
@@ -330,7 +305,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
     private def mergePackageWithBinding(ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(implicit transid: TransactionId): RequestContext => Unit = {
         wp.binding map {
             case Binding(ns, n) =>
-                val docid = DocId(WhiskEntity.qualifiedName(ns, n))
+                val docid = FullyQualifiedEntityName(ns, n).toDocId
                 info(this, s"fetching package '$docid' for reference")
                 getEntity(WhiskPackage, entityStore, docid, Some {
                     mergePackageWithBinding(Some { wp }) _

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -17,13 +17,14 @@
 package whisk.core.controller
 
 import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import spray.http.StatusCodes.BadRequest
 import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.InternalServerError
+import spray.http.StatusCodes.NotFound
 import spray.http.StatusCodes.OK
 import spray.httpx.SprayJsonSupport._
 import spray.json.JsBoolean
@@ -35,13 +36,15 @@ import spray.routing.directives.ParamDefMagnet.apply
 import whisk.common.TransactionId
 import whisk.core.database.NoDocumentException
 import whisk.core.entitlement.Collection
+import whisk.core.entitlement.Privilege
+import whisk.core.entitlement.Resource
 import whisk.core.entity.Binding
 import whisk.core.entity.DocId
 import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
+import whisk.core.entity.Identity
 import whisk.core.entity.Parameters
 import whisk.core.entity.SemVer
-import whisk.core.entity.types.EntityStore
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
@@ -50,7 +53,10 @@ import whisk.core.entity.WhiskPackageAction
 import whisk.core.entity.WhiskPackagePut
 import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
-import whisk.core.entity.Identity
+import spray.http.StatusCode
+import whisk.http.ErrorResponse
+import whisk.http.Messages
+import whisk.core.database.DocumentTypeMismatchException
 
 object WhiskPackagesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
@@ -90,8 +96,26 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskPackagePut]) { content =>
                 val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-                putEntity(WhiskPackage, entityStore, docid, overwrite,
-                    update(content) _, () => create(content, namespace, name))
+
+                def doput() = {
+                    putEntity(WhiskPackage, entityStore, docid, overwrite,
+                        update(content) _, () => create(content, namespace, name))
+                }
+
+                def abort(t: Throwable) = {
+                    val r = rewriteFailure(t)
+                    terminate(r.code, r.message)
+                }
+
+                content.binding.map(_.resolve(namespace)) map {
+                    case binding =>
+                        info(this, "checking if package is accessible")
+                        val referencedPackage = Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name()))
+                        authorizeAndContinue(Privilege.READ, user, referencedPackage, next = doput, recover = Some(abort))
+                } getOrElse {
+                    info(this, "no binding specified")
+                    doput()
+                }
             }
         }
     }
@@ -121,7 +145,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
         deleteEntity(WhiskPackage, entityStore, docid, (wp: WhiskPackage) => {
             wp.binding map {
                 // this is a binding, it is safe to remove
-                _ => Future successful true
+                _ => Future.successful(true)
             } getOrElse {
                 // may only delete a package if all its ingredients are deleted already
                 WhiskAction.listCollectionInNamespace(entityStore, wp.namespace.addpath(wp.name), skip = 0, limit = 0) flatMap {
@@ -129,7 +153,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
                         Future failed {
                             RejectRequest(Conflict, s"Package not empty (contains ${list.size} ${if (list.size == 1) "entity" else "entities"})")
                         }
-                    case _ => Future successful true
+                    case _ => Future.successful(true)
                 }
             }
         })
@@ -201,91 +225,90 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
      * If this is a binding, confirm the referenced package exists.
      */
     private def create(content: WhiskPackagePut, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
-        content.binding match {
-            case Some(binding) =>
-                val promise = Promise[WhiskPackage]
-                val resolvedBinding = Some(binding.resolve(namespace))
-                WhiskPackage.get(entityStore, resolvedBinding.get.docid) onComplete {
-                    case Success(doc) =>
-                        if (doc.binding.isEmpty) promise success {
-                            WhiskPackage(
-                                namespace,
-                                name,
-                                resolvedBinding,
-                                content.parameters getOrElse Parameters(),
-                                content.version getOrElse SemVer(),
-                                content.publish getOrElse false,
-                                // override any binding annotation from PUT (always set by the controller)
-                                (content.annotations getOrElse Parameters()) ++ bindingAnnotation(resolvedBinding))
-                        }
-                        else promise failure {
-                            RejectRequest(BadRequest, "cannot bind to another package binding")
-                        }
-                    case Failure(t: NoDocumentException) =>
-                        promise failure {
-                            RejectRequest(BadRequest, "binding references a package that does not exist")
-                        }
-                    case Failure(t) => promise failure RejectRequest(BadRequest, t)
-                }
-                promise.future
-            case None =>
-                Future successful {
+        content.binding map { binding =>
+            val resolvedBinding = Some(binding.resolve(namespace))
+            WhiskPackage.get(entityStore, resolvedBinding.get.docid) recoverWith {
+                case t: NoDocumentException => Future.failed(RejectRequest(BadRequest, Messages.bindingDoesNotExist))
+                case t                      => Future.failed(RejectRequest(BadRequest, t))
+            } map { provider =>
+                if (provider.binding.isEmpty) {
                     WhiskPackage(
                         namespace,
                         name,
-                        binding = None,
+                        resolvedBinding,
                         content.parameters getOrElse Parameters(),
                         content.version getOrElse SemVer(),
                         content.publish getOrElse false,
-                        // remove any binding annotation from PUT (always set by the controller)
-                        (content.annotations map { _ -- WhiskPackage.bindingFieldName }) getOrElse Parameters())
+                        // override any binding annotation from PUT (always set by the controller)
+                        (content.annotations getOrElse Parameters()) ++ bindingAnnotation(resolvedBinding))
+                } else {
+                    throw RejectRequest(BadRequest, Messages.bindingCannotReferenceBinding)
                 }
+            }
+        } getOrElse {
+            Future.successful {
+                WhiskPackage(
+                    namespace,
+                    name,
+                    binding = None,
+                    content.parameters getOrElse Parameters(),
+                    content.version getOrElse SemVer(),
+                    content.publish getOrElse false,
+                    // remove any binding annotation from PUT (always set by the controller)
+                    (content.annotations map { _ -- WhiskPackage.bindingFieldName }) getOrElse Parameters())
+            }
         }
     }
 
     /** Updates a WhiskPackage from PUT content, merging old package/binding where necessary. */
     private def update(content: WhiskPackagePut)(wp: WhiskPackage)(implicit transid: TransactionId) = {
-        content.binding match {
-            case Some(binding) =>
-                if (wp.binding == None) Future failed {
-                    RejectRequest(Conflict, "resource is a package but content specifies a binding")
-                }
-                else {
-                    val promise = Promise[WhiskPackage]
-                    val resolvedBinding = Some(binding.resolve(wp.namespace))
-                    WhiskPackage.get(entityStore, binding.docid) onComplete {
-                        case Success(_) =>
-                            promise success {
-                                WhiskPackage(
-                                    wp.namespace,
-                                    wp.name,
-                                    resolvedBinding,
-                                    content.parameters getOrElse wp.parameters,
-                                    content.version getOrElse wp.version.upPatch,
-                                    content.publish getOrElse wp.publish,
-                                    // override any binding annotation from PUT (always set by the controller)
-                                    (content.annotations getOrElse wp.annotations) ++ bindingAnnotation(resolvedBinding)).
-                                    revision[WhiskPackage](wp.docinfo.rev)
-                            }
-                        case Failure(t) => promise.failure { RejectRequest(BadRequest, t) }
-                    }
-                    promise.future
-                }
-            case None =>
-                Future successful {
+        content.binding map { binding =>
+            if (wp.binding.isDefined) {
+                val resolvedBinding = Some(binding.resolve(wp.namespace))
+                WhiskPackage.get(entityStore, resolvedBinding.get.docid) recoverWith {
+                    case t: NoDocumentException => Future.failed(RejectRequest(BadRequest, Messages.bindingDoesNotExist))
+                    case t                      => Future.failed(RejectRequest(BadRequest, t))
+                } map { _ =>
                     WhiskPackage(
                         wp.namespace,
                         wp.name,
-                        wp.binding,
+                        resolvedBinding,
                         content.parameters getOrElse wp.parameters,
                         content.version getOrElse wp.version.upPatch,
                         content.publish getOrElse wp.publish,
                         // override any binding annotation from PUT (always set by the controller)
-                        (content.annotations map {
-                            _ -- WhiskPackage.bindingFieldName
-                        } getOrElse wp.annotations) ++ bindingAnnotation(wp.binding)).
+                        (content.annotations getOrElse wp.annotations) ++ bindingAnnotation(resolvedBinding)).
                         revision[WhiskPackage](wp.docinfo.rev)
                 }
+            } else {
+                Future.failed(RejectRequest(Conflict, Messages.packageCannotBecomeBinding))
+            }
+        } getOrElse {
+            Future.successful {
+                WhiskPackage(
+                    wp.namespace,
+                    wp.name,
+                    wp.binding,
+                    content.parameters getOrElse wp.parameters,
+                    content.version getOrElse wp.version.upPatch,
+                    content.publish getOrElse wp.publish,
+                    // override any binding annotation from PUT (always set by the controller)
+                    (content.annotations map {
+                        _ -- WhiskPackage.bindingFieldName
+                    } getOrElse wp.annotations) ++ bindingAnnotation(wp.binding)).
+                    revision[WhiskPackage](wp.docinfo.rev)
+            }
+        }
+    }
+
+    private def rewriteFailure(failure: Throwable)(implicit transid: TransactionId) = {
+        info(this, s"rewriting failure $failure")
+        failure match {
+            case RejectRequest(NotFound, _)       => RejectRequest(NotFound, Messages.bindingDoesNotExist)
+            case RejectRequest(c, m)              => RejectRequest(c, m)
+            case _: NoDocumentException           => RejectRequest(BadRequest, Messages.bindingDoesNotExist)
+            case _: DocumentTypeMismatchException => RejectRequest(BadRequest, Messages.requestedBindingIsNotValid)
+            case _                                => RejectRequest(BadRequest, failure)
         }
     }
 
@@ -319,10 +342,10 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
             val pkg = ref map { _ inherit wp.parameters } getOrElse wp
             info(this, s"fetching package actions in '${wp.path}'")
             val actions = WhiskAction.listCollectionInNamespace(entityStore, wp.path, skip = 0, limit = 0) flatMap {
-                case Left(list) => Future successful {
+                case Left(list) => Future.successful {
                     pkg withPackageActions (list map { o => WhiskPackageAction.serdes.read(o) })
                 }
-                case t => Future failed {
+                case t => Future.failed {
                     error(this, "unexpected result in package action lookup: $t")
                     new IllegalStateException(s"unexpected result in package action lookup: $t")
                 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -21,13 +21,10 @@ import scala.concurrent.ExecutionContext
 import spray.http.AllOrigins
 import spray.http.HttpHeaders.`Access-Control-Allow-Origin`
 import spray.http.HttpHeaders.`Access-Control-Allow-Headers`
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.PermanentRedirect
-import spray.http.StatusCodes.{ OK, PermanentRedirect }
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
-import spray.json.JsObject
-import spray.json.pimpAny
+import spray.json._
 import spray.routing.Directive.pimpApply
 import spray.routing.Directives
 import spray.routing.Route
@@ -35,8 +32,8 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.whiskVersionDate
 import whisk.core.WhiskConfig.whiskVersionBuildno
-import whisk.core.entitlement.{ Collection, EntitlementService }
-import whisk.core.entity.{ WhiskActivationStore, WhiskAuthStore, WhiskEntityStore }
+import whisk.core.entitlement._
+import whisk.core.entity._
 import whisk.core.entity.types.{ ActivationStore, EntityStore }
 import whisk.core.loadBalancer.LoadBalancerService
 import akka.event.Logging.LogLevel
@@ -188,7 +185,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
             override val iam: Identities,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val executionContext: ExecutionContext)
         extends WhiskNamespacesApi {
         setVerbosity(verbosity)
@@ -202,7 +199,7 @@ protected[controller] class RestAPIVersion_v1(
             override val entityStore: EntityStore,
             override val activationStore: ActivationStore,
             override val iam: Identities,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,
@@ -221,7 +218,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             implicit override val entityStore: EntityStore,
             override val iam: Identities,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationStore: ActivationStore,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
@@ -239,7 +236,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
             override val iam: Identities,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,
@@ -254,7 +251,7 @@ protected[controller] class RestAPIVersion_v1(
         val apiversion: String,
         val verbosity: LogLevel)(
             implicit override val activationStore: ActivationStore,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val executionContext: ExecutionContext)
         extends WhiskActivationsApi {
         setVerbosity(verbosity)
@@ -266,7 +263,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
             override val iam: Identities,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationId: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -45,7 +45,7 @@ object WhiskRulesApi {
 }
 
 /** A trait implementing the rules API */
-trait WhiskRulesApi extends WhiskCollectionAPI {
+trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
     services: WhiskServices =>
 
     protected override val collection = Collection(Collection.RULES)
@@ -98,16 +98,6 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                 }
             }
         }
-    }
-
-    private def referencedEntities(content: WhiskRulePut) = {
-        val triggerResource = content.trigger.map {
-            t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name()))
-        }
-        val actionResource = content.action map {
-            a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name()))
-        }
-        Set(triggerResource, actionResource).flatten
     }
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -21,37 +21,17 @@ import scala.util.Failure
 import scala.util.Success
 
 import akka.actor.ActorSystem
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.InternalServerError
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.NotFound
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DeserializationException
 import spray.routing.Directive.pimpApply
 import spray.routing.RequestContext
-import spray.routing.directives.OnCompleteFutureMagnet.apply
-import spray.routing.directives.ParamDefMagnet.apply
 import whisk.common.TransactionId
 import whisk.core.database.DocumentConflictException
 import whisk.core.database.NoDocumentException
-import whisk.core.entitlement.Collection
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.ReducedRule
-import whisk.core.entity.SemVer
-import whisk.core.entity.Status
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.WhiskRulePut
-import whisk.core.entity.WhiskTrigger
+import whisk.core.entitlement._
+import whisk.core.entity._
 import whisk.core.entity.types.EntityStore
-import whisk.core.entity.Identity
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages._
 
@@ -105,13 +85,29 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
     override def create(user: Identity, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskRulePut]) { content =>
-                val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-                putEntity(WhiskRule, entityStore, docid, overwrite, update(content) _, () => { create(content, namespace, name) },
-                    postProcess = Some { rule: WhiskRule =>
-                        completeAsRuleResponse(rule, Status.ACTIVE)
-                    })
+                val request = content.resolve(namespace.root)
+                onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
+                    case Success(true) =>
+                        val docid = FullyQualifiedEntityName(namespace, name).toDocId
+                        putEntity(WhiskRule, entityStore, docid, overwrite,
+                            update(request) _, () => { create(request, namespace, name) },
+                            postProcess = Some { rule: WhiskRule =>
+                                completeAsRuleResponse(rule, Status.ACTIVE)
+                            })
+                    case failure => handleEntitlementFailure(failure)
+                }
             }
         }
+    }
+
+    private def referencedEntities(content: WhiskRulePut) = {
+        val triggerResource = content.trigger.map {
+            t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name()))
+        }
+        val actionResource = content.action map {
+            a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name()))
+        }
+        Set(triggerResource, actionResource).flatten
     }
 
     /**
@@ -128,14 +124,13 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      */
     override def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
         extractStatusRequest { requestedState =>
-            val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+            val docid = FullyQualifiedEntityName(namespace, name).toDocId
 
             getEntity(WhiskRule, entityStore, docid, Some {
                 rule: WhiskRule =>
-                    val tid = DocId(WhiskEntity.qualifiedName(namespace, rule.trigger))
-                    val ruleName = EntityPath(WhiskEntity.qualifiedName(rule.namespace, rule.name))
+                    val ruleName = rule.fullyQualifiedName(false)
 
-                    val changeStatus = getTrigger(tid) map { trigger =>
+                    val changeStatus = getTrigger(rule.trigger) map { trigger =>
                         getStatus(trigger, ruleName)
                     } flatMap { oldStatus =>
                         if (requestedState != oldStatus) {
@@ -148,12 +143,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                     } flatMap {
                         case (newStatus) =>
                             info(this, s"[POST] attempting to set rule state to: ${newStatus}")
-
-                            val actionName = EntityPath(WhiskEntity.qualifiedName(namespace, rule.action))
-
-                            WhiskTrigger.get(entityStore, tid) flatMap { trigger =>
+                            WhiskTrigger.get(entityStore, rule.trigger.toDocId) flatMap { trigger =>
                                 val newTrigger = trigger.removeRule(ruleName)
-                                val triggerLink = ReducedRule(actionName, newStatus)
+                                val triggerLink = ReducedRule(rule.action, newStatus)
                                 WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
                             }
                     }
@@ -171,6 +163,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                             case _: NoDocumentException =>
                                 info(this, s"[POST] the trigger attached to the rule doesn't exist")
                                 terminate(NotFound, "Only rules with existing triggers can be activated")
+                            case _: DeserializationException =>
+                                error(this, s"[POST] rule update failed: ${t.getMessage}")
+                                terminate(InternalServerError, corruptedEntity)
                             case _: Throwable =>
                                 error(this, s"[POST] rule update failed: ${t.getMessage}")
                                 terminate(InternalServerError, t.getMessage)
@@ -190,11 +185,10 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def remove(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         deleteEntity(WhiskRule, entityStore, docid, (r: WhiskRule) => {
-            val tid = DocId(WhiskEntity.qualifiedName(namespace, r.trigger))
-            val ruleName = EntityPath(WhiskEntity.qualifiedName(r.namespace, r.name))
-            getTrigger(tid) map { trigger =>
+            val ruleName = FullyQualifiedEntityName(r.namespace, r.name)
+            getTrigger(r.trigger) map { trigger =>
                 (getStatus(trigger, ruleName), trigger)
             } flatMap {
                 case (status, triggerOpt) =>
@@ -220,14 +214,10 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def fetch(namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-        getEntity(WhiskRule, entityStore, docid, Some { rule: WhiskRule =>
-            val ruleName = WhiskEntity.qualifiedName(namespace, name)
-            val triggerName = WhiskEntity.qualifiedName(namespace, rule.trigger)
-            val tid = DocId(triggerName)
-
-            val getRuleWithStatus = getTrigger(tid) map { trigger =>
-                getStatus(trigger, EntityPath(ruleName))
+        val ruleName = FullyQualifiedEntityName(namespace, name)
+        getEntity(WhiskRule, entityStore, ruleName.toDocId, Some { rule: WhiskRule =>
+            val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
+                getStatus(trigger, ruleName)
             } map { status =>
                 rule.withStatus(status)
             }
@@ -269,14 +259,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
     /** Creates a WhiskRule from PUT content, generating default values where necessary. */
     private def create(content: WhiskRulePut, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId): Future[WhiskRule] = {
         if (content.trigger.isDefined && content.action.isDefined) {
-            val ruleName = WhiskEntity.qualifiedName(namespace, name)
-            val triggerName = WhiskEntity.qualifiedName(namespace, content.trigger.get)
-            val actionName = WhiskEntity.qualifiedName(namespace, content.action.get)
+            val ruleName = FullyQualifiedEntityName(namespace, name)
+            val triggerName = content.trigger.get
+            val actionName = content.action.get
 
-            val tid = DocId(triggerName)
-            val aid = DocId(actionName)
-
-            checkTriggerAndActionExist(tid, aid) recoverWith {
+            checkTriggerAndActionExist(triggerName, actionName) recoverWith {
                 case t => Future.failed(RejectRequest(BadRequest, t))
             } flatMap {
                 case (trigger, action) =>
@@ -289,32 +276,30 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                         content.publish getOrElse false,
                         content.annotations getOrElse Parameters())
 
-                    val triggerLink = ReducedRule(EntityPath(actionName), Status.ACTIVE)
-                    WhiskTrigger.put(entityStore, trigger.addRule(EntityPath(ruleName), triggerLink)).map(_ => rule)
+                    val triggerLink = ReducedRule(actionName, Status.ACTIVE)
+                    info(this, s"about to put ${trigger.addRule(ruleName, triggerLink)}")
+                    WhiskTrigger.put(entityStore, trigger.addRule(ruleName, triggerLink)) map { _ => rule }
             }
         } else Future.failed(RejectRequest(BadRequest, "rule requires a valid trigger and a valid action"))
     }
 
     /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
     private def update(content: WhiskRulePut)(rule: WhiskRule)(implicit transid: TransactionId): Future[WhiskRule] = {
-        val ruleName = WhiskEntity.qualifiedName(rule.namespace, rule.name)
-        val oldTriggerName = WhiskEntity.qualifiedName(rule.namespace, rule.trigger)
-        val oldTid = DocId(oldTriggerName)
+        val ruleName = FullyQualifiedEntityName(rule.namespace, rule.name)
+        val oldTriggerName = rule.trigger
 
-        getTrigger(oldTid) map {
-            trigger => (getStatus(trigger, EntityPath(ruleName)), trigger)
+        getTrigger(oldTriggerName) map {
+            trigger => (getStatus(trigger, ruleName), trigger)
         } flatMap {
             case (status, oldTriggerOpt) => status match {
                 case Status.INACTIVE =>
                     val newTriggerEntity = content.trigger getOrElse rule.trigger
-                    val newTriggerName = WhiskEntity.qualifiedName(rule.namespace, newTriggerEntity)
-                    val tid = DocId(newTriggerName)
+                    val newTriggerName = newTriggerEntity
 
                     val actionEntity = content.action getOrElse rule.action
-                    val actionName = WhiskEntity.qualifiedName(rule.namespace, actionEntity)
-                    val aid = DocId(actionName)
+                    val actionName = actionEntity
 
-                    checkTriggerAndActionExist(tid, aid) recoverWith {
+                    checkTriggerAndActionExist(newTriggerName, actionName) recoverWith {
                         case t => Future.failed(RejectRequest(BadRequest, t))
                     } flatMap {
                         case (newTrigger, newAction) =>
@@ -333,12 +318,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                                 isDifferentTrigger <- content.trigger.filter(_ => newTriggerName != oldTriggerName)
                                 oldTrigger <- oldTriggerOpt
                             } yield {
-                                WhiskTrigger.put(entityStore, oldTrigger.removeRule(EntityPath(ruleName)))
+                                WhiskTrigger.put(entityStore, oldTrigger.removeRule(ruleName))
                             }
 
-                            val triggerLink = ReducedRule(EntityPath(actionName), Status.INACTIVE)
-                            val update = WhiskTrigger.put(entityStore, newTrigger.addRule(EntityPath(ruleName), triggerLink))
-
+                            val triggerLink = ReducedRule(actionName, Status.INACTIVE)
+                            val update = WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
                             Future.sequence(Seq(deleteOldLink.getOrElse(Future.successful(true)), update)).map(_ => r)
                     }
                 case _ => Future.failed(RejectRequest(Conflict, s"rule may not be updated while status is ${status}"))
@@ -352,11 +336,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param tid DocInfo defining the trigger to get
      * @return a WhiskTrigger iff found, else None
      */
-    private def getTrigger(tid: DocId)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
-        WhiskTrigger.get(entityStore, tid) map {
+    private def getTrigger(t: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
+        WhiskTrigger.get(entityStore, t.toDocId) map {
             trigger => Some(trigger)
         } recover {
-            case _: NoDocumentException => None
+            case _: NoDocumentException | DeserializationException(_, _, _) => None
         }
     }
 
@@ -368,7 +352,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param ruleName Namespace the name of the rule being worked on
      * @return Status of the rule
      */
-    private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: EntityPath)(implicit transid: TransactionId): Status = {
+    private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: FullyQualifiedEntityName)(implicit transid: TransactionId): Status = {
         val statusFromTrigger = for {
             trigger <- triggerOpt
             rules <- trigger.rules
@@ -396,13 +380,26 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param action the action id
      * @return future that completes with references trigger and action if they exist
      */
-    private def checkTriggerAndActionExist(trigger: DocId, action: DocId)(implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
+    private def checkTriggerAndActionExist(trigger: FullyQualifiedEntityName, action: FullyQualifiedEntityName)(
+        implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
+
         for {
-            triggerExists <- WhiskTrigger.get(entityStore, trigger) recoverWith {
-                case _: NoDocumentException => Future.failed(new NoDocumentException(s"trigger $trigger does not exist"))
+            triggerExists <- WhiskTrigger.get(entityStore, trigger.toDocId) recoverWith {
+                case _: NoDocumentException => Future.failed {
+                    new NoDocumentException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} does not exist")
+                }
+                case _: DeserializationException => Future.failed {
+                    new DeserializationException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} is corrupted")
+                }
             }
-            actionExists <- WhiskAction.get(entityStore, action) recoverWith {
-                case _: NoDocumentException => Future.failed(new NoDocumentException(s"action $action does not exist"))
+
+            actionExists <- WhiskAction.get(entityStore, action.toDocId) recoverWith {
+                case _: NoDocumentException => Future.failed {
+                    new NoDocumentException(s"action ${action.qualifiedNameWithLeadingSlash} does not exist")
+                }
+                case _: DeserializationException => Future.failed {
+                    new DeserializationException(s"action ${action.qualifiedNameWithLeadingSlash} is corrupted")
+                }
             }
         } yield (triggerExists, actionExists)
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -46,7 +46,6 @@ import spray.routing.RequestContext
 import whisk.common.TransactionId
 import whisk.core.entitlement.Collection
 import whisk.core.entity.ActivationResponse
-import whisk.core.entity.DocId
 import whisk.core.entity.EntityName
 import whisk.core.entity.EntityPath
 import whisk.core.entity.Parameters
@@ -54,7 +53,6 @@ import whisk.core.entity.SemVer
 import whisk.core.entity.Status
 import whisk.core.entity.TriggerLimits
 import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.WhiskTriggerPut
@@ -64,6 +62,7 @@ import whisk.http.ErrorResponse.terminate
 import spray.httpx.UnsuccessfulResponseException
 import spray.http.StatusCodes
 import whisk.core.entity.Identity
+import whisk.core.entity.FullyQualifiedEntityName
 
 /**
  * A singleton object which defines the properties that must be present in a configuration
@@ -108,7 +107,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
     override def create(user: Identity, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskTriggerPut]) { content =>
-                val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+                val docid = FullyQualifiedEntityName(namespace, name).toDocId
                 putEntity(WhiskTrigger, entityStore, docid, overwrite, update(content) _, () => { create(content, namespace, name) }, postProcess = Some { trigger =>
                     completeAsTriggerResponse(trigger)
                 })
@@ -129,7 +128,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
 
         entity(as[Option[JsObject]]) {
             payload =>
-                val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+                val docid = FullyQualifiedEntityName(namespace, name).toDocId
                 getEntity(WhiskTrigger, entityStore, docid, Some {
                     trigger: WhiskTrigger =>
                         val args = trigger.parameters.merge(payload)
@@ -163,7 +162,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                                 case (ruleName, rule) =>
                                     val ruleActivation = WhiskActivation(
                                         namespace = user.namespace.toPath, // all activations should end up in the one space regardless trigger.namespace,
-                                        ruleName.last,
+                                        ruleName.name,
                                         user.subject,
                                         activationId.make(),
                                         Instant.now(Clock.systemUTC()),
@@ -174,8 +173,18 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                                     info(this, s"[POST] rule ${ruleName} activated, writing activation record to datastore")
                                     WhiskActivation.put(activationStore, ruleActivation)
 
-                                    val actionPath = Path("/api/v1") / "namespaces" / rule.action.root.toString / "actions" / rule.action.last.toString
-                                    pipeline(Post(url.withPath(actionPath), args)) onComplete {
+                                    val actionNamespace = rule.action.path.root()
+                                    val actionPath = {
+                                        rule.action.path.relpath.map {
+                                            pkg => (Path.SingleSlash + pkg.namespace) / rule.action.name()
+                                        } getOrElse {
+                                            Path.SingleSlash + rule.action.name()
+                                        }
+                                    }.toString
+
+                                    val actionUrl = Path("/api/v1") / "namespaces" / actionNamespace / "actions"
+
+                                    pipeline(Post(url.withPath(actionUrl + actionPath), args)) onComplete {
                                         case Success(o) =>
                                             info(this, s"successfully invoked ${rule.action} -> ${o.fields("activationId")}")
                                         case Failure(usr: UnsuccessfulResponseException) if usr.response.status == StatusCodes.NotFound =>
@@ -207,7 +216,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def remove(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         deleteEntity(WhiskTrigger, entityStore, docid, (t: WhiskTrigger) => Future successful true, postProcess = Some { trigger =>
             completeAsTriggerResponse(trigger)
         })
@@ -222,7 +231,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def fetch(namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         getEntity(WhiskTrigger, entityStore, docid, Some { trigger =>
             completeAsTriggerResponse(trigger)
         })

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entitlement
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import Privilege.Privilege
+import whisk.common.TransactionId
+import whisk.core.entity.Identity
+import whisk.core.entity.types.EntityStore
+
+class ActionCollection(entityStore: EntityStore) extends Collection(Collection.ACTIONS) {
+
+    protected override val allowedEntityRights = Privilege.ALL
+
+    /**
+     * Computes implicit rights on an action (sequence, in package, or primitive).
+     */
+    protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
+        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId) = {
+        val isOwner = namespaces.contains(resource.namespace.root())
+        resource.entity map {
+            name =>
+                right match {
+                    // if action is in a package, check that the user is entitled to package [binding]
+                    case (Privilege.READ | Privilege.ACTIVATE) if !resource.namespace.defaultPackage =>
+                        val packageNamespace = resource.namespace.root
+                        val packageName = Some(resource.namespace.last.name)
+                        val packageResource = Resource(packageNamespace, Collection(Collection.PACKAGES), packageName)
+                        es.check(user, right, packageResource)
+                    case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
+                }
+        } getOrElse {
+            // only a READ on the action collection is permitted if this is the owner of the collection
+            Future.successful(isOwner && right == Privilege.READ)
+        }
+    }
+
+}

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -28,6 +28,7 @@ import spray.http.HttpMethods.POST
 import spray.http.HttpMethods.PUT
 import whisk.common.Logging
 import whisk.common.TransactionId
+import whisk.core.entity.Identity
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskActivation
 import whisk.core.entity.WhiskEntityStore
@@ -79,8 +80,8 @@ protected[core] case class Collection protected (
      * to any resource in in any of their namespaces as long as the right (the implied operation)
      * is permitted on the resource.
      */
-    protected[core] def implicitRights(namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
+    protected[core] def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
+        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
         // if the resource root namespace is in any of the allowed namespaces
         // then this is an owner of the resource
         val self = namespaces.contains(resource.namespace.root())
@@ -111,7 +112,7 @@ protected[core] object Collection {
     protected[core] def apply(name: String) = collections.get(name).get
 
     protected[core] def initialize(entityStore: EntityStore, verbosity: LogLevel) = {
-        register(new Collection(ACTIONS))
+        register(new ActionCollection(entityStore))
         register(new Collection(TRIGGERS))
         register(new Collection(RULES))
         register(new PackageCollection(entityStore))

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -81,7 +81,7 @@ protected[core] case class Collection protected (
      * is permitted on the resource.
      */
     protected[core] def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
+        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
         // if the resource root namespace is in any of the allowed namespaces
         // then this is an owner of the resource
         val self = namespaces.contains(resource.namespace.root())

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -279,6 +279,10 @@ trait ReferencedEntities {
         reference match {
             case WhiskPackagePut(Some(binding), _, _, _, _) =>
                 Set(Resource(binding.path, Collection(Collection.PACKAGES), Some(binding.name())))
+            case r: WhiskRulePut =>
+                val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name())) }
+                val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name())) }
+                Set(triggerResource, actionResource).flatten
             case _ => Set()
         }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -64,7 +64,7 @@ protected[core] case class Resource(
     override def toString = id
 }
 
-protected[core] object EntitlementService {
+protected[core] object EntitlementProvider {
     val requiredProperties = WhiskConfig.consulServer ++ WhiskConfig.entitlementHost ++ Map(
         WhiskConfig.actionInvokePerMinuteDefaultLimit -> null,
         WhiskConfig.actionInvokeConcurrentDefaultLimit -> null,
@@ -82,7 +82,7 @@ protected[core] object EntitlementService {
  * A trait that implements entitlements to resources. It performs checks for CRUD and Acivation requests.
  * This is where enforcement of activation quotas takes place, in additional to basic authorization.
  */
-protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalancer: LoadBalancer, iam: Identities)(
+protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBalancer: LoadBalancer, iam: Identities)(
     implicit actorSystem: ActorSystem) extends Logging {
 
     private implicit val executionContext = actorSystem.dispatcher

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -33,10 +33,7 @@ import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.controller.RejectRequest
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Identity
-import whisk.core.entity.Parameters
-import whisk.core.entity.Subject
+import whisk.core.entity._
 import whisk.core.iam.Identities
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.http.Messages._
@@ -164,12 +161,14 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
         val subject = user.subject
 
         val entitlementCheck = if (user.rights.contains(right)) {
-            info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
-            checkSystemOverload(subject, right) orElse {
-                checkUserThrottle(subject, right, resources)
-            } orElse {
-                checkConcurrentUserThrottle(subject, right, resources)
-            } getOrElse checkPrivilege(user, right, resources)
+            if (resources.nonEmpty) {
+                info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
+                checkSystemOverload(subject, right) orElse {
+                    checkUserThrottle(subject, right, resources)
+                } orElse {
+                    checkConcurrentUserThrottle(subject, right, resources)
+                } getOrElse checkPrivilege(user, right, resources)
+            } else Future.successful(true)
         } else if (right != REJECT) {
             info(this, s"supplied authkey for user '$subject' does not have privilege '$right' for '${resources.mkString(",")}'")
             Future.failed(RejectRequest(Forbidden))
@@ -178,7 +177,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
         }
 
         entitlementCheck andThen {
-            case Success(r) =>
+            case Success(r) if resources.nonEmpty =>
                 info(this, if (r) "authorized" else "not authorized")
             case Failure(r: RejectRequest) =>
                 info(this, s"not authorized: $r")
@@ -271,5 +270,16 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
         if (right == ACTIVATE && userThrottled) {
             Some(Future.failed(RejectRequest(TooManyRequests, tooManyConcurrentRequests)))
         } else None
+    }
+}
+
+trait ReferencedEntities {
+
+    def referencedEntities(reference: Any): Set[Resource] = {
+        reference match {
+            case WhiskPackagePut(Some(binding), _, _, _, _) =>
+                Set(Resource(binding.path, Collection(Collection.PACKAGES), Some(binding.name())))
+            case _ => Set()
+        }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -27,21 +27,21 @@ import whisk.core.entity.Subject
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.core.iam.Identities
 
-private object LocalEntitlementService {
+private object LocalEntitlementProvider {
     /** Poor mans entitlement matrix. Must persist to datastore eventually. */
     private val matrix = TrieMap[(Subject, String), Set[Privilege]]()
 }
 
-protected[core] class LocalEntitlementService(
+protected[core] class LocalEntitlementProvider(
     private val config: WhiskConfig,
     private val loadBalancer: LoadBalancer,
     private val iam: Identities)(
         implicit actorSystem: ActorSystem)
-    extends EntitlementService(config, loadBalancer, iam) {
+    extends EntitlementProvider(config, loadBalancer, iam) {
 
     private implicit val executionContext = actorSystem.dispatcher
 
-    private val matrix = LocalEntitlementService.matrix
+    private val matrix = LocalEntitlementProvider.matrix
 
     /** Grants subject right to resource by adding them to the entitlement matrix. */
     protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future {

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -90,8 +90,8 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
             case wp =>
                 if (isOwner) {
                     val binding = wp.binding.get
-                    val pkgOwner = namespaces.contains(binding.namespace.root())
-                    val pkgDocid = binding.docid
+                    val pkgOwner = namespaces.contains(binding.path.root())
+                    val pkgDocid = binding.toDocId
                     info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
                     checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)
                 } else {

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -24,15 +24,11 @@ import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.NotFound
 import whisk.common.TransactionId
 import whisk.core.controller.RejectRequest
-import whisk.core.database.NoDocumentException
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityName
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskPackage
-import whisk.core.entity.types.EntityStore
 import whisk.core.database.DocumentTypeMismatchException
+import whisk.core.database.NoDocumentException
+import whisk.core.entity._
+import whisk.core.entity.types.EntityStore
 import whisk.http.Messages
-import whisk.core.entity.Identity
 
 class PackageCollection(entityStore: EntityStore) extends Collection(Collection.PACKAGES) {
 
@@ -54,7 +50,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
      * All assets that are not in an explicit package are private because the default package is private.
      */
     protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId) = {
+        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
         resource.entity map {
             pkgname =>
                 val isOwner = namespaces.contains(resource.namespace.root())
@@ -62,7 +58,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                     case Privilege.READ =>
                         // must determine if this is a public or owned package
                         // or, for a binding, that it references a public or owned package
-                        val docid = DocId(WhiskEntity.qualifiedName(resource.namespace.root, EntityName(pkgname)))
+                        val docid = FullyQualifiedEntityName(resource.namespace.root.toPath, EntityName(pkgname)).toDocId
                         checkPackageReadPermission(namespaces, isOwner, docid)
                     case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
                 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -113,7 +113,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                 // if owner, reject with not found, otherwise fail the future to reject with
                 // unauthorized (this prevents information leaks about packages in other namespaces)
                 if (isOwner) {
-                    Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
+                    Future.failed(RejectRequest(Conflict, Messages.conformanceMessage))
                 } else {
                     Future.successful(false)
                 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -32,6 +32,7 @@ import whisk.core.entity.WhiskPackage
 import whisk.core.entity.types.EntityStore
 import whisk.core.database.DocumentTypeMismatchException
 import whisk.http.Messages
+import whisk.core.entity.Identity
 
 class PackageCollection(entityStore: EntityStore) extends Collection(Collection.PACKAGES) {
 
@@ -52,8 +53,8 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
      * A published package makes all its assets public regardless of their shared bit.
      * All assets that are not in an explicit package are private because the default package is private.
      */
-    protected[core] override def implicitRights(namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ec: ExecutionContext, transid: TransactionId) = {
+    protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
+        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId) = {
         resource.entity map {
             pkgname =>
                 val isOwner = namespaces.contains(resource.namespace.root())

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -20,6 +20,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import Privilege.Privilege
+import spray.http.StatusCodes.Conflict
 import spray.http.StatusCodes.NotFound
 import whisk.common.TransactionId
 import whisk.core.controller.RejectRequest
@@ -29,6 +30,8 @@ import whisk.core.entity.EntityName
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskPackage
 import whisk.core.entity.types.EntityStore
+import whisk.core.database.DocumentTypeMismatchException
+import whisk.http.Messages
 
 class PackageCollection(entityStore: EntityStore) extends Collection(Collection.PACKAGES) {
 
@@ -100,7 +103,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                 }
         } recoverWith {
             case t: NoDocumentException =>
-                info(this, s"the package does not exist")
+                info(this, s"the package does not exist (owner? $isOwner)")
                 // if owner, reject with not found, otherwise fail the future to reject with
                 // unauthorized (this prevents information leaks about packages in other namespaces)
                 if (isOwner) {
@@ -108,9 +111,21 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                 } else {
                     Future.successful(false)
                 }
+            case t: DocumentTypeMismatchException =>
+                info(this, s"the requested binding is not a package (owner? $isOwner)")
+                // if owner, reject with not found, otherwise fail the future to reject with
+                // unauthorized (this prevents information leaks about packages in other namespaces)
+                if (isOwner) {
+                    Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
+                } else {
+                    Future.successful(false)
+                }
+            case t: RejectRequest =>
+                error(this, s"entitlement check on package failed: $t")
+                Future.failed(t)
             case t =>
                 error(this, s"entitlement check on package failed: ${t.getMessage}")
-                Future.successful(false)
+                Future.failed(t)
         }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -47,7 +47,7 @@ protected[core] class RemoteEntitlementService(
     private val iam: Identities,
     private val timeout: FiniteDuration = 5 seconds)(
         private implicit val actorSystem: ActorSystem)
-    extends EntitlementService(config, loadBalancer, iam) {
+    extends EntitlementProvider(config, loadBalancer, iam) {
 
     private implicit val executionContext = actorSystem.dispatcher
 

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -171,12 +171,12 @@ class ContainerPool(
      */
     def getAction(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): (WhiskContainer, Option[RunResult]) = {
         if (shuttingDown) {
-            info(this, s"Shutting down: Not getting container for ${action.fullyQualifiedName} with ${auth.uuid}")
+            info(this, s"Shutting down: Not getting container for ${action.fullyQualifiedName(true)} with ${auth.uuid}")
             throw new Exception("system is shutting down")
         } else {
-            val key = ActionContainerId(auth.uuid, action.fullyQualifiedName, action.rev)
+            val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true).toString, action.rev)
             val myPos = nextPosition.next()
-            info(this, s"""Getting container for ${action.fullyQualifiedName} of kind ${action.exec.kind} with ${auth.uuid}:
+            info(this, s"""Getting container for ${action.fullyQualifiedName(true)} of kind ${action.exec.kind} with ${auth.uuid}:
                           | myPos = $myPos
                           | completed = ${completedPosition.cur}
                           | slack = ${slack()}
@@ -426,7 +426,7 @@ class ContainerPool(
         ContainerCounter.containerName(invokerInstance.toString(), localName)
 
     private def makeContainerName(action: WhiskAction): ContainerName =
-        makeContainerName(action.fullyQualifiedName)
+        makeContainerName(action.fullyQualifiedName(true).toString)
 
     /**
      * dockerLock is a fair lock used to serialize all docker operations except pull.
@@ -559,7 +559,7 @@ class ContainerPool(
         val imageName = getDockerImageName(action)
         val limits = action.limits
         val nodeImageName = WhiskAction.containerImageName(nodejsExec, config.dockerRegistry, config.dockerImagePrefix, config.dockerImageTag)
-        val key = ActionContainerId(auth.uuid, action.fullyQualifiedName, action.rev)
+        val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true).toString, action.rev)
         val warmedContainer = if (limits.memory == defaultMemoryLimit && imageName == nodeImageName) getStemCellNodejsContainer(key) else None
         val containerName = makeContainerName(action)
         warmedContainer getOrElse {

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -28,9 +28,9 @@ import scala.util.{ Failure, Success, Try }
 import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
 import akka.event.Logging.{ InfoLevel, LogLevel }
 import akka.japi.Creator
-import spray.json.{ JsArray, JsObject, pimpAny, pimpString }
-import spray.json.DefaultJsonProtocol._
+import spray.json._
 import spray.json.DefaultJsonProtocol
+import spray.json.DefaultJsonProtocol._
 import whisk.common.{ ConsulKVReporter, Counter, Logging, LoggingMarkers, PrintStreamEmitter, SimpleExec, TransactionId }
 import whisk.common.ConsulClient
 import whisk.common.ConsulKV.InvokerKeys
@@ -91,7 +91,7 @@ class Invoker(
         val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION)
         val namespace = msg.action.path
         val name = msg.action.name
-        val actionid = DocId(WhiskEntity.qualifiedName(namespace, name)).asDocInfo(msg.revision)
+        val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)
         val tran = Transaction(msg)
         val subject = msg.subject
 
@@ -222,7 +222,7 @@ class Invoker(
             val boundParams = action.parameters.toJsObject
             val params = JsObject(boundParams.fields ++ payload.fields)
             val timeout = action.limits.timeout.duration
-            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName, msg.activationId.toString)
+            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName(true).toString, msg.activationId.toString)
         }
 
         initResultOpt match {

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -806,15 +806,10 @@ sealed trait RunWskCmd extends Matchers {
         if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
         val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, args ++ params: _*)
 
-        withClue(args.mkString(" ") + " " + params.mkString(" ") + ":\n") {
+        withClue(reportFailure(args ++ params, expectedExitCode, rr)) {
             if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
-                val ok = {
-                    (rr.exitCode == expectedExitCode) ||
-                        (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
-                }
-
+                val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
                 if (!ok) {
-                    println(s"expected exit code = $expectedExitCode\n$rr")
                     rr.exitCode shouldBe expectedExitCode
                 }
             }
@@ -829,6 +824,14 @@ sealed trait RunWskCmd extends Matchers {
      */
     def parseJsonString(jsonStr: String): JsObject = {
         jsonStr.substring(jsonStr.indexOf("\n") + 1).parseJson.asJsObject // Skip optional status line before parsing
+    }
+
+    private def reportFailure(args: Buffer[String], ec: Integer, rr: RunResult) = {
+        val s = new StringBuilder()
+        s.append(args.mkString(" ") + "\n")
+        if (rr.stdout.nonEmpty) s.append(rr.stdout + "\n")
+        if (rr.stderr.nonEmpty) s.append(rr.stderr)
+        s.append("exit code:")
     }
 }
 

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -37,6 +37,7 @@ import spray.json.pimpString
 import whisk.utils.retry
 import java.time.Instant
 import whisk.core.entity.ByteSize
+import org.scalatest.Matchers
 
 /**
  * Provide Scala bindings for the whisk CLI.
@@ -198,7 +199,7 @@ trait HasActivation {
     /**
      * Extracts activation id from 'wsk activation get' run result
      */
-    private def extractActivationIdFromActivation(result:RunResult): Option[String] = {
+    private def extractActivationIdFromActivation(result: RunResult): Option[String] = {
         Try {
             // a characteristic string that comes right before the activationId
             val idPrefix = "ok: got activation "
@@ -211,7 +212,7 @@ trait HasActivation {
     /**
      * Extracts activation id from 'wsk action invoke' or 'wsk trigger invoke'
      */
-    private def extractActivationIdFromInvoke(result:RunResult): Option[String] = {
+    private def extractActivationIdFromInvoke(result: RunResult): Option[String] = {
         Try {
             val stdout = result.stdout
             assert(stdout.contains("ok: invoked") || stdout.contains("ok: triggered"), stdout)
@@ -782,7 +783,7 @@ object Wsk {
         if (WhiskProperties.useCLIDownload) Buffer(getDownloadedGoCLIPath) else Buffer(WhiskProperties.getCLIPath)
 }
 
-sealed trait RunWskCmd {
+sealed trait RunWskCmd extends Matchers {
 
     /**
      * The base command to run.
@@ -804,7 +805,21 @@ sealed trait RunWskCmd {
         if (verbose) args += "--verbose"
         if (showCmd) println(args.mkString(" ") + " " + params.mkString(" "))
         val rr = TestUtils.runCmd(DONTCARE_EXIT, workingDir, TestUtils.logger, sys.env ++ env, args ++ params: _*)
-        rr.validateExitCode(expectedExitCode)
+
+        withClue(args.mkString(" ") + " " + params.mkString(" ") + ":\n") {
+            if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
+                val ok = {
+                    (rr.exitCode == expectedExitCode) ||
+                        (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
+                }
+
+                if (!ok) {
+                    println(s"expected exit code = $expectedExitCode\n$rr")
+                    rr.exitCode shouldBe expectedExitCode
+                }
+            }
+        }
+
         rr
     }
 

--- a/tests/src/system/basic/WskRuleTests.scala
+++ b/tests/src/system/basic/WskRuleTests.scala
@@ -102,6 +102,39 @@ class WskRuleTests
             }
     }
 
+    it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val ruleName = "pr1to1"
+            val triggerName = "pt1to1"
+            val pkgName = "rule pkg" // spaces in name intended to test uri path encoding
+            val actionName = "a1 to 1"
+            val pkgActionName = s"$pkgName/$actionName"
+
+            assetHelper.withCleaner(wsk.pkg, pkgName) {
+                (pkg, name) => pkg.create(name)
+            }
+
+            ruleSetup(Seq(
+                (ruleName, triggerName, (pkgActionName, defaultAction))),
+                assetHelper)
+
+            val now = Instant.now
+            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+
+            withActivation(wsk.activation, run) {
+                triggerActivation =>
+                    triggerActivation.cause shouldBe None
+
+                    withActivationsFromEntity(wsk.activation, ruleName, since = Some(Instant.ofEpochMilli(triggerActivation.start))) {
+                        _.head.cause shouldBe Some(triggerActivation.activationId)
+                    }
+
+                    withActivationsFromEntity(wsk.activation, actionName, since = Some(Instant.ofEpochMilli(triggerActivation.start))) {
+                        _.head.response.result shouldBe Some(testResult)
+                    }
+            }
+    }
+
     it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val ruleName = "ruleDelete"
@@ -252,7 +285,6 @@ class WskRuleTests
             val triggerName2 = "t1to1b"
             val actionName1 = "a1to1a"
             val actionName2 = "a1to1b"
-
 
             ruleSetup(Seq(
                 ("r2to2a", triggerName1, (actionName1, defaultAction)),

--- a/tests/src/whisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/whisk/core/cli/test/WskEntitlementTests.scala
@@ -215,6 +215,22 @@ class WskEntitlementTests
             }
     }
 
+    it should "not create a package binding for private package" in withAssetCleaner(guestWskProps) {
+        (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, samplePackage) {
+                (pkg, _) => pkg.create(samplePackage, shared = Some(false))(wp)
+            }
+
+            val name = "bindPackage"
+            val provider = s"/$guestNamespace/$samplePackage"
+            withAssetCleaner(defaultWskProps) {
+                (wp, assetHelper) =>
+                    assetHelper.withCleaner(wsk.pkg, name, confirmDelete = false) {
+                        (pkg, _) => pkg.bind(provider, name, expectedExitCode = FORBIDDEN)(wp)
+                    }
+            }
+    }
+
     behavior of "Wsk Package Action"
 
     it should "get and invoke an action from package" in withAssetCleaner(guestWskProps) {

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -336,6 +336,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         }
     }
 
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.toJson)
 
     // this test is sneaky; the installation of the sequence is done directly in the db

--- a/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
@@ -16,32 +16,21 @@
 
 package whisk.core.controller.test
 
+import java.time.Clock
+import java.time.Instant
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.MethodNotAllowed
-import spray.http.StatusCodes.OK
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.JsObject
+
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 import whisk.core.controller.WhiskActivationsApi
-import whisk.core.entity.ActivationId
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.AuthKey
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskActivation
-import spray.json.JsString
-import whisk.core.entity.ActivationResponse
-import java.time.Instant
-import java.time.Clock
-import spray.json.JsNumber
+import whisk.core.entity._
 
 /**
- * UNDER CONSTRUCTION: tests for new scala controller
+ * Tests Activations API.
  *
  * Unit tests of the controller service as a standalone component.
  * These tests exercise a fresh instance of the service object in memory -- these
@@ -87,6 +76,24 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
                 activations forall { a => response contains a.summaryAsJson } should be(true)
                 rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName() case _ => false } }
             }
+        }
+
+        // it should "list activations with explicit namespace owned by subject" in {
+        whisk.utils.retry {
+            Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(creds)) ~> check {
+                status should be(OK)
+                val rawResponse = responseAs[List[JsObject]]
+                val response = responseAs[List[JsObject]]
+                activations.length should be(response.length)
+                activations forall { a => response contains a.summaryAsJson } should be(true)
+                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName() case _ => false } }
+            }
+        }
+
+        // it should "reject list activations with explicit namespace not owned by subject" in {
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
+        Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(auser)) ~> check {
+            status should be(Forbidden)
         }
     }
 
@@ -231,6 +238,19 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
             status should be(OK)
             val response = responseAs[JsObject]
             response should be(activation.toExtendedJson)
+        }
+
+        // it should "get activation by name in explicit namespace owned by subject" in
+        Get(s"/$namespace/${collection.path}/${activation.activationId()}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[JsObject]
+            response should be(activation.toExtendedJson)
+        }
+
+        // it should "reject get activation by name in explicit namespace not owned by subject" in
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
+        Get(s"/$namespace/${collection.path}/${activation.activationId()}") ~> sealRoute(routes(auser)) ~> check {
+            status should be(Forbidden)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/AuthorizeTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthorizeTests.scala
@@ -25,18 +25,17 @@ import org.scalatest.junit.JUnitRunner
 
 import whisk.core.controller.Authenticate
 import whisk.core.controller.RejectRequest
+import whisk.core.entitlement.Privilege
 import whisk.core.entitlement.Privilege.ACTIVATE
 import whisk.core.entitlement.Privilege.DELETE
 import whisk.core.entitlement.Privilege.PUT
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Privilege.REJECT
 import whisk.core.entitlement.Resource
-import whisk.core.entity.Subject
 import whisk.core.entity.AuthKey
-import whisk.core.entitlement.Privilege
 import whisk.core.entity.EntityName
 import whisk.core.entity.Identity
-import whisk.core.entitlement.OperationNotAllowed
+import whisk.core.entity.Subject
 
 /**
  * Tests authorization handler which guards resources.
@@ -110,13 +109,13 @@ class AuthorizeTests extends ControllerTestCommon with Authenticate {
         val collections = Seq(ACTIONS, RULES, TRIGGERS)
         val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
         resources foreach { r =>
-            an[OperationNotAllowed] should be thrownBy {
+            a[RejectRequest] should be thrownBy {
                 Await.result(entitlementService.check(someUser, READ, r), requestTimeout)
             }
-            an[OperationNotAllowed] should be thrownBy {
+            a[RejectRequest] should be thrownBy {
                 Await.result(entitlementService.check(someUser, PUT, r), requestTimeout)
             }
-            an[OperationNotAllowed] should be thrownBy {
+            a[RejectRequest] should be thrownBy {
                 Await.result(entitlementService.check(someUser, DELETE, r), requestTimeout)
             }
             Await.result(entitlementService.check(someUser, ACTIVATE, r), requestTimeout) should be(true)

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -36,7 +36,7 @@ import whisk.core.connector.ActivationMessage
 import whisk.core.controller.WhiskActionsApi
 import whisk.core.controller.WhiskServices
 import whisk.core.database.test.DbUtils
-import whisk.core.entitlement.{ Collection, EntitlementService, LocalEntitlementService }
+import whisk.core.entitlement._
 import whisk.core.entity._
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.core.iam.Identities
@@ -65,7 +65,7 @@ protected trait ControllerTestCommon
 
     override val loadBalancer = new DegenerateLoadBalancerService(whiskConfig, InfoLevel)
     override val iam = new Identities(whiskConfig, forceLocal = true)
-    override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig, loadBalancer, iam)
+    override val entitlementProvider: EntitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer, iam)
 
     override val activationId = new ActivationId.ActivationIdGenerator() {
         // need a static activation id to test activations api
@@ -143,7 +143,7 @@ protected trait ControllerTestCommon
     entityStore.setVerbosity(InfoLevel)
     activationStore.setVerbosity(InfoLevel)
     authStore.setVerbosity(InfoLevel)
-    entitlementService.setVerbosity(InfoLevel)
+    entitlementProvider.setVerbosity(InfoLevel)
 
     val ACTIONS = Collection(Collection.ACTIONS)
     val TRIGGERS = Collection(Collection.TRIGGERS)

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -19,31 +19,12 @@ package whisk.core.controller.test
 import scala.concurrent.duration.DurationInt
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import spray.http.StatusCodes.Accepted
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Forbidden
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.OK
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsObject
-import spray.json.pimpAny
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import whisk.core.controller.WhiskActionsApi
-import whisk.core.entity.ActionLimits
-import whisk.core.entity.Exec
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskActionPut
-import whisk.core.entity.AuthKey
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskPackage
+import whisk.core.entity._
 import whisk.core.entitlement.Resource
 import whisk.core.entitlement.Privilege._
 import scala.concurrent.Await
@@ -312,7 +293,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, binding)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, READ, pkgaccess), 1 second)
+        Await.result(entitlementProvider.grant(auser.subject, READ, pkgaccess), 1 second)
         Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskAction]
@@ -456,7 +437,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, reference)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
+        Await.result(entitlementProvider.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
         Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Accepted)
             val response = responseAs[JsObject]

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -19,33 +19,14 @@ package whisk.core.controller.test
 import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Forbidden
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.RequestEntityTooLarge
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.JsObject
-import spray.json.pimpString
-import whisk.core.entity.Exec
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.AuthKey
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskPackage
-import whisk.core.entity.Binding
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+import whisk.core.entity._
 import whisk.core.controller.WhiskPackagesApi
-import whisk.core.entity.WhiskPackagePut
 import whisk.http.ErrorResponse
-import whisk.core.entity.WhiskPackageWithActions
-import spray.json.JsArray
+import whisk.http.Messages
 
 /**
  * Tests Packages API.
@@ -246,7 +227,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
-    it should "get package reference" in {
+    it should "get package reference for private package in same namespace" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname, None, Parameters("a", "A") ++ Parameters("b", "B"))
         val reference = WhiskPackage(namespace, aname, provider.bind, Parameters("b", "b") ++ Parameters("c", "C"))
@@ -261,14 +242,26 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
+    it should "not get package reference for a private package in other namespace" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+
+        val provider = WhiskPackage(privateNamespace, aname)
+        val reference = WhiskPackage(namespace, aname, provider.bind)
+        put(entityStore, provider)
+        put(entityStore, reference)
+        Get(s"$collectionPath/${reference.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
+        }
+    }
+
     it should "get package with its actions and feeds" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
-        val reference = WhiskPackage(namespace, aname, provider.bind)
         val action = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"))
         val feed = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"), annotations = Parameters(Parameters.Feed, "true"))
         put(entityStore, provider)
-        put(entityStore, reference)
         put(entityStore, action)
         put(entityStore, feed)
 
@@ -306,6 +299,30 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(OK)
             val response = responseAs[WhiskPackageWithActions]
             response should be(reference withActions (List(action, feed)))
+        }
+    }
+
+    it should "not get package reference with its actions and feeds from private package" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+        val provider = WhiskPackage(privateNamespace, aname)
+        val reference = WhiskPackage(namespace, aname, provider.bind)
+        val action = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"))
+        val feed = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"), annotations = Parameters(Parameters.Feed, "true"))
+        put(entityStore, provider)
+        put(entityStore, reference)
+        put(entityStore, action)
+        put(entityStore, feed)
+
+        // it should "reject get package reference from other subject" in {
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
+        Get(s"/$namespace/${collection.path}/${reference.name}") ~> sealRoute(routes(auser)) ~> check {
+            status should be(Forbidden)
+        }
+
+        Get(s"$collectionPath/${reference.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
         }
     }
 
@@ -347,6 +364,22 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
+    it should "not create package reference from private package in another namespace" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+
+        val provider = WhiskPackage(privateNamespace, aname)
+        val reference = WhiskPackage(namespace, aname, provider.bind)
+        // binding annotation should be removed and set by controller
+        val content = WhiskPackagePut(reference.binding)
+        put(entityStore, provider)
+
+        Put(s"/$namespace/${collection.path}/${reference.name}", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
+        }
+    }
+
     it should "create package reference with implicit namespace" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
@@ -364,13 +397,25 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
-    it should "reject create package reference when referencing non-existent package" in {
+    it should "reject create package reference when referencing non-existent package in same namespace" in {
         implicit val tid = transid()
         val binding = Some(Binding(namespace, aname))
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(BadRequest)
-            responseAs[ErrorResponse].error should include("binding references a package that does not exist")
+            status should be(NotFound)
+            responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
+        }
+    }
+
+    it should "reject create package reference when referencing non-existent package in another namespace" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+
+        val binding = Some(Binding(privateNamespace, aname))
+        val content = WhiskPackagePut(binding)
+        Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
         }
     }
 
@@ -379,10 +424,11 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val provider = WhiskPackage(namespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
         val content = WhiskPackagePut(Some(Binding(reference.namespace, reference.name)))
+        put(entityStore, provider)
         put(entityStore, reference)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[ErrorResponse].error should include("cannot bind to another package binding")
+            responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
         }
     }
 
@@ -486,14 +532,43 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
-    it should "reject update package reference when new binding refers to non-existent package" in {
+    it should "reject update package reference when new binding refers to non-existent package in same namespace" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
         val content = WhiskPackagePut(reference.binding)
         put(entityStore, reference)
         Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(BadRequest)
+            status should be(NotFound)
+        }
+    }
+
+    it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+
+        val provider = WhiskPackage(privateNamespace, aname)
+        val reference = WhiskPackage(namespace, aname, provider.bind)
+        val content = WhiskPackagePut(reference.binding)
+        put(entityStore, reference)
+        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
+        }
+    }
+
+    it should "reject update package reference when new binding refers to private package in another namespace" in {
+        implicit val tid = transid()
+        val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
+        val privateNamespace = EntityPath(privateCreds.subject())
+
+        val provider = WhiskPackage(privateNamespace, aname)
+        val reference = WhiskPackage(namespace, aname, provider.bind)
+        val content = WhiskPackagePut(reference.binding)
+        put(entityStore, provider)
+        put(entityStore, reference)
+        Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(Forbidden)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -402,7 +402,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val binding = Some(Binding(namespace, aname))
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(NotFound)
+            status should be(BadRequest)
             responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
         }
     }
@@ -539,7 +539,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val content = WhiskPackagePut(reference.binding)
         put(entityStore, reference)
         Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(NotFound)
+            status should be(BadRequest)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -337,7 +337,6 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             deletePackage(provider.docid)
             status should be(OK)
             val response = responseAs[WhiskPackage]
-            response should be(provider)
         }
     }
 
@@ -529,6 +528,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
         Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
+            responseAs[ErrorResponse].error should include(Messages.packageCannotBecomeBinding)
         }
     }
 
@@ -540,6 +540,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, reference)
         Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
+            responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
         }
     }
 
@@ -613,10 +614,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject delete non-empty package" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
-        val reference = WhiskPackage(namespace, aname, provider.bind)
         val action = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"))
         put(entityStore, provider)
-        put(entityStore, reference)
         put(entityStore, action)
         whisk.utils.retry {
             Get(s"$collectionPath/${provider.name}") ~> sealRoute(routes(creds)) ~> check {
@@ -641,6 +640,20 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
         Get(s"$collectionPath/${provider.name}/bar") ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
+        }
+    }
+
+    it should "reject bind to non-package" in {
+        implicit val tid = transid()
+        val action = WhiskAction(namespace, aname, Exec.js("??"))
+        val reference = WhiskPackage(namespace, aname, Some(action.fullyQualifiedName(false)))
+        val content = WhiskPackagePut(reference.binding)
+
+        put(entityStore, action)
+
+        Put(s"$collectionPath/${reference.name}", content) ~> sealRoute(routes(creds)) ~> check {
+            status should be(Conflict)
+            responseAs[ErrorResponse].error should include(Messages.requestedBindingIsNotValid)
         }
     }
 }

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -18,40 +18,17 @@ package whisk.core.controller.test
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.RequestEntityTooLarge
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.listFormat
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import spray.json.pimpString
 import whisk.core.controller.WhiskRulesApi
-import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.SemVer
-import whisk.core.entity.Status
-import whisk.core.entity.AuthKey
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.WhiskRulePut
-import whisk.core.entity.WhiskTrigger
+import whisk.core.entity._
+import whisk.core.entity.test.OldWhiskTrigger
 import whisk.http.ErrorResponse
 import scala.language.postfixOps
-import whisk.core.entity.WhiskRuleResponse
-import whisk.core.entity.ReducedRule
 import whisk.core.entity.test.OldWhiskRule
-import whisk.core.entity.test.OldWhiskTrigger
-import whisk.core.entity.WhiskPackage
 
 /**
  * Tests Rules API.
@@ -74,6 +51,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject())
     def aname() = MakeName.next("rules_tests")
+    def afullname(namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     val activeStatus = s"""{"status":"${Status.ACTIVE}"}""".parseJson.asJsObject
     val inactiveStatus = s"""{"status":"${Status.INACTIVE}"}""".parseJson.asJsObject
@@ -83,8 +61,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     //// GET /rules
     it should "list rules by default namespace" in {
         implicit val tid = transid()
+
         val rules = (1 to 2).map { i =>
-            WhiskRule(namespace, aname(), EntityName("bogus trigger"), EntityName("bogus action"))
+            WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
         }.toList
         rules foreach { put(entityStore, _) }
         waitOnView(entityStore, WhiskRule, namespace, 2)
@@ -99,8 +78,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     //?docs disabled
     ignore should "list rules by default namespace with full docs" in {
         implicit val tid = transid()
+
         val rules = (1 to 2).map { i =>
-            WhiskRule(namespace, aname(), EntityName("bogus trigger"), EntityName("bogus action"))
+            WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
         }.toList
         rules foreach { put(entityStore, _) }
         waitOnView(entityStore, WhiskRule, namespace, 2)
@@ -115,7 +95,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     //// GET /rule/name
     it should "get rule" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname(), EntityName("bogus trigger"), EntityName("bogus action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
         put(entityStore, rule)
         Get(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
@@ -126,6 +107,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "reject get of non existent rule" in {
         implicit val tid = transid()
+
         Get(s"$collectionPath/xxx") ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
         }
@@ -133,10 +115,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "get rule with active state in trigger" in {
         implicit val tid = transid()
-        val ruleName = EntityName("get_active_rule")
-        val triggerName = EntityName("get_active_rule trigger")
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(EntityPath(WhiskEntity.qualifiedName(namespace, ruleName)) -> ReducedRule(namespace, Status.ACTIVE))))
+
+        val rule = WhiskRule(namespace, EntityName("get_active_rule"), afullname(namespace, "get_active_rule trigger"), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+        })
 
         put(entityStore, trigger)
         put(entityStore, rule)
@@ -150,10 +133,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "get rule with no rule-entries in trigger" in {
         implicit val tid = transid()
-        val ruleName = EntityName("get_rule_with_empty_trigger")
-        val triggerName = EntityName("get_rule_with_empty_trigger trigger")
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
-        val trigger = WhiskTrigger(namespace, triggerName)
+
+        val trigger = WhiskTrigger(namespace, EntityName("get_rule_with_empty_trigger trigger"))
+        val rule = WhiskRule(namespace, EntityName("get_rule_with_empty_trigger"), trigger.fullyQualifiedName(false), afullname(namespace, "an action"))
 
         put(entityStore, trigger)
         put(entityStore, rule)
@@ -167,8 +149,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "report Conflict if the name was of a different type" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
+
         put(entityStore, trigger)
+
         Get(s"/$namespace/${collection.path}/${trigger.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
         }
@@ -177,12 +162,15 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     // DEL /rules/name
     it should "reject delete rule in state active" in {
         implicit val tid = transid()
-        val ruleName = EntityName("reject_delete_rule_active")
-        val triggerName = aname()
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(EntityPath(WhiskEntity.qualifiedName(namespace, ruleName)) -> ReducedRule(namespace, Status.ACTIVE))))
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+
+        val rule = WhiskRule(namespace, EntityName("reject_delete_rule_active"), FullyQualifiedEntityName(namespace, aname()), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+        })
+
         put(entityStore, trigger)
         put(entityStore, rule)
+
         Delete(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
             val response = responseAs[ErrorResponse]
@@ -193,22 +181,20 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "delete rule in state inactive" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val actionName = aname()
-        val actionNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, actionName))
-        val triggerLink = ReducedRule(actionNameQualified, Status.INACTIVE)
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> triggerLink)))
-        val rule = WhiskRule(namespace, ruleName, triggerName, actionName)
+
+        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
+        val triggerLink = ReducedRule(rule.action, Status.INACTIVE)
+        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some(Map(rule.fullyQualifiedName(false) -> triggerLink)))
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Delete(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
 
             status should be(OK)
-            t.rules.get.get(ruleNameQualified) shouldBe None
+            t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe None
             val response = responseAs[WhiskRuleResponse]
             response should be(rule.withStatus(Status.INACTIVE))
         }
@@ -216,8 +202,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "delete rule in state inactive even if the trigger has been deleted" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, EntityName("delete_rule_inactive"), EntityName("a trigger"), EntityName("an action"))
+
+        val rule = WhiskRule(namespace, EntityName("delete_rule_inactive"), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+
         put(entityStore, rule)
+
         Delete(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskRuleResponse]
@@ -227,13 +216,13 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "delete rule in state inactive even if the trigger has no reference to the rule" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val trigger = WhiskTrigger(namespace, triggerName)
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Delete(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             deleteTrigger(trigger.docid)
 
@@ -247,74 +236,66 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     it should "create rule" in {
         implicit val tid = transid()
 
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val actionName = aname()
-        val actionNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, actionName))
-        val trigger = WhiskTrigger(namespace, triggerName)
-        val rule = WhiskRule(namespace, ruleName, triggerName, actionName)
-        val action = WhiskAction(namespace, actionName, Exec.js("??"))
-        val content = WhiskRulePut(Some(trigger.name), Some(action.name))
+        val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
+        val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
+        val action = WhiskAction(rule.action.path, rule.action.name, Exec.js("??"))
+        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
+
         Put(s"$collectionPath/${rule.name}", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.get(ruleNameQualified) shouldBe ReducedRule(actionNameQualified, Status.ACTIVE)
             val response = responseAs[WhiskRuleResponse]
             response should be(rule.withStatus(Status.ACTIVE))
+            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
         }
     }
 
-    ignore should "create rule with an action in a package" in {
+    it should "create rule with an action in a package" in {
         implicit val tid = transid()
 
-        val provider = WhiskPackage(namespace, aname())
+        val provider = WhiskPackage(namespace, aname(), publish = true)
+        val action = WhiskAction(provider.path, aname(), Exec.js("??"))
+        val trigger = WhiskTrigger(namespace, aname())
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
         put(entityStore, provider)
-
-        val actionName = aname()
-        val action = WhiskAction(provider.path, actionName, Exec.js("??"))
-        // TODO: this should be an EntityQName, not an EntityPath
-        val actionNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, action.name))
-
-        val triggerName = aname()
-        val trigger = WhiskTrigger(namespace, triggerName)
-
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-
-        val rule = WhiskRule(namespace, ruleName, triggerName, actionName)
-        val content = WhiskRulePut(Some(trigger.name), Some(action.name))
-
         put(entityStore, trigger, false)
         put(entityStore, action)
+
         Put(s"$collectionPath/${rule.name}", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.get(ruleNameQualified) shouldBe ReducedRule(actionNameQualified, Status.ACTIVE)
             val response = responseAs[WhiskRuleResponse]
             response should be(rule.withStatus(Status.ACTIVE))
+            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
         }
     }
 
     it should "reject create rule with annotations which are too big" in {
         implicit val tid = transid()
+
+        val trigger = WhiskTrigger(namespace, aname())
+        val action = WhiskAction(namespace, aname(), Exec.js("??"))
+
         val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), Exec.js("??"))
         val content = s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$parameters}""".parseJson.asJsObject
+
         put(entityStore, trigger, false)
         put(entityStore, action)
+
         Put(s"$collectionPath/${aname()}", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
@@ -326,17 +307,21 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "reject update rule with annotations which are too big" in {
         implicit val tid = transid()
+
+        val trigger = WhiskTrigger(namespace, aname())
+        val action = WhiskAction(namespace, aname(), Exec.js("??"))
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+
         val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
-        val trigger = WhiskTrigger(namespace, aname())
-        val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.name, action.name)
         val content = s"""{"trigger":"${trigger.name}","action":"${action.name}","annotations":$parameters}""".parseJson.asJsObject
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule)
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
@@ -348,29 +333,37 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "reject rule if action does not exist" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
-        val content = WhiskRulePut(Some(trigger.name), Some(EntityName("bogus action")))
+        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(afullname(namespace, "bogus action")))
+
         put(entityStore, trigger)
+
         Put(s"$collectionPath/xxx", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] === s"${WhiskEntity.qualifiedName(namespace, content.action.get)} does not exist"
+            responseAs[String] === s"${content.action.get.qualifiedNameWithLeadingSlash} does not exist"
         }
     }
 
     it should "reject rule if trigger does not exist" in {
         implicit val tid = transid()
+
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val content = WhiskRulePut(Some(EntityName("bogus trigger")), Some(action.name))
+        val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(action.fullyQualifiedName(false)))
+
         put(entityStore, action)
+
         Put(s"$collectionPath/xxx", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] === s"${WhiskEntity.qualifiedName(namespace, content.trigger.get)} does not exist"
+            responseAs[String] === s"${content.trigger.get.qualifiedNameWithLeadingSlash} does not exist"
         }
     }
 
     it should "reject rule if neither action or trigger do not exist" in {
         implicit val tid = transid()
-        val content = WhiskRulePut(Some(EntityName("bogus trigger")), Some(EntityName("bogus action")))
+
+        val content = WhiskRulePut(Some(afullname(namespace, "bogus trigger")), Some(afullname(namespace, "bogus action")))
+
         Put(s"$collectionPath/xxx", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
             responseAs[String].contains("does not exist") should be(true)
@@ -379,13 +372,16 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "update rule updating trigger and action at once" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), EntityName("bogus trigger"), EntityName("bogus action"))
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
+        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule, false)
-        val content = WhiskRulePut(Some(trigger.name), Some(action.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
@@ -393,72 +389,81 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
             status should be(OK)
 
-            t.rules.get(EntityPath(WhiskEntity.qualifiedName(namespace, rule.name))).action should be(EntityPath(WhiskEntity.qualifiedName(namespace, action.name)))
+            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
             val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.name, action.name, version = SemVer().upPatch))
+            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
         }
     }
 
     it should "update rule with a new action while passing the same trigger" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.name, EntityName("bogus action"))
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+        val content = WhiskRulePut(Some(trigger.fullyQualifiedName(false)), Some(action.fullyQualifiedName(false)))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule, false)
-        val content = WhiskRulePut(Some(trigger.name), Some(action.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.get(EntityPath(WhiskEntity.qualifiedName(namespace, rule.name))).action should be(EntityPath(WhiskEntity.qualifiedName(namespace, action.name)))
+            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
             val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.name, action.name, version = SemVer().upPatch))
+            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
         }
     }
 
     it should "update rule with just a new action" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.name, EntityName("bogus action"))
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+        val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule, false)
-        val content = WhiskRulePut(action = Some(action.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.map { rules => rules(EntityPath(WhiskEntity.qualifiedName(namespace, rule.name))).action }.get should be(EntityPath(WhiskEntity.qualifiedName(namespace, action.name)))
+            t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
             val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.name, action.name, version = SemVer().upPatch))
+            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
         }
     }
 
     it should "update rule with just a new trigger" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.name, action.name)
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+        val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule, false)
-        val content = WhiskRulePut(trigger = Some(trigger.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.get.get(EntityPath(WhiskEntity.qualifiedName(namespace, rule.name))) shouldBe a[Some[_]]
+            t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe a[Some[_]]
             val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.name, action.name, version = SemVer().upPatch))
+            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
         }
     }
 
@@ -466,67 +471,83 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         implicit val tid = transid()
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), trigger.name, action.name)
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
+        val content = WhiskRulePut(None, None, None, None, None)
+
         put(entityStore, trigger, false)
         put(entityStore, action)
         put(entityStore, rule, false)
-        val content = WhiskRulePut(None, None, None, None, None)
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             deleteTrigger(trigger.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
             val response = responseAs[WhiskRuleResponse]
-            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.name, action.name, version = SemVer().upPatch))
+            response should be(WhiskRuleResponse(namespace, rule.name, Status.ACTIVE, trigger.fullyQualifiedName(false), action.fullyQualifiedName(false), version = SemVer().upPatch))
         }
     }
 
     it should "reject update rule if trigger does not exist" in {
         implicit val tid = transid()
+
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
-        val rule = WhiskRule(namespace, aname(), EntityName("bogus trigger"), action.name)
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), action.fullyQualifiedName(false))
+        val content = WhiskRulePut(action = Some(action.fullyQualifiedName(false)))
+
         put(entityStore, action)
         put(entityStore, rule)
-        val content = WhiskRulePut(action = Some(action.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] === s"${WhiskEntity.qualifiedName(namespace, EntityName(rule.trigger.name))} does not exist"
+            responseAs[String] === s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist"
         }
     }
 
     it should "reject update rule if action does not exist" in {
         implicit val tid = transid()
+
         val trigger = WhiskTrigger(namespace, aname())
-        val rule = WhiskRule(namespace, aname(), trigger.name, EntityName("bogus action"))
+        val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), afullname(namespace, "bogus action"))
+        val content = WhiskRulePut(trigger = Some(trigger.fullyQualifiedName(false)))
+
         put(entityStore, trigger)
         put(entityStore, rule)
-        val content = WhiskRulePut(trigger = Some(trigger.name))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] === s"${WhiskEntity.qualifiedName(namespace, EntityName(rule.action.name))} does not exist"
+            responseAs[String] === s"${rule.action.qualifiedNameWithLeadingSlash} does not exist"
         }
     }
 
     it should "reject update rule if neither trigger or action exist" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname(), EntityName("bogus trigger"), EntityName("bogus action"))
-        put(entityStore, rule)
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "bogus trigger"), afullname(namespace, "bogus action"))
         val content = WhiskRulePut(None, None, None, None, None)
+
+        put(entityStore, rule)
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String].contains("does not exist") should be(true)
+            responseAs[String] should {
+                include(s"${rule.action.qualifiedNameWithLeadingSlash} does not exist") or
+                    include(s"${rule.trigger.qualifiedNameWithLeadingSlash} does not exist")
+            }
         }
     }
 
     it should "reject update rule in state active" in {
         implicit val tid = transid()
-        val triggerName = EntityName("a trigger")
-        val ruleName = aname()
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(EntityPath(WhiskEntity.qualifiedName(namespace, ruleName)) -> ReducedRule(namespace, Status.ACTIVE))))
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+        })
+        val content = WhiskRulePut(publish = Some(!rule.publish))
+
         put(entityStore, trigger)
         put(entityStore, rule)
-        val content = WhiskRulePut(publish = Some(!rule.publish))
+
         Put(s"$collectionPath/${rule.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
         }
@@ -535,8 +556,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     //// POST /rules/name
     it should "do nothing to disable already disabled rule" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname(), EntityName("a trigger"), EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
         }
@@ -544,12 +568,15 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "do nothing to enable already enabled rule" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val triggerName = aname()
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(EntityPath(WhiskEntity.qualifiedName(namespace, ruleName)) -> ReducedRule(namespace, Status.ACTIVE))))
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+        })
+
         put(entityStore, trigger)
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
         }
@@ -557,6 +584,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "reject post with status undefined" in {
         implicit val tid = transid()
+
         Post(s"$collectionPath/xyz") ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
         }
@@ -564,7 +592,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "reject post with invalid status" in {
         implicit val tid = transid()
+
         val badStatus = s"""{"status":"xxx"}""".parseJson.asJsObject
+
         Post(s"$collectionPath/xyz", badStatus) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
         }
@@ -572,48 +602,50 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "activate rule" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> ReducedRule(namespace, Status.INACTIVE))))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.INACTIVE))
+        })
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
 
             status should be(OK)
 
-            t.rules.get(ruleNameQualified).status should be(Status.ACTIVE)
+            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
         }
     }
 
     it should "activate rule without rule in trigger" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
-        val trigger = WhiskTrigger(namespace, triggerName)
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name)
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
 
             status should be(OK)
-            t.rules.get(ruleNameQualified).status should be(Status.ACTIVE)
+            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.ACTIVE)
         }
     }
 
     it should "reject rule activation, if the trigger is absent" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
         }
@@ -621,27 +653,32 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "deactivate rule" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val rule = WhiskRule(namespace, ruleName, triggerName, EntityName("an action"))
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> ReducedRule(namespace, Status.ACTIVE))))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "an action"))
+        val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+        })
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", inactiveStatus) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
 
             status should be(OK)
-            t.rules.get(ruleNameQualified).status should be(Status.INACTIVE)
+            t.rules.get(rule.fullyQualifiedName(false)).status should be(Status.INACTIVE)
         }
     }
 
     // invalid resource
     it should "reject invalid resource" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname(), EntityName("a trigger"), EntityName("an action"))
+
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, "a trigger"), afullname(namespace, "an action"))
+
         put(entityStore, rule)
+
         Get(s"$collectionPath/${rule.name}/bar") ~> sealRoute(routes(creds)) ~> check {
             status should be(NotFound)
         }
@@ -650,8 +687,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     // migration path
     it should "handle a rule with the old schema gracefully" in {
         implicit val tid = transid()
+
         val rule = OldWhiskRule(namespace, aname(), EntityName("a trigger"), EntityName("an action"), Status.ACTIVE)
+
         put(entityStore, rule)
+
         Get(s"$collectionPath/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskRuleResponse]
@@ -662,24 +702,22 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     it should "create rule even if the attached trigger has the old schema" in {
         implicit val tid = transid()
 
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
-        val triggerName = aname()
-        val actionName = aname()
-        val actionNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, actionName))
-        val trigger = OldWhiskTrigger(namespace, triggerName)
-        val rule = WhiskRule(namespace, ruleName, triggerName, actionName)
-        val action = WhiskAction(namespace, actionName, Exec.js("??"))
-        val content = WhiskRulePut(Some(trigger.name), Some(action.name))
+        val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, aname().name))
+        val trigger = OldWhiskTrigger(namespace, rule.trigger.name)
+
+        val action = WhiskAction(namespace, rule.action.name, Exec.js("??"))
+        val content = WhiskRulePut(Some(rule.trigger), Some(rule.action))
+
         put(entityStore, trigger, false)
         put(entityStore, action)
+
         Put(s"$collectionPath/${rule.name}", content) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)
             deleteRule(rule.docid)
 
             status should be(OK)
-            t.rules.get(ruleNameQualified) shouldBe ReducedRule(actionNameQualified, Status.ACTIVE)
+            t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
             val response = responseAs[WhiskRuleResponse]
             response should be(rule.withStatus(Status.ACTIVE))
         }
@@ -687,13 +725,16 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
     it should "activate rule even if it is still in the old schema" in {
         implicit val tid = transid()
-        val ruleName = aname()
-        val ruleNameQualified = EntityPath(WhiskEntity.qualifiedName(namespace, ruleName))
+
+        val ruleNameQualified = FullyQualifiedEntityName(namespace, aname())
         val triggerName = aname()
-        val rule = OldWhiskRule(namespace, ruleName, triggerName, EntityName("an action"), Status.ACTIVE)
-        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> ReducedRule(namespace, Status.INACTIVE))))
+        val actionName = FullyQualifiedEntityName(namespace, aname())
+        val rule = OldWhiskRule(namespace, ruleNameQualified.name, triggerName, actionName.name, Status.ACTIVE)
+        val trigger = WhiskTrigger(namespace, triggerName, rules = Some(Map(ruleNameQualified -> ReducedRule(actionName, Status.INACTIVE))))
+
         put(entityStore, trigger, false)
         put(entityStore, rule)
+
         Post(s"$collectionPath/${rule.name}", activeStatus) ~> sealRoute(routes(creds)) ~> check {
             val t = get(entityStore, trigger.docid, WhiskTrigger)
             deleteTrigger(t.docid)

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -23,35 +23,13 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.NotFound
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.RequestEntityTooLarge
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsObject
-import spray.json.JsString
-import spray.json.pimpAny
-import spray.json.pimpString
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import whisk.core.controller.WhiskTriggersApi
-import whisk.core.entity.ActivationId
-import whisk.core.entity.AuthKey
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskTrigger
-import whisk.core.entity.WhiskTriggerPut
+import whisk.core.entity._
 import whisk.core.entity.test.OldWhiskTrigger
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.FullyQualifiedEntityName
 
 /**
  * Tests Trigger API.
@@ -79,7 +57,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val parametersLimit = Parameters.sizeLimit
 
     //// GET /triggers
-    it should "list triggers by default namespace" in {
+    it should "list triggers by default/explicit namespace" in {
         implicit val tid = transid()
         val triggers = (1 to 2).map { i =>
             WhiskTrigger(namespace, aname, Parameters("x", "b"))
@@ -91,6 +69,20 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
             val response = responseAs[List[JsObject]]
             triggers.length should be(response.length)
             triggers forall { a => response contains a.summaryAsJson } should be(true)
+        }
+
+        // it should "list triggers with explicit namespace owned by subject" in {
+        Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[List[JsObject]]
+            triggers.length should be(response.length)
+            triggers forall { a => response contains a.summaryAsJson } should be(true)
+        }
+
+        // it should "reject list triggers with explicit namespace not owned by subject" in {
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
+        Get(s"/$namespace/${collection.path}") ~> sealRoute(routes(auser)) ~> check {
+            status should be(Forbidden)
         }
     }
 
@@ -111,7 +103,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     }
 
     //// GET /triggers/name
-    it should "get trigger by name in default namespace" in {
+    it should "get trigger by name in default/explicit namespace" in {
         implicit val tid = transid()
         val trigger = WhiskTrigger(namespace, aname, Parameters("x", "b"))
         put(entityStore, trigger)
@@ -119,6 +111,19 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
             status should be(OK)
             val response = responseAs[WhiskTrigger]
             response should be(trigger.withoutRules)
+        }
+
+        // it should "get trigger by name in explicit namespace owned by subject" in
+        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> sealRoute(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            response should be(trigger.withoutRules)
+        }
+
+        // it should "reject get trigger by name in explicit namespace not owned by subject" in
+        val auser = WhiskAuth(Subject(), AuthKey()).toIdentity
+        Get(s"/$namespace/${collection.path}/${trigger.name}") ~> sealRoute(routes(auser)) ~> check {
+            status should be(Forbidden)
         }
     }
 

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -51,6 +51,7 @@ import whisk.core.entity.WhiskTrigger
 import whisk.core.entity.WhiskTriggerPut
 import whisk.core.entity.test.OldWhiskTrigger
 import whisk.core.entity.WhiskRule
+import whisk.core.entity.FullyQualifiedEntityName
 
 /**
  * Tests Trigger API.
@@ -123,7 +124,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
     it should "report Conflict if the name was of a different type" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname, aname, aname)
+        val rule = WhiskRule(namespace, aname, FullyQualifiedEntityName(namespace, aname), FullyQualifiedEntityName(namespace, aname))
         put(entityStore, rule)
         Get(s"/$namespace/${collection.path}/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)

--- a/tests/src/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/whisk/core/entity/test/DatastoreTests.scala
@@ -63,6 +63,8 @@ class DatastoreTests extends FlatSpec
         EntityName(s"$n$counter")
     }
 
+    def afullname(implicit namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
+
     after {
         cleanup()
     }
@@ -131,8 +133,8 @@ class DatastoreTests extends FlatSpec
         implicit val tid = transid()
         implicit val basename = EntityName("create rule")
         val rules = Seq(
-            WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action")),
-            WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action")))
+            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")),
+            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")))
         val docs = rules.map { entity =>
             putGetCheck(datastore, entity, WhiskRule)
         }
@@ -176,13 +178,13 @@ class DatastoreTests extends FlatSpec
     it should "reject rule with null arguments" in {
         val name = EntityName("bad rule")
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(null), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(null)), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(""), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName("")), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(" "), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(" ")), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
     }
 
@@ -216,7 +218,7 @@ class DatastoreTests extends FlatSpec
     it should "update rule with a revision" in {
         implicit val tid = transid()
         implicit val basename = EntityName("update rule")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         val docinfo = putGetCheck(datastore, rule, WhiskRule, false)._2.docinfo
         val revRule = WhiskRule(namespace, rule.name, rule.trigger, rule.action).revision[WhiskRule](docinfo.rev)
         putGetCheck(datastore, revRule, WhiskRule)
@@ -264,7 +266,7 @@ class DatastoreTests extends FlatSpec
     it should "fail with document conflict when trying to write the same rule twice without a revision" in {
         implicit val tid = transid()
         implicit val basename = EntityName("create rule twice")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         putGetCheck(datastore, rule, WhiskRule)
         intercept[DocumentConflictException] {
             putGetCheck(datastore, rule, WhiskRule)
@@ -320,7 +322,7 @@ class DatastoreTests extends FlatSpec
     it should "fail with document does not exist when trying to delete the same rule twice" in {
         implicit val tid = transid()
         implicit val basename = EntityName("delete rule twice")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         val doc = putGetCheck(datastore, rule, WhiskRule, false)._1
         assert(Await.result(WhiskRule.del(datastore, doc), dbOpTimeout))
         intercept[NoDocumentException] {

--- a/tests/src/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/whisk/core/entity/test/MigrationEntities.scala
@@ -32,8 +32,8 @@ import whisk.core.entity._
 case class OldWhiskRule(
     namespace: EntityPath,
     override val name: EntityName,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: EntityName,
+    action: EntityName,
     status: Status,
     version: SemVer = SemVer(),
     publish: Boolean = false,
@@ -42,7 +42,12 @@ case class OldWhiskRule(
 
     def toJson = OldWhiskRule.serdes.write(this).asJsObject
 
-    def toWhiskRule = WhiskRule(namespace, name, trigger, action, version, publish, annotations)
+    def toWhiskRule = {
+        WhiskRule(namespace, name,
+            FullyQualifiedEntityName(namespace, trigger),
+            FullyQualifiedEntityName(namespace, action),
+            version, publish, annotations)
+    }
 }
 
 object OldWhiskRule

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -33,22 +33,7 @@ import org.scalatest.junit.JUnitRunner
 
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import whisk.core.entity.ActionLimits
-import whisk.core.entity.ActivationId
-import whisk.core.entity.AuthKey
-import whisk.core.entity.DocId
-import whisk.core.entity.DocInfo
-import whisk.core.entity.DocRevision
-import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
-import whisk.core.entity.LogLimit
-import whisk.core.entity.MemoryLimit
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.Secret
-import whisk.core.entity.SemVer
-import whisk.core.entity.TimeLimit
-import whisk.core.entity.UUID
+import whisk.core.entity._
 import whisk.core.entity.size.SizeInt
 
 @RunWith(classOf[JUnitRunner])
@@ -150,6 +135,92 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
                 EntityName(p)
             }
         }
+    }
+
+    behavior of "FullyQualifiedEntityName"
+
+    it should "deserialize a fully qualified name without a version" in {
+
+        val names = Seq(
+            JsObject("path" -> "a".toJson, "name" -> "b".toJson),
+            JsObject("path" -> "a".toJson, "name" -> "b".toJson, "version" -> "0.0.1".toJson),
+            JsString("a/b"),
+            JsObject("namespace" -> "a".toJson, "name" -> "b".toJson))
+
+        FullyQualifiedEntityName.serdes.read(names(0)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+        FullyQualifiedEntityName.serdes.read(names(1)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"), Some(SemVer()))
+        FullyQualifiedEntityName.serdes.read(names(2)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+
+        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(0))
+        a[DeserializationException] should be thrownBy FullyQualifiedEntityName.serdesAsDocId.read(names(1))
+        FullyQualifiedEntityName.serdesAsDocId.read(names(2)) shouldBe FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))
+    }
+
+    behavior of "Binding"
+
+    it should "desiarilize legacy format" in {
+        val names = Seq(
+            JsObject("path" -> "a".toJson, "name" -> "b".toJson),
+            JsObject("path" -> "a".toJson, "name" -> "b".toJson, "version" -> "0.0.1".toJson),
+            JsString("a/b"),
+            JsObject("namespace" -> "a".toJson, "name" -> "b".toJson),
+            JsObject("namespace" -> "a".toJson, "path" -> "a".toJson, "name" -> "b".toJson),
+            JsObject("name" -> "b".toJson),
+            JsObject())
+
+        WhiskPackage.bindingDeserializer.read(names(0)) shouldBe Some(FullyQualifiedEntityName(EntityPath("a"), EntityName("b")))
+        WhiskPackage.bindingDeserializer.read(names(1)) shouldBe Some(FullyQualifiedEntityName(EntityPath("a"), EntityName("b"), Some(SemVer())))
+        WhiskPackage.bindingDeserializer.read(names(2)) shouldBe Some(FullyQualifiedEntityName(EntityPath("a"), EntityName("b")))
+        WhiskPackage.bindingDeserializer.read(names(3)) shouldBe Some(FullyQualifiedEntityName(EntityPath("a"), EntityName("b")))
+        WhiskPackage.bindingDeserializer.read(names(6)) shouldBe None
+        a[DeserializationException] should be thrownBy WhiskPackage.bindingDeserializer.read(names(4))
+        a[DeserializationException] should be thrownBy WhiskPackage.bindingDeserializer.read(names(5))
+    }
+
+    behavior of "WhiskPackagePut"
+
+    it should "deserialize empty request" in {
+        WhiskPackagePut.serdes.read(JsObject()) shouldBe WhiskPackagePut()
+        WhiskPackagePut.serdes.read(JsObject("binding" -> JsObject())) shouldBe WhiskPackagePut()
+        WhiskPackagePut.serdes.read(JsObject("binding" -> JsNull)) shouldBe WhiskPackagePut()
+        WhiskPackagePut.serdes.read(JsObject("binding" -> "a/b".toJson)) shouldBe WhiskPackagePut(binding = Some(FullyQualifiedEntityName(EntityPath("a"), EntityName("b"))))
+    }
+
+    behavior of "WhiskPackage"
+
+    it should "not deserialize package without binding property" in {
+        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
+        WhiskPackage.serdes.read(JsObject(pkg.toJson.fields + ("binding" -> JsObject()))) shouldBe pkg
+        a[DeserializationException] should be thrownBy WhiskPackage.serdes.read(JsObject(pkg.toJson.fields - "binding"))
+    }
+
+    it should "serialize package with empty binding property" in {
+        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"))
+        WhiskPackage.serdes.write(pkg) shouldBe JsObject(
+            "namespace" -> "a".toJson,
+            "name" -> "b".toJson,
+            "binding" -> JsObject(),
+            "parameters" -> Parameters().toJson,
+            "version" -> SemVer().toJson,
+            "publish" -> JsBoolean(false),
+            "annotations" -> Parameters().toJson)
+    }
+
+    it should "serialize and deserialize package binding" in {
+        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"), Some(FullyQualifiedEntityName(EntityPath("x"), EntityName("y"))))
+        val pkgAsJson = JsObject(
+            "namespace" -> "a".toJson,
+            "name" -> "b".toJson,
+            "binding" -> JsObject("path" -> "x".toJson, "name" -> "y".toJson),
+            "parameters" -> Parameters().toJson,
+            "version" -> SemVer().toJson,
+            "publish" -> JsBoolean(false),
+            "annotations" -> Parameters().toJson)
+        val legacyPkgAsJson = JsObject(pkgAsJson.fields
+            + ("binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson)))
+        WhiskPackage.serdes.write(pkg) shouldBe pkgAsJson
+        WhiskPackage.serdes.read(pkgAsJson) shouldBe pkg
+        WhiskPackage.serdes.read(legacyPkgAsJson) shouldBe pkg
     }
 
     behavior of "SemVer"

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -18,42 +18,26 @@ package whisk.core.entity.test
 
 import java.time.Clock
 import java.time.Instant
+
 import scala.concurrent.Await
+import scala.language.postfixOps
 import scala.util.Try
+
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+
+import akka.event.Logging.InfoLevel
+import common.WskActorSystem
 import spray.json.JsObject
 import whisk.core.WhiskConfig
 import whisk.core.database.test.DbUtils
-import whisk.core.entity.ActivationId
-import whisk.core.entity.AuthKey
-import whisk.core.entity.Binding
-import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskEntityQueries.listAllInNamespace
-import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
-import whisk.core.entity.WhiskEntityQueries.listCollectionInAnyNamespace
-import whisk.core.entity.WhiskEntityQueries.listCollectionByName
-import whisk.core.entity.WhiskEntityQueries.listCollectionInNamespace
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.WhiskPackage
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.WhiskTrigger
-import org.scalatest.BeforeAndAfterAll
-import scala.language.postfixOps
-import akka.event.Logging.InfoLevel
-
-import common.WskActorSystem
+import whisk.core.entity._
 import whisk.core.entity.FullyQualifiedEntityName
+import whisk.core.entity.WhiskEntityQueries._
 
 @RunWith(classOf[JUnitRunner])
 class ViewTests extends FlatSpec
@@ -196,8 +180,8 @@ class ViewTests extends FlatSpec
             WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
             WhiskPackage(namespace1, aname),
             WhiskPackage(namespace1, aname),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
+            WhiskPackage(namespace1, aname, Some(FullyQualifiedEntityName(namespace2, aname))),
+            WhiskPackage(namespace1, aname, Some(FullyQualifiedEntityName(namespace2, aname))),
             WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
 
@@ -213,8 +197,8 @@ class ViewTests extends FlatSpec
             WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
             WhiskPackage(namespace2, aname),
             WhiskPackage(namespace2, aname),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))),
+            WhiskPackage(namespace2, aname, Some(FullyQualifiedEntityName(namespace1, aname))),
+            WhiskPackage(namespace2, aname, Some(FullyQualifiedEntityName(namespace1, aname))),
             WhiskActivation(namespace2, aname, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now))
@@ -297,13 +281,13 @@ class ViewTests extends FlatSpec
         implicit val entities = Seq(
             WhiskPackage(namespace1, aname, publish = true),
             WhiskPackage(namespace1, aname, publish = false),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname)), publish = true),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
+            WhiskPackage(namespace1, aname, Some(FullyQualifiedEntityName(namespace2, aname)), publish = true),
+            WhiskPackage(namespace1, aname, Some(FullyQualifiedEntityName(namespace2, aname))),
 
             WhiskPackage(namespace2, aname, publish = true),
             WhiskPackage(namespace2, aname, publish = false),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname)), publish = true),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))))
+            WhiskPackage(namespace2, aname, Some(FullyQualifiedEntityName(namespace1, aname)), publish = true),
+            WhiskPackage(namespace2, aname, Some(FullyQualifiedEntityName(namespace1, aname))))
 
         entities foreach { put(datastore, _) }
         waitOnView(datastore, namespace1, entities.length / 2)

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -105,8 +105,8 @@ var packageBindCmd = &cobra.Command{
     }
 
     binding := whisk.Binding{
-      Name:      pkgQName.entityName,
-      Namespace: pkgQName.namespace,
+      Name: pkgQName.entityName,
+      Path: pkgQName.namespace,
     }
 
     p := &whisk.BindingPackage{

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -199,8 +199,8 @@ var ruleCreateCmd = &cobra.Command{
 
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        triggerName := args[1]
-        actionName := args[2]
+        triggerName := getQualifiedName(args[1], Properties.Namespace)
+        actionName := getQualifiedName(args[2], Properties.Namespace)
 
         rule := &whisk.Rule{
             Name:    ruleName,
@@ -257,8 +257,8 @@ var ruleUpdateCmd = &cobra.Command{
 
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        triggerName := args[1]  //MWD qualified name?
-        actionName := args[2]   //MWD qualified name?
+        triggerName := getQualifiedName(args[1], Properties.Namespace)
+        actionName := getQualifiedName(args[2], Properties.Namespace)
 
         if (flags.common.shared == "yes") {
             shared = true

--- a/tools/cli/go-whisk/whisk/package.go
+++ b/tools/cli/go-whisk/whisk/package.go
@@ -91,7 +91,7 @@ func (p *BindingPackage) GetName() string {
 }
 
 type Binding struct {
-    Namespace string `json:"namespace,omitempty"`
+    Path      string `json:"path,omitempty"`
     Name      string `json:"name,omitempty"`
 }
 

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -35,8 +35,8 @@ type Rule struct {
     Version   string    `json:"version,omitempty"`
     Publish   bool      `json:"publish,omitempty"`
     Status  string      `json:"status"`
-    Trigger string      `json:"trigger"`
-    Action  string      `json:"action"`
+    Trigger interface{} `json:"trigger"`
+    Action  interface{} `json:"action"`
 }
 
 type RuleListOptions struct {


### PR DESCRIPTION
Additional refactoring on top of #1490.
0. Replace Binding type with FullyQualifiedEntityName (Binding type was Binding(namespace: EntityPath, name: EntityName) which is the same as FullyQualifiedEntityName with no Version defined).
1. Introduce a common trait for computing referenced entities.
2. Use this trait for packages, rules and actions.
3. Add more tests related to entitlement.
