### PR TITLE
apigateway ansible integration

### DIFF
--- a/ansible/apigateway.yml
+++ b/ansible/apigateway.yml
@@ -1,0 +1,5 @@
+
+- hosts: all:!ansible
+  roles:
+  - apigateway
+

--- a/ansible/environments/local/hosts
+++ b/ansible/environments/local/hosts
@@ -24,3 +24,10 @@ ansible ansible_connection=local
 ; db group is only used if db_provider is CouchDB
 [db]
 172.17.0.1 ansible_connection=local
+
+[redis]
+172.17.0.1 ansible_connection=local
+
+[apigateway]
+172.17.0.1 ansible_connection=local
+

--- a/ansible/environments/mac/hosts.j2.ini
+++ b/ansible/environments/mac/hosts.j2.ini
@@ -24,6 +24,12 @@ ansible ansible_connection=local
 [db]
 {{ docker_machine_ip }}
 
+[redis]
+{{ docker_machine_ip }}
+
+[apigateway]
+{{ docker_machine_ip }}
+
 ; define variables
 [all:vars]
 ansible_connection=ssh

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -60,6 +60,14 @@ db:
   - guest
   - whisk.system
 
+apigateway:
+  port:
+    api: 9000
+    mgmt: 9001
+
+redis:
+  port: 6379
+
 linux:
   version: 4.4.0-31
 

--- a/ansible/roles/apigateway/tasks/clean.yml
+++ b/ansible/roles/apigateway/tasks/clean.yml
@@ -1,0 +1,19 @@
+---
+# Remove redis and apigateway containers.
+
+- name: remove apigateway
+  docker_container:
+    name: apigateway
+    state: absent
+  ignore_errors: True
+
+- name: remove apigateway docker image
+  docker_image:
+    name: apigateway
+    state: absent
+
+- name: remove redis
+  docker_container:
+    name: redis
+    state: absent
+  ignore_errors: True

--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -1,0 +1,37 @@
+---
+# This role will install redis and apigateway
+
+- name: (re)start redis
+  docker_container:
+    name: redis
+    image: redis
+    state: started
+    recreate: true
+    restart_policy: "{{ docker.restart.policy }}"
+    ports:
+      - "{{ redis.port }}:6379"
+
+- name: (re)start apigateway
+  docker_container:
+    name: apigateway
+    image: openwhisk/apigateway
+    state: started
+    recreate: true
+    restart_policy: "{{ docker.restart.policy }}"
+    hostname: apigateway
+    env:
+      "REDIS_HOST": "{{ groups['redis'] | first }}"
+      "REDIS_PORT": "{{ redis.port }}"
+      "PUBLIC_MANAGEDURL_HOST": "{{ groups['apigateway'] | first }}"
+      "PUBLIC_MANAGEDURL_PORT": "{{ apigateway.port.mgmt }}"
+    ports:
+      - "{{ apigateway.port.mgmt }}:8080"
+      - "{{ apigateway.port.api }}:9000"
+
+- name: wait until the API Gateway in this host is up and running
+  uri:
+    url: "http://{{ groups['apigateway'] | first }}:{{ apigateway.port.api }}/v1/apis"
+  register: result
+  until: result.status == 200
+  retries: 12
+  delay: 5

--- a/ansible/roles/apigateway/tasks/main.yml
+++ b/ansible/roles/apigateway/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# This role will install controller in group 'controllers' in the environment inventory
+# In deploy mode it will deploy controllers.
+# In clean mode it will remove the controller containers.
+
+- include: deploy.yml
+  when: mode == "deploy"
+
+- include: clean.yml
+  when: mode == "clean"
+

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -26,6 +26,7 @@ cd $ROOTDIR/ansible
 
 $ANSIBLE_CMD wipe.yml
 $ANSIBLE_CMD openwhisk.yml
+$ANSIBLE_CMD apigateway.yml
 
 cd $ROOTDIR
 cat whisk.properties

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -140,6 +140,7 @@ $script_end = <<SCRIPT
   su vagrant -c 'ansible-playbook -i environments/local wipe.yml'
   su vagrant -c 'ansible-playbook -i environments/local openwhisk.yml'
   su vagrant -c 'ansible-playbook -i environments/local postdeploy.yml'
+  su vagrant -c 'ansible-playbook -i environments/local apigateway.yml'
   
   # Setup OpenWhisk CLI
   su vagrant -c 'mkdir ${HOME}/bin'


### PR DESCRIPTION
This PR adds the ability to deploy the apigateway container from ansible.
This will allow us to test the different environments (travis, mac, vagrant)  to see apigateway comes up OK

Not documented in ansible README or other READMEs on purpose for now, until the other pieces (cli, controller, routemgmtactions) come into play

PG1 881 (result=blue)