### PR TITLE
replace nproc limit with pids-limit to limit number of forks

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -70,7 +70,7 @@ trait ContainerUtils extends Logging {
         val capabilityArg = Array("--cap-drop", "NET_RAW", "--cap-drop", "NET_ADMIN")
         val consulServiceIgnore = Array("-e", "SERVICE_IGNORE=true")
         val fileHandleLimit = Array("--ulimit", "nofile=64:64")
-        val processLimit = Array("--ulimit", "nproc=512:512")
+        val processLimit = Array("--pids-limit", "64")
         val securityOpts = policy map { p => Array("--security-opt", s"apparmor:${p}") } getOrElse (Array.empty[String])
         val containerNetwork = Array("--net", network)
 


### PR DESCRIPTION
nproc ulimit does not work with docker containers. with docker 1.12 we can leverage the pid limit on cgroups using the --pids-limit flag. 