### PR TITLE
Allow rules to reference actions in packages.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -87,6 +87,7 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat9(ActivationMessage.apply)
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -44,9 +44,10 @@ import whisk.http.Messages
 protected[core] class EntityPath private (private val path: Seq[String]) extends AnyVal {
     def namespace: String = path.foldLeft("")((a, b) => if (a != "") a.trim + EntityPath.PATHSEP + b.trim else b.trim)
     def addpath(e: EntityName) = EntityPath(path :+ e.name)
-    def root = EntityPath(Seq(path(0)))
-    def last = EntityName(path.last)
-    def defaultPackage = path.size == 1 // if only one element in the path, then it's the namespace with a default package
+    def relpath: Option[EntityPath] = Try(EntityPath(path.drop(1))).toOption
+    def root: EntityName = EntityName(path.head)
+    def last: EntityName = EntityName(path.last)
+    def defaultPackage: Boolean = path.size == 1 // if only one element in the path, then it's the namespace with a default package
     def toJson = JsString(namespace)
     def apply() = namespace
     override def toString = namespace
@@ -57,7 +58,7 @@ protected[core] class EntityPath private (private val path: Seq[String]) extends
      */
     def resolveNamespace(newNamespace: EntityName): EntityPath = {
         // check if namespace is default
-        if (root == EntityPath.DEFAULT) {
+        if (root.toPath == EntityPath.DEFAULT) {
             val newPath = path.updated(0, newNamespace.name)
             EntityPath(newPath)
         } else this

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -61,6 +61,20 @@ case class WhiskActionPut(
     protected[core] def replace(exec: Exec) = {
         WhiskActionPut(Some(exec), parameters, limits, version, publish, annotations)
     }
+
+    /**
+     * Resolves sequence components if they contain default namespace.
+     */
+    protected[core] def resolve(namespace: EntityName): WhiskActionPut = {
+        exec map {
+            case SequenceExec(code, components) =>
+                val newExec = SequenceExec(code, components map {
+                    c => FullyQualifiedEntityName(c.path.resolveNamespace(namespace), c.name)
+                })
+                WhiskActionPut(Some(newExec), parameters, limits, version, publish, annotations)
+            case _ => this
+        } getOrElse this
+    }
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -60,16 +60,10 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
      * The name of the entity qualified with its namespace and version for
      * creating unique keys in backend services.
      */
-    final def fullyQualifiedName(withVersion: Boolean) = {
-        if (!withVersion) {
-            WhiskEntity.qualifiedName(namespace, en)
-        } else {
-            WhiskEntity.fullyQualifiedName(namespace, en, version)
-        }
-    }
+    final def fullyQualifiedName(withVersion: Boolean) = FullyQualifiedEntityName(namespace, en, if (withVersion) Some(version) else None)
 
     /** The primary key for the entity in the datastore */
-    override final def docid = DocId(WhiskEntity.qualifiedName(namespace, en))
+    override final def docid = fullyQualifiedName(false).toDocId
 
     /**
      * Returns a JSON object with the fields specific to this abstract class.
@@ -108,31 +102,10 @@ object WhiskEntity {
     val sharedFieldName = "publish"
 
     /**
-     * Gets fully qualified name of an entity based on its namespace and entity name.
-     */
-    def qualifiedName(namespace: EntityPath, name: EntityName) = {
-        s"$namespace${EntityPath.PATHSEP}$name"
-    }
-
-    /**
      * Gets fully qualified name of an activation based on its namespace and activation id.
      */
     def qualifiedName(namespace: EntityPath, activationId: ActivationId) = {
         s"$namespace${EntityPath.PATHSEP}$activationId"
-    }
-
-    /**
-     * Gets fully qualified name of an entity based on its namespace, entity name and version.
-     */
-    def fullyQualifiedName(namespace: EntityPath, name: EntityName, version: SemVer) = {
-        s"$namespace${EntityPath.PATHSEP}${versionedName(name, version)}"
-    }
-
-    /**
-     * Gets versioned name of an entity based on its entity name and version.
-     */
-    def versionedName(name: EntityName, version: SemVer) = {
-        s"$name${EntityPath.PATHSEP}$version"
     }
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -37,7 +37,15 @@ case class WhiskPackagePut(
     parameters: Option[Parameters] = None,
     version: Option[SemVer] = None,
     publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None)
+    annotations: Option[Parameters] = None) {
+
+    /**
+     * Resolves the binding if it contains the default namespace.
+     */
+    protected[core] def resolve(namespace: EntityName): WhiskPackagePut = {
+        WhiskPackagePut(binding.map(_.resolve(namespace.toPath)), parameters, version, publish, annotations)
+    }
+}
 
 /**
  * A WhiskPackage provides an abstraction of the meta-data for a whisk package
@@ -200,7 +208,7 @@ object WhiskPackage
  * namespace and package name.
  */
 case class Binding(namespace: EntityPath, name: EntityName) {
-    private def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
+    def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
     def docid = fullyQualifiedName.toDocId
     override def toString = fullyQualifiedName.toString
 

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -200,8 +200,9 @@ object WhiskPackage
  * namespace and package name.
  */
 case class Binding(namespace: EntityPath, name: EntityName) {
-    def docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-    override def toString = WhiskEntity.qualifiedName(namespace, name)
+    private def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
+    def docid = fullyQualifiedName.toDocId
+    override def toString = fullyQualifiedName.toString
 
     /**
      * Returns a Binding namespace if it is the default namespace

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -43,7 +43,7 @@ case class WhiskRulePut(
     /**
      * Resolves the trigger and action name if they contains the default namespace.
      */
-    def resolve(namespace: EntityName): WhiskRulePut = {
+    protected[core] def resolve(namespace: EntityName): WhiskRulePut = {
         val t = trigger map { _.resolve(namespace) }
         val a = action map { _.resolve(namespace) }
         WhiskRulePut(t, a, version, publish, annotations)

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskRule.scala
@@ -21,6 +21,7 @@ import scala.util.Success
 import scala.util.Try
 
 import spray.json.DefaultJsonProtocol
+import spray.json.DeserializationException
 import spray.json.JsObject
 import spray.json.JsString
 import spray.json.JsValue
@@ -33,11 +34,21 @@ import whisk.core.database.DocumentFactory
  * that are auto-assigned or derived from URI: namespace, name, status.
  */
 case class WhiskRulePut(
-    trigger: Option[EntityName] = None,
-    action: Option[EntityName] = None,
+    trigger: Option[FullyQualifiedEntityName] = None,
+    action: Option[FullyQualifiedEntityName] = None,
     version: Option[SemVer] = None,
     publish: Option[Boolean] = None,
-    annotations: Option[Parameters] = None)
+    annotations: Option[Parameters] = None) {
+
+    /**
+     * Resolves the trigger and action name if they contains the default namespace.
+     */
+    def resolve(namespace: EntityName): WhiskRulePut = {
+        val t = trigger map { _.resolve(namespace) }
+        val a = action map { _.resolve(namespace) }
+        WhiskRulePut(t, a, version, publish, annotations)
+    }
+}
 
 /**
  * A WhiskRule provides an abstraction of the meta-data for a whisk rule.
@@ -61,8 +72,8 @@ case class WhiskRulePut(
 case class WhiskRule(
     namespace: EntityPath,
     override val name: EntityName,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: FullyQualifiedEntityName,
+    action: FullyQualifiedEntityName,
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters())
@@ -91,8 +102,8 @@ case class WhiskRuleResponse(
     namespace: EntityPath,
     name: EntityName,
     status: Status,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: FullyQualifiedEntityName,
+    action: FullyQualifiedEntityName,
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters()) {
@@ -189,16 +200,47 @@ object WhiskRule
     with DefaultJsonProtocol {
 
     override val collectionName = "rules"
-    override implicit val serdes = jsonFormat7(WhiskRule.apply)
+
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
+    private val caseClassSerdes = jsonFormat7(WhiskRule.apply)
+
+    override implicit val serdes = new RootJsonFormat[WhiskRule] {
+        def write(r: WhiskRule) = caseClassSerdes.write(r)
+
+        def read(value: JsValue) = Try {
+            caseClassSerdes.read(value)
+        } recover {
+            case DeserializationException(_, _, List("trigger")) | DeserializationException(_, _, List("action")) =>
+                val namespace = value.asJsObject.fields("namespace").convertTo[EntityPath]
+                val actionName = value.asJsObject.fields("action")
+                val triggerName = value.asJsObject.fields("trigger")
+
+                val refs = Seq(actionName, triggerName).map { name =>
+                    Try {
+                        FullyQualifiedEntityName(namespace, EntityName.serdes.read(name))
+                    } match {
+                        case Success(n) => n
+                        case Failure(t) => deserializationError(t.getMessage)
+                    }
+                }
+                val fields = value.asJsObject.fields + ("action" -> refs(0).toDocId.toJson) + ("trigger" -> refs(1).toDocId.toJson)
+                caseClassSerdes.read(JsObject(fields))
+        } match {
+            case Success(r) => r
+            case Failure(t) => deserializationError(t.getMessage)
+        }
+    }
 
     override val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskRule) = w.docid.asDocInfo
 }
 
 object WhiskRuleResponse extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat8(WhiskRuleResponse.apply)
 }
 
 object WhiskRulePut extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat5(WhiskRulePut.apply)
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -44,12 +44,6 @@ package object types {
     type AuthStore = ArtifactStore[WhiskAuth]
     type EntityStore = ArtifactStore[WhiskEntity]
     type ActivationStore = ArtifactStore[WhiskActivation]
-
-    // A placeholder type should we change the trigger and action references
-    // to a type that more explicitly captures the namespace, name, and version
-    // which are currently encoded in one string as DocId.id
-    type Trigger = EntityName
-    type Action = EntityName
 }
 
 protected[core] trait WhiskDocument

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -18,6 +18,7 @@ package whisk.core.entity
 
 import spray.json.DefaultJsonProtocol
 import whisk.core.database.DocumentFactory
+import spray.json._
 
 /**
  * WhiskTriggerPut is a restricted WhiskTrigger view that eschews properties
@@ -39,7 +40,7 @@ case class WhiskTriggerPut(
  * @param status status of the rule
  */
 case class ReducedRule(
-    action: EntityPath,
+    action: FullyQualifiedEntityName,
     status: Status)
 
 /**
@@ -68,7 +69,7 @@ case class WhiskTrigger(
     version: SemVer = SemVer(),
     publish: Boolean = false,
     annotations: Parameters = Parameters(),
-    rules: Option[Map[EntityPath, ReducedRule]] = None)
+    rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
     extends WhiskEntity(name) {
 
     require(limits != null, "limits undefined")
@@ -84,9 +85,9 @@ case class WhiskTrigger(
      * @param rule The rule, that will be fired by this trigger. It's from type ReducedRule. This type
      * contains the fully qualified name of the action to be fired by the rule and the status of the rule.
      */
-    def addRule(rulename: EntityPath, rule: ReducedRule) = {
+    def addRule(rulename: FullyQualifiedEntityName, rule: ReducedRule) = {
         val entry = rulename -> rule
-        val links = rules getOrElse Map[EntityPath, ReducedRule]()
+        val links = rules getOrElse Map[FullyQualifiedEntityName, ReducedRule]()
         WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
     }
 
@@ -96,12 +97,13 @@ case class WhiskTrigger(
      * @param rule The fully qualified name of the rule, that should be removed from the
      * trigger. After removing the rule, it won't be fired anymore by this trigger.
      */
-    def removeRule(rule: EntityPath) = {
+    def removeRule(rule: FullyQualifiedEntityName) = {
         WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
     }
 }
 
 object ReducedRule extends DefaultJsonProtocol {
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     implicit val serdes = jsonFormat2(ReducedRule.apply)
 }
 
@@ -111,6 +113,8 @@ object WhiskTrigger
     with DefaultJsonProtocol {
 
     override val collectionName = "triggers"
+
+    private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
     override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
 
     override val cacheEnabled = true

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -23,15 +23,8 @@ import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
 import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.json.DefaultJsonProtocol.LongJsonFormat
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsNumber
-import spray.json.JsObject
-import spray.json.JsString
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.pimpAny
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import spray.routing.Directives
 import spray.routing.Rejection
 import spray.routing.StandardRoute

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -46,7 +46,7 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
     protected implicit val executionContext: ExecutionContext
 
     /** An entitlement service to check access rights. */
-    protected val entitlementService: EntitlementService
+    protected val entitlementProvider: EntitlementProvider
 
     /** The collection type for this trait. */
     protected val collection: Collection
@@ -67,53 +67,20 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
         resource: Resource)(
             implicit transid: TransactionId): RequestContext => Unit = {
         val right = collection.determineRight(method, resource.entity)
-        authorizeAndContinue(right, user, resource, () => dispatchOp(user, right, resource))
-    }
 
-    /** Checks entitlement and if authorized, continues with next handler. */
-    protected def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resource: Resource,
-        next: () => RequestContext => Unit,
-        recover: Option[Throwable => RequestContext => Unit] = None)(
-            implicit transid: TransactionId): RequestContext => Unit = {
-        onComplete(entitlementService.check(user, right, resource)) {
-            // do not use "authorize" directive here because it does not compose
-            // hence for nested authorizations the rejection list will end up empty
-            case Success(true)                       => next()
-            case Success(false)                      => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
-            case Failure(t) if recover.isDefined     => recover.get(t)
-            case Failure(r: RejectRequest)           => terminate(r.code, r.message)
-            case Failure(t)                          => terminate(InternalServerError, t.getMessage)
+        onComplete(entitlementProvider.check(user, right, resource)) {
+            case Success(true) => dispatchOp(user, right, resource)
+            case t             => handleEntitlementFailure(t)
         }
     }
 
-    protected def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resources: Set[Resource],
-        next: () => RequestContext => Unit)(
-            recover: Throwable => RequestContext => Unit)(
-                implicit transid: TransactionId): RequestContext => Unit = {
-        authorizeAndContinue(right, user, resources, next, Some(recover))
-    }
-
-    private def authorizeAndContinue(
-        right: Privilege,
-        user: Identity,
-        resources: Set[Resource],
-        next: () => RequestContext => Unit,
-        recover: Option[Throwable => RequestContext => Unit])(
-            implicit transid: TransactionId): RequestContext => Unit = {
-        onComplete(entitlementService.check(user, right, resources)) {
-            // do not use "authorize" directive here because it does not compose
-            // hence for nested authorizations the rejection list will end up empty
-            case Success(true)                   => next()
-            case Success(false)                  => recover.map(_(RejectRequest(Forbidden))) getOrElse terminate(Forbidden)
-            case Failure(t) if recover.isDefined => recover.get(t)
-            case Failure(r: RejectRequest)       => terminate(r.code, r.message)
-            case Failure(t)                      => terminate(InternalServerError, t.getMessage)
+    protected def handleEntitlementFailure(failure: Try[Boolean])(
+        implicit transid: TransactionId): RequestContext => Unit = {
+        failure match {
+            case Success(false)            => terminate(Forbidden)
+            case Failure(r: RejectRequest) => terminate(r.code, r.message)
+            case Failure(t)                => terminate(InternalServerError, t.getMessage)
+            case _ /*Success(true)*/       => terminate(InternalServerError, "Should not reach here.")
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -31,9 +31,7 @@ import spray.routing.RequestContext
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.entity.EntityPath
-import whisk.core.entitlement.EntitlementService
-import whisk.core.entitlement.Collection
-import whisk.core.entitlement.EntitlementService
+import whisk.core.entitlement._
 import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -22,9 +22,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.ActorSystem
 import akka.event.Logging.InfoLevel
 import whisk.core.WhiskConfig
-import whisk.core.entitlement.EntitlementService
-import whisk.core.entitlement.LocalEntitlementService
-import whisk.core.entitlement.RemoteEntitlementService
+import whisk.core.entitlement._
 import whisk.core.loadBalancer.{ LoadBalancer, LoadBalancerService }
 import scala.language.postfixOps
 import whisk.core.entity.ActivationId.ActivationIdGenerator
@@ -32,7 +30,7 @@ import whisk.core.iam.NamespaceProvider
 
 object WhiskServices {
 
-    def requiredProperties = WhiskConfig.loadbalancerHost ++ WhiskConfig.consulServer ++ EntitlementService.requiredProperties
+    def requiredProperties = WhiskConfig.loadbalancerHost ++ WhiskConfig.consulServer ++ EntitlementProvider.requiredProperties
 
     def consulServer(config: WhiskConfig) = config.consulServer
 
@@ -44,7 +42,7 @@ object WhiskServices {
         // remote entitlement service requires a host:port definition. If not given,
         // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
         if (config.entitlementHost.startsWith(":")) {
-            new LocalEntitlementService(config, loadBalancer, iam)
+            new LocalEntitlementProvider(config, loadBalancer, iam)
         } else {
             new RemoteEntitlementService(config, loadBalancer, iam, timeout)
         }
@@ -75,7 +73,7 @@ trait WhiskServices {
     protected val whiskConfig: WhiskConfig
 
     /** An entitlement service to check access rights. */
-    protected val entitlementService: EntitlementService
+    protected val entitlementProvider: EntitlementProvider
 
     /** An identity provider. */
     protected val iam: NamespaceProvider

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -29,7 +29,7 @@ import spray.routing.Route
 import akka.actor.ActorContext
 import akka.event.Logging.InfoLevel
 import akka.event.Logging.LogLevel
-import whisk.core.entitlement.EntitlementService
+import whisk.core.entitlement.EntitlementProvider
 
 /**
  * The Controller is the service that provides the REST API for OpenWhisk.
@@ -90,9 +90,9 @@ object Controller {
     def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
         RestAPIVersion_v1.requiredProperties ++
         LoadBalancerService.requiredProperties ++
-        EntitlementService.requiredProperties
+        EntitlementProvider.requiredProperties
 
-    def optionalProperties = EntitlementService.optionalProperties
+    def optionalProperties = EntitlementProvider.optionalProperties
 
     // akka-style factory to create a Controller object
     private class ServiceBuilder(config: WhiskConfig, instance: Int) extends Creator[Controller] {

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -27,19 +27,19 @@ import spray.json._
 import spray.routing.Directive.pimpApply
 import spray.routing.RequestContext
 import whisk.common.TransactionId
+import whisk.core.database.DocumentTypeMismatchException
 import whisk.core.database.NoDocumentException
 import whisk.core.entitlement._
 import whisk.core.entity._
 import whisk.core.entity.types.EntityStore
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
-import whisk.core.database.DocumentTypeMismatchException
 
 object WhiskPackagesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
 }
 
-trait WhiskPackagesApi extends WhiskCollectionAPI {
+trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
     services: WhiskServices =>
 
     protected override val collection = Collection(Collection.PACKAGES)
@@ -73,28 +73,16 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskPackagePut]) { content =>
                 val docid = FullyQualifiedEntityName(namespace, name).toDocId
+                val request = content.resolve(namespace.root)
 
-                def doput() = {
-                    putEntity(WhiskPackage, entityStore, docid, overwrite,
-                        update(content) _, () => create(content, namespace, name))
-                }
+                request.binding.map { b => info(this, "checking if package is accessible") }
+                val referencedentities = referencedEntities(request)
 
-                def abort(t: Throwable) = {
-                    val r = rewriteFailure(t)
-                    terminate(r.code, r.message)
-                }
-
-                content.binding.map(_.resolve(namespace)) map {
-                    case binding =>
-                        info(this, "checking if package is accessible")
-                        val referencedPackage = Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name()))
-                        onComplete(entitlementProvider.check(user, Privilege.READ, Set(referencedPackage))) {
-                            case Success(true) => doput()
-                            case failure       => rewriteEntitlementFailure(failure)
-                        }
-                } getOrElse {
-                    info(this, "no binding specified")
-                    doput()
+                onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
+                    case Success(true) =>
+                        putEntity(WhiskPackage, entityStore, docid, overwrite,
+                            update(request) _, () => create(request, namespace, name))
+                    case failure => rewriteEntitlementFailure(failure)
                 }
             }
         }
@@ -201,6 +189,22 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
     }
 
     /**
+     * Validates that a referenced binding exists.
+     */
+    private def checkBinding(binding: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Unit] = {
+        WhiskPackage.get(entityStore, binding.toDocId) recoverWith {
+            case t: NoDocumentException           => Future.failed(RejectRequest(BadRequest, Messages.bindingDoesNotExist))
+            case t: DocumentTypeMismatchException => Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
+            case t                                => Future.failed(RejectRequest(BadRequest, t))
+        } flatMap {
+            // trying to create a new package binding that refers to another binding
+            case provider if provider.binding.nonEmpty => Future.failed(RejectRequest(BadRequest, Messages.bindingCannotReferenceBinding))
+            // or creating a package binding that refers to a package
+            case _                                     => Future.successful({})
+        }
+    }
+
+    /**
      * Creates a WhiskPackage from PUT content, generating default values where necessary.
      * If this is a binding, confirm the referenced package exists.
      */
@@ -234,21 +238,21 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
                 // pre-existing entity is a package, cannot make it a binding
                 Future.failed(RejectRequest(Conflict, Messages.packageCannotBecomeBinding))
             }
-        } getOrElse {
-            Future.successful {
-                WhiskPackage(
-                    wp.namespace,
-                    wp.name,
-                    wp.binding,
-                    content.parameters getOrElse wp.parameters,
-                    content.version getOrElse wp.version.upPatch,
-                    content.publish getOrElse wp.publish,
-                    // override any binding annotation from PUT (always set by the controller)
-                    (content.annotations map {
-                        _ -- WhiskPackage.bindingFieldName
-                    } getOrElse wp.annotations) ++ bindingAnnotation(wp.binding)).
-                    revision[WhiskPackage](wp.docinfo.rev)
-            }
+        } getOrElse Future.successful({})
+
+        validateBinding map { _ =>
+            WhiskPackage(
+                wp.namespace,
+                wp.name,
+                content.binding orElse wp.binding,
+                content.parameters getOrElse wp.parameters,
+                content.version getOrElse wp.version.upPatch,
+                content.publish getOrElse wp.publish,
+                // override any binding annotation from PUT (always set by the controller)
+                (content.annotations getOrElse wp.annotations)
+                    -- WhiskPackage.bindingFieldName
+                    ++ bindingAnnotation(content.binding orElse wp.binding)).
+                revision[WhiskPackage](wp.docinfo.rev)
         }
     }
 
@@ -258,7 +262,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI {
         failure match {
             case Failure(RejectRequest(NotFound, _)) => terminate(BadRequest, Messages.bindingDoesNotExist)
             case Failure(RejectRequest(Conflict, _)) => terminate(Conflict, Messages.requestedBindingIsNotValid)
-            case _ => super.handleEntitlementFailure(failure)
+            case _                                   => super.handleEntitlementFailure(failure)
         }
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -21,13 +21,10 @@ import scala.concurrent.ExecutionContext
 import spray.http.AllOrigins
 import spray.http.HttpHeaders.`Access-Control-Allow-Origin`
 import spray.http.HttpHeaders.`Access-Control-Allow-Headers`
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.PermanentRedirect
-import spray.http.StatusCodes.{ OK, PermanentRedirect }
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
-import spray.json.JsObject
-import spray.json.pimpAny
+import spray.json._
 import spray.routing.Directive.pimpApply
 import spray.routing.Directives
 import spray.routing.Route
@@ -35,8 +32,8 @@ import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.whiskVersionDate
 import whisk.core.WhiskConfig.whiskVersionBuildno
-import whisk.core.entitlement.{ Collection, EntitlementService }
-import whisk.core.entity.{ WhiskActivationStore, WhiskAuthStore, WhiskEntityStore }
+import whisk.core.entitlement._
+import whisk.core.entity._
 import whisk.core.entity.types.{ ActivationStore, EntityStore }
 import whisk.core.loadBalancer.LoadBalancerService
 import akka.event.Logging.LogLevel
@@ -188,7 +185,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
             override val iam: NamespaceProvider,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val executionContext: ExecutionContext)
         extends WhiskNamespacesApi {
         setVerbosity(verbosity)
@@ -202,7 +199,7 @@ protected[controller] class RestAPIVersion_v1(
             override val entityStore: EntityStore,
             override val activationStore: ActivationStore,
             override val iam: NamespaceProvider,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationIdFactory: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,
@@ -221,7 +218,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             implicit override val entityStore: EntityStore,
             override val iam: NamespaceProvider,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationStore: ActivationStore,
             override val activationIdFactory: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
@@ -239,7 +236,7 @@ protected[controller] class RestAPIVersion_v1(
             implicit override val actorSystem: ActorSystem,
             override val entityStore: EntityStore,
             override val iam: NamespaceProvider,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationIdFactory: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,
@@ -254,7 +251,7 @@ protected[controller] class RestAPIVersion_v1(
         val apiversion: String,
         val verbosity: LogLevel)(
             implicit override val activationStore: ActivationStore,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val executionContext: ExecutionContext)
         extends WhiskActivationsApi {
         setVerbosity(verbosity)
@@ -266,7 +263,7 @@ protected[controller] class RestAPIVersion_v1(
         val verbosity: LogLevel)(
             implicit override val entityStore: EntityStore,
             override val iam: NamespaceProvider,
-            override val entitlementService: EntitlementService,
+            override val entitlementProvider: EntitlementProvider,
             override val activationIdFactory: ActivationIdGenerator,
             override val loadBalancer: LoadBalancerService,
             override val consulServer: String,

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -45,7 +45,7 @@ object WhiskRulesApi {
 }
 
 /** A trait implementing the rules API */
-trait WhiskRulesApi extends WhiskCollectionAPI {
+trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
     services: WhiskServices =>
 
     protected override val collection = Collection(Collection.RULES)
@@ -98,16 +98,6 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                 }
             }
         }
-    }
-
-    private def referencedEntities(content: WhiskRulePut) = {
-        val triggerResource = content.trigger.map {
-            t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name()))
-        }
-        val actionResource = content.action map {
-            a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name()))
-        }
-        Set(triggerResource, actionResource).flatten
     }
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Rules.scala
@@ -21,37 +21,17 @@ import scala.util.Failure
 import scala.util.Success
 
 import akka.actor.ActorSystem
-import spray.http.StatusCodes.BadRequest
-import spray.http.StatusCodes.Conflict
-import spray.http.StatusCodes.InternalServerError
-import spray.http.StatusCodes.OK
-import spray.http.StatusCodes.NotFound
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DeserializationException
 import spray.routing.Directive.pimpApply
 import spray.routing.RequestContext
-import spray.routing.directives.OnCompleteFutureMagnet.apply
-import spray.routing.directives.ParamDefMagnet.apply
 import whisk.common.TransactionId
 import whisk.core.database.DocumentConflictException
 import whisk.core.database.NoDocumentException
-import whisk.core.entitlement.Collection
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.ReducedRule
-import whisk.core.entity.SemVer
-import whisk.core.entity.Status
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.WhiskRulePut
-import whisk.core.entity.WhiskTrigger
+import whisk.core.entitlement._
+import whisk.core.entity._
 import whisk.core.entity.types.EntityStore
-import whisk.core.entity.Identity
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages._
 
@@ -105,13 +85,29 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
     override def create(user: Identity, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
         parameter('overwrite ? false) { overwrite =>
             entity(as[WhiskRulePut]) { content =>
-                val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-                putEntity(WhiskRule, entityStore, docid, overwrite, update(content) _, () => { create(content, namespace, name) },
-                    postProcess = Some { rule: WhiskRule =>
-                        completeAsRuleResponse(rule, Status.ACTIVE)
-                    })
+                val request = content.resolve(namespace.root)
+                onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
+                    case Success(true) =>
+                        val docid = FullyQualifiedEntityName(namespace, name).toDocId
+                        putEntity(WhiskRule, entityStore, docid, overwrite,
+                            update(request) _, () => { create(request, namespace, name) },
+                            postProcess = Some { rule: WhiskRule =>
+                                completeAsRuleResponse(rule, Status.ACTIVE)
+                            })
+                    case failure => handleEntitlementFailure(failure)
+                }
             }
         }
+    }
+
+    private def referencedEntities(content: WhiskRulePut) = {
+        val triggerResource = content.trigger.map {
+            t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name()))
+        }
+        val actionResource = content.action map {
+            a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name()))
+        }
+        Set(triggerResource, actionResource).flatten
     }
 
     /**
@@ -128,14 +124,13 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      */
     override def activate(user: Identity, namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
         extractStatusRequest { requestedState =>
-            val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+            val docid = FullyQualifiedEntityName(namespace, name).toDocId
 
             getEntity(WhiskRule, entityStore, docid, Some {
                 rule: WhiskRule =>
-                    val tid = DocId(WhiskEntity.qualifiedName(namespace, rule.trigger))
-                    val ruleName = EntityPath(WhiskEntity.qualifiedName(rule.namespace, rule.name))
+                    val ruleName = rule.fullyQualifiedName(false)
 
-                    val changeStatus = getTrigger(tid) map { trigger =>
+                    val changeStatus = getTrigger(rule.trigger) map { trigger =>
                         getStatus(trigger, ruleName)
                     } flatMap { oldStatus =>
                         if (requestedState != oldStatus) {
@@ -148,12 +143,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                     } flatMap {
                         case (newStatus) =>
                             info(this, s"[POST] attempting to set rule state to: ${newStatus}")
-
-                            val actionName = EntityPath(WhiskEntity.qualifiedName(namespace, rule.action))
-
-                            WhiskTrigger.get(entityStore, tid) flatMap { trigger =>
+                            WhiskTrigger.get(entityStore, rule.trigger.toDocId) flatMap { trigger =>
                                 val newTrigger = trigger.removeRule(ruleName)
-                                val triggerLink = ReducedRule(actionName, newStatus)
+                                val triggerLink = ReducedRule(rule.action, newStatus)
                                 WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
                             }
                     }
@@ -171,6 +163,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                             case _: NoDocumentException =>
                                 info(this, s"[POST] the trigger attached to the rule doesn't exist")
                                 terminate(NotFound, "Only rules with existing triggers can be activated")
+                            case _: DeserializationException =>
+                                error(this, s"[POST] rule update failed: ${t.getMessage}")
+                                terminate(InternalServerError, corruptedEntity)
                             case _: Throwable =>
                                 error(this, s"[POST] rule update failed: ${t.getMessage}")
                                 terminate(InternalServerError, t.getMessage)
@@ -190,11 +185,10 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def remove(namespace: EntityPath, name: EntityName)(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
+        val docid = FullyQualifiedEntityName(namespace, name).toDocId
         deleteEntity(WhiskRule, entityStore, docid, (r: WhiskRule) => {
-            val tid = DocId(WhiskEntity.qualifiedName(namespace, r.trigger))
-            val ruleName = EntityPath(WhiskEntity.qualifiedName(r.namespace, r.name))
-            getTrigger(tid) map { trigger =>
+            val ruleName = FullyQualifiedEntityName(r.namespace, r.name)
+            getTrigger(r.trigger) map { trigger =>
                 (getStatus(trigger, ruleName), trigger)
             } flatMap {
                 case (status, triggerOpt) =>
@@ -220,14 +214,10 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * - 500 Internal Server Error
      */
     override def fetch(namespace: EntityPath, name: EntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        val docid = DocId(WhiskEntity.qualifiedName(namespace, name))
-        getEntity(WhiskRule, entityStore, docid, Some { rule: WhiskRule =>
-            val ruleName = WhiskEntity.qualifiedName(namespace, name)
-            val triggerName = WhiskEntity.qualifiedName(namespace, rule.trigger)
-            val tid = DocId(triggerName)
-
-            val getRuleWithStatus = getTrigger(tid) map { trigger =>
-                getStatus(trigger, EntityPath(ruleName))
+        val ruleName = FullyQualifiedEntityName(namespace, name)
+        getEntity(WhiskRule, entityStore, ruleName.toDocId, Some { rule: WhiskRule =>
+            val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
+                getStatus(trigger, ruleName)
             } map { status =>
                 rule.withStatus(status)
             }
@@ -269,14 +259,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
     /** Creates a WhiskRule from PUT content, generating default values where necessary. */
     private def create(content: WhiskRulePut, namespace: EntityPath, name: EntityName)(implicit transid: TransactionId): Future[WhiskRule] = {
         if (content.trigger.isDefined && content.action.isDefined) {
-            val ruleName = WhiskEntity.qualifiedName(namespace, name)
-            val triggerName = WhiskEntity.qualifiedName(namespace, content.trigger.get)
-            val actionName = WhiskEntity.qualifiedName(namespace, content.action.get)
+            val ruleName = FullyQualifiedEntityName(namespace, name)
+            val triggerName = content.trigger.get
+            val actionName = content.action.get
 
-            val tid = DocId(triggerName)
-            val aid = DocId(actionName)
-
-            checkTriggerAndActionExist(tid, aid) recoverWith {
+            checkTriggerAndActionExist(triggerName, actionName) recoverWith {
                 case t => Future.failed(RejectRequest(BadRequest, t))
             } flatMap {
                 case (trigger, action) =>
@@ -289,32 +276,30 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                         content.publish getOrElse false,
                         content.annotations getOrElse Parameters())
 
-                    val triggerLink = ReducedRule(EntityPath(actionName), Status.ACTIVE)
-                    WhiskTrigger.put(entityStore, trigger.addRule(EntityPath(ruleName), triggerLink)).map(_ => rule)
+                    val triggerLink = ReducedRule(actionName, Status.ACTIVE)
+                    info(this, s"about to put ${trigger.addRule(ruleName, triggerLink)}")
+                    WhiskTrigger.put(entityStore, trigger.addRule(ruleName, triggerLink)) map { _ => rule }
             }
         } else Future.failed(RejectRequest(BadRequest, "rule requires a valid trigger and a valid action"))
     }
 
     /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
     private def update(content: WhiskRulePut)(rule: WhiskRule)(implicit transid: TransactionId): Future[WhiskRule] = {
-        val ruleName = WhiskEntity.qualifiedName(rule.namespace, rule.name)
-        val oldTriggerName = WhiskEntity.qualifiedName(rule.namespace, rule.trigger)
-        val oldTid = DocId(oldTriggerName)
+        val ruleName = FullyQualifiedEntityName(rule.namespace, rule.name)
+        val oldTriggerName = rule.trigger
 
-        getTrigger(oldTid) map {
-            trigger => (getStatus(trigger, EntityPath(ruleName)), trigger)
+        getTrigger(oldTriggerName) map {
+            trigger => (getStatus(trigger, ruleName), trigger)
         } flatMap {
             case (status, oldTriggerOpt) => status match {
                 case Status.INACTIVE =>
                     val newTriggerEntity = content.trigger getOrElse rule.trigger
-                    val newTriggerName = WhiskEntity.qualifiedName(rule.namespace, newTriggerEntity)
-                    val tid = DocId(newTriggerName)
+                    val newTriggerName = newTriggerEntity
 
                     val actionEntity = content.action getOrElse rule.action
-                    val actionName = WhiskEntity.qualifiedName(rule.namespace, actionEntity)
-                    val aid = DocId(actionName)
+                    val actionName = actionEntity
 
-                    checkTriggerAndActionExist(tid, aid) recoverWith {
+                    checkTriggerAndActionExist(newTriggerName, actionName) recoverWith {
                         case t => Future.failed(RejectRequest(BadRequest, t))
                     } flatMap {
                         case (newTrigger, newAction) =>
@@ -333,12 +318,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
                                 isDifferentTrigger <- content.trigger.filter(_ => newTriggerName != oldTriggerName)
                                 oldTrigger <- oldTriggerOpt
                             } yield {
-                                WhiskTrigger.put(entityStore, oldTrigger.removeRule(EntityPath(ruleName)))
+                                WhiskTrigger.put(entityStore, oldTrigger.removeRule(ruleName))
                             }
 
-                            val triggerLink = ReducedRule(EntityPath(actionName), Status.INACTIVE)
-                            val update = WhiskTrigger.put(entityStore, newTrigger.addRule(EntityPath(ruleName), triggerLink))
-
+                            val triggerLink = ReducedRule(actionName, Status.INACTIVE)
+                            val update = WhiskTrigger.put(entityStore, newTrigger.addRule(ruleName, triggerLink))
                             Future.sequence(Seq(deleteOldLink.getOrElse(Future.successful(true)), update)).map(_ => r)
                     }
                 case _ => Future.failed(RejectRequest(Conflict, s"rule may not be updated while status is ${status}"))
@@ -352,11 +336,11 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param tid DocInfo defining the trigger to get
      * @return a WhiskTrigger iff found, else None
      */
-    private def getTrigger(tid: DocId)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
-        WhiskTrigger.get(entityStore, tid) map {
+    private def getTrigger(t: FullyQualifiedEntityName)(implicit transid: TransactionId): Future[Option[WhiskTrigger]] = {
+        WhiskTrigger.get(entityStore, t.toDocId) map {
             trigger => Some(trigger)
         } recover {
-            case _: NoDocumentException => None
+            case _: NoDocumentException | DeserializationException(_, _, _) => None
         }
     }
 
@@ -368,7 +352,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param ruleName Namespace the name of the rule being worked on
      * @return Status of the rule
      */
-    private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: EntityPath)(implicit transid: TransactionId): Status = {
+    private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: FullyQualifiedEntityName)(implicit transid: TransactionId): Status = {
         val statusFromTrigger = for {
             trigger <- triggerOpt
             rules <- trigger.rules
@@ -396,13 +380,26 @@ trait WhiskRulesApi extends WhiskCollectionAPI {
      * @param action the action id
      * @return future that completes with references trigger and action if they exist
      */
-    private def checkTriggerAndActionExist(trigger: DocId, action: DocId)(implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
+    private def checkTriggerAndActionExist(trigger: FullyQualifiedEntityName, action: FullyQualifiedEntityName)(
+        implicit transid: TransactionId): Future[(WhiskTrigger, WhiskAction)] = {
+
         for {
-            triggerExists <- WhiskTrigger.get(entityStore, trigger) recoverWith {
-                case _: NoDocumentException => Future.failed(new NoDocumentException(s"trigger $trigger does not exist"))
+            triggerExists <- WhiskTrigger.get(entityStore, trigger.toDocId) recoverWith {
+                case _: NoDocumentException => Future.failed {
+                    new NoDocumentException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} does not exist")
+                }
+                case _: DeserializationException => Future.failed {
+                    new DeserializationException(s"trigger ${trigger.qualifiedNameWithLeadingSlash} is corrupted")
+                }
             }
-            actionExists <- WhiskAction.get(entityStore, action) recoverWith {
-                case _: NoDocumentException => Future.failed(new NoDocumentException(s"action $action does not exist"))
+
+            actionExists <- WhiskAction.get(entityStore, action.toDocId) recoverWith {
+                case _: NoDocumentException => Future.failed {
+                    new NoDocumentException(s"action ${action.qualifiedNameWithLeadingSlash} does not exist")
+                }
+                case _: DeserializationException => Future.failed {
+                    new DeserializationException(s"action ${action.qualifiedNameWithLeadingSlash} is corrupted")
+                }
             }
         } yield (triggerExists, actionExists)
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
@@ -32,17 +32,17 @@ class ActionCollection(entityStore: EntityStore) extends Collection(Collection.A
      * Computes implicit rights on an action (sequence, in package, or primitive).
      */
     protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId) = {
+        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
         val isOwner = namespaces.contains(resource.namespace.root())
         resource.entity map {
             name =>
                 right match {
                     // if action is in a package, check that the user is entitled to package [binding]
                     case (Privilege.READ | Privilege.ACTIVATE) if !resource.namespace.defaultPackage =>
-                        val packageNamespace = resource.namespace.root
+                        val packageNamespace = resource.namespace.root.toPath
                         val packageName = Some(resource.namespace.last.name)
                         val packageResource = Resource(packageNamespace, Collection(Collection.PACKAGES), packageName)
-                        es.check(user, Privilege.READ, packageResource)
+                        ep.check(user, Privilege.READ, packageResource)
                     case _ => Future.successful(isOwner && allowedEntityRights.contains(right))
                 }
         } getOrElse {

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -81,7 +81,7 @@ protected[core] case class Collection protected (
      * is permitted on the resource.
      */
     protected[core] def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit es: EntitlementService, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
+        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
         // if the resource root namespace is in any of the allowed namespaces
         // then this is an owner of the resource
         val self = namespaces.contains(resource.namespace.root())

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -294,6 +294,10 @@ trait ReferencedEntities {
         reference match {
             case WhiskPackagePut(Some(binding), _, _, _, _) =>
                 Set(Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name())))
+            case r: WhiskRulePut =>
+                val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name())) }
+                val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name())) }
+                Set(triggerResource, actionResource).flatten
             case _ => Set()
         }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -33,11 +33,8 @@ import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.controller.RejectRequest
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Identity
-import whisk.core.entity.Parameters
-import whisk.core.entity.Subject
 import whisk.core.iam.NamespaceProvider
+import whisk.core.entity._
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.http.Messages._
 
@@ -82,7 +79,7 @@ protected[core] object EntitlementProvider {
  * A trait that implements entitlements to resources. It performs checks for CRUD and Acivation requests.
  * This is where enforcement of activation quotas takes place, in additional to basic authorization.
  */
-protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalancer: LoadBalancer, iam: NamespaceProvider)(
+protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBalancer: LoadBalancer, iam: NamespaceProvider)(
     implicit actorSystem: ActorSystem) extends Logging {
 
     private implicit val executionContext = actorSystem.dispatcher
@@ -164,12 +161,14 @@ protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalan
         val subject = user.subject
 
         val entitlementCheck = if (user.rights.contains(right)) {
-            info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
-            checkSystemOverload(subject, right) orElse {
-                checkUserThrottle(subject, right, resources)
-            } orElse {
-                checkConcurrentUserThrottle(subject, right, resources)
-            } getOrElse checkPrivilege(user, right, resources)
+            if (resources.nonEmpty) {
+                info(this, s"checking user '$subject' has privilege '$right' for '${resources.mkString(",")}'")
+                checkSystemOverload(subject, right) orElse {
+                    checkUserThrottle(subject, right, resources)
+                } orElse {
+                    checkConcurrentUserThrottle(subject, right, resources)
+                } getOrElse checkPrivilege(user, right, resources)
+            } else Future.successful(true)
         } else if (right != REJECT) {
             info(this, s"supplied authkey for user '$subject' does not have privilege '$right' for '${resources.mkString(",")}'")
             Future.failed(RejectRequest(Forbidden))
@@ -178,7 +177,7 @@ protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalan
         }
 
         entitlementCheck andThen {
-            case Success(r) =>
+            case Success(r) if resources.nonEmpty =>
                 info(this, if (r) "authorized" else "not authorized")
             case Failure(r: RejectRequest) =>
                 info(this, s"not authorized: $r")
@@ -269,5 +268,33 @@ protected[core] abstract class EntitlementService(config: WhiskConfig, loadBalan
         if (right == ACTIVATE && userThrottled) {
             Some(Future.failed(RejectRequest(TooManyRequests, tooManyConcurrentRequests)))
         } else None
+    }
+}
+
+/**
+ * A trait to consolidate gathering of referenced entities for various types.
+ * Current entities that refer to others: action sequences, rules, and package bindings.
+ */
+trait ReferencedEntities {
+
+    /**
+     * Gathers referenced resources for types knows to refer to others.
+     * This is usually done on a PUT request, hence the types are not one of the
+     * canonical datastore types. Hence this method accepts Any reference but is
+     * only defined for WhiskPackagePut, WhiskRulePut, and SequenceExec.
+     *
+     * It is plausible to lift these disambiguation below to a new trait which is
+     * implemented by these types - however this will require exposing the Resource
+     * type outside of the controller which is not yet desirable (although this could
+     * cause further consolidation of the WhiskEntity and Resource types).
+     *
+     * @return Set of Resource instances if there are referenced entities.
+     */
+    def referencedEntities(reference: Any): Set[Resource] = {
+        reference match {
+            case WhiskPackagePut(Some(binding), _, _, _, _) =>
+                Set(Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name())))
+            case _ => Set()
+        }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -196,7 +196,6 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
         implicit transid: TransactionId): Future[Boolean] = {
         // check the default namespace first, bypassing additional checks if permitted
         val defaultNamespaces = Set(user.namespace())
-        val subject = user.subject
         implicit val es = this
 
         Future.sequence {
@@ -298,6 +297,10 @@ trait ReferencedEntities {
                 val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name())) }
                 val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name())) }
                 Set(triggerResource, actionResource).flatten
+            case e: SequenceExec =>
+                e.components.map {
+                    c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name()))
+                }.toSet
             case _ => Set()
         }
     }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -64,7 +64,7 @@ protected[core] case class Resource(
     override def toString = id
 }
 
-protected[core] object EntitlementService {
+protected[core] object EntitlementProvider {
     val requiredProperties = WhiskConfig.consulServer ++ WhiskConfig.entitlementHost ++ Map(
         WhiskConfig.actionInvokePerMinuteDefaultLimit -> null,
         WhiskConfig.actionInvokeConcurrentDefaultLimit -> null,

--- a/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/LocalEntitlement.scala
@@ -27,21 +27,21 @@ import whisk.core.entity.Subject
 import whisk.core.loadBalancer.LoadBalancer
 import whisk.core.iam.NamespaceProvider
 
-private object LocalEntitlementService {
+private object LocalEntitlementProvider {
     /** Poor mans entitlement matrix. Must persist to datastore eventually. */
     private val matrix = TrieMap[(Subject, String), Set[Privilege]]()
 }
 
-protected[core] class LocalEntitlementService(
+protected[core] class LocalEntitlementProvider(
     private val config: WhiskConfig,
     private val loadBalancer: LoadBalancer,
     private val iam: NamespaceProvider)(
         implicit actorSystem: ActorSystem)
-    extends EntitlementService(config, loadBalancer, iam) {
+    extends EntitlementProvider(config, loadBalancer, iam) {
 
     private implicit val executionContext = actorSystem.dispatcher
 
-    private val matrix = LocalEntitlementService.matrix
+    private val matrix = LocalEntitlementProvider.matrix
 
     /** Grants subject right to resource by adding them to the entitlement matrix. */
     protected[core] override def grant(subject: Subject, right: Privilege, resource: Resource)(implicit transid: TransactionId) = Future {

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -112,7 +112,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
                 // if owner, reject with not found, otherwise fail the future to reject with
                 // unauthorized (this prevents information leaks about packages in other namespaces)
                 if (isOwner) {
-                    Future.failed(RejectRequest(Conflict, Messages.requestedBindingIsNotValid))
+                    Future.failed(RejectRequest(Conflict, Messages.conformanceMessage))
                 } else {
                     Future.successful(false)
                 }

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -47,7 +47,7 @@ protected[core] class RemoteEntitlementService(
     private val iam: NamespaceProvider,
     private val timeout: FiniteDuration = 5 seconds)(
         private implicit val actorSystem: ActorSystem)
-    extends EntitlementService(config, loadBalancer, iam) {
+    extends EntitlementProvider(config, loadBalancer, iam) {
 
     private implicit val executionContext = actorSystem.dispatcher
 

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -167,7 +167,7 @@ class ContainerPool(
             info(this, s"Shutting down: Not getting container for ${action.fullyQualifiedName(true)} with ${auth.uuid}")
             throw new Exception("system is shutting down")
         } else {
-            val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true), action.rev)
+            val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true).toString, action.rev)
             val myPos = nextPosition.next()
             info(this, s"""Getting container for ${action.fullyQualifiedName(true)} of kind ${action.exec.kind} with ${auth.uuid}:
                           | myPos = $myPos
@@ -419,7 +419,7 @@ class ContainerPool(
         ContainerCounter.containerName(invokerInstance.toString(), localName)
 
     private def makeContainerName(action: WhiskAction): ContainerName =
-        makeContainerName(action.fullyQualifiedName(true))
+        makeContainerName(action.fullyQualifiedName(true).toString)
 
     /**
      * dockerLock is a fair lock used to serialize all docker operations except pull.
@@ -552,7 +552,7 @@ class ContainerPool(
         val imageName = getDockerImageName(action)
         val limits = action.limits
         val nodeImageName = WhiskAction.containerImageName(nodejsExec, config.dockerRegistry, config.dockerImagePrefix, config.dockerImageTag)
-        val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true), action.rev)
+        val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true).toString, action.rev)
         val warmedContainer = if (limits.memory == defaultMemoryLimit && imageName == nodeImageName) getStemCellNodejsContainer(key) else None
         val containerName = makeContainerName(action)
         warmedContainer getOrElse {

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -28,9 +28,9 @@ import scala.util.{ Failure, Success, Try }
 import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
 import akka.event.Logging.{ InfoLevel, LogLevel }
 import akka.japi.Creator
-import spray.json.{ JsArray, JsObject, pimpAny, pimpString }
-import spray.json.DefaultJsonProtocol._
+import spray.json._
 import spray.json.DefaultJsonProtocol
+import spray.json.DefaultJsonProtocol._
 import whisk.common.{ ConsulKVReporter, Counter, Logging, LoggingMarkers, PrintStreamEmitter, SimpleExec, TransactionId }
 import whisk.common.ConsulClient
 import whisk.common.ConsulKV.InvokerKeys
@@ -91,7 +91,7 @@ class Invoker(
         val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION)
         val namespace = msg.action.path
         val name = msg.action.name
-        val actionid = DocId(WhiskEntity.qualifiedName(namespace, name)).asDocInfo(msg.revision)
+        val actionid = FullyQualifiedEntityName(namespace, name).toDocId.asDocInfo(msg.revision)
         val tran = Transaction(msg)
         val subject = msg.subject
 
@@ -222,7 +222,7 @@ class Invoker(
             val boundParams = action.parameters.toJsObject
             val params = JsObject(boundParams.fields ++ payload.fields)
             val timeout = action.limits.timeout.duration
-            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName(true), msg.activationId.toString)
+            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName(true).toString, msg.activationId.toString)
         }
 
         initResultOpt match {

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -174,17 +174,16 @@ class WskBasicTests
             }
 
             val expectedParam = JsObject(
-                "payload" -> JsString("test")
-            )
+                "payload" -> JsString("test"))
 
             val ns_regex_list = wsk.namespace.list().stdout.trim.replace('\n', '|')
 
             wsk.pkg.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns_regex_list""")
-            wsk.pkg.get(name, fieldFilter = Some("name")).stdout should include (s"""$successMsg name\n"$name"""")
-            wsk.pkg.get(name, fieldFilter = Some("version")).stdout should include (s"""$successMsg version\n"0.0.1"""")
-            wsk.pkg.get(name, fieldFilter = Some("publish")).stdout should include (s"""$successMsg publish\nfalse""")
+            wsk.pkg.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+            wsk.pkg.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+            wsk.pkg.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
             wsk.pkg.get(name, fieldFilter = Some("binding")).stdout should include regex (s"""\\{\\}""")
-            wsk.pkg.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include ("error: Invalid field filter 'invalid'.")
+            wsk.pkg.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
     }
 
     behavior of "Wsk Action CLI"
@@ -305,20 +304,19 @@ class WskBasicTests
             }
 
             val expectedParam = JsObject(
-                "payload" -> JsString("test")
-            )
+                "payload" -> JsString("test"))
 
             val ns_regex_list = wsk.namespace.list().stdout.trim.replace('\n', '|')
 
-            wsk.action.get(name, fieldFilter = Some("name")).stdout should include (s"""$successMsg name\n"$name"""")
-            wsk.action.get(name, fieldFilter = Some("version")).stdout should include (s"""$successMsg version\n"0.0.1"""")
-            wsk.action.get(name, fieldFilter = Some("publish")).stdout should include (s"""$successMsg publish\nfalse""")
+            wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+            wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+            wsk.action.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
             wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*\\\\n \\* Hello, world.\\\\n \\*\\/\\\\nfunction main\\(params\\) \\{\\\\n    console.log\\('hello', params.payload\\+'!'\\);\\\\n\\}\\\\n"\n\\}""")
             wsk.action.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("annotations")).stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("limits")).stdout should include regex (s"""$successMsg limits\n\\{\\s+"timeout":\\s+60000,\\s+"memory":\\s+256,\\s+"logs":\\s+10\\s+\\}""")
             wsk.action.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns_regex_list""")
-            wsk.action.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include ("error: Invalid field filter 'invalid'.")
+            wsk.action.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
     }
 
     /**
@@ -522,19 +520,18 @@ class WskBasicTests
             }
 
             val expectedParam = JsObject(
-                "payload" -> JsString("test")
-            )
+                "payload" -> JsString("test"))
 
             val ns_regex_list = wsk.namespace.list().stdout.trim.replace('\n', '|')
 
             wsk.trigger.get(name, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns_regex_list""")
-            wsk.trigger.get(name, fieldFilter = Some("name")).stdout should include (s"""$successMsg name\n"$name"""")
-            wsk.trigger.get(name, fieldFilter = Some("version")).stdout should include (s"""$successMsg version\n"0.0.1"""")
-            wsk.trigger.get(name, fieldFilter = Some("publish")).stdout should include (s"""$successMsg publish\nfalse""")
-            wsk.trigger.get(name, fieldFilter = Some("annotations")).stdout should include (s"""$successMsg annotations\n[]""")
+            wsk.trigger.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+            wsk.trigger.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+            wsk.trigger.get(name, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
+            wsk.trigger.get(name, fieldFilter = Some("annotations")).stdout should include(s"""$successMsg annotations\n[]""")
             wsk.trigger.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
-            wsk.trigger.get(name, fieldFilter = Some("limits")).stdout should include  (s"""$successMsg limits\n{}""")
-            wsk.trigger.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include ("error: Invalid field filter 'invalid'.")
+            wsk.trigger.get(name, fieldFilter = Some("limits")).stdout should include(s"""$successMsg limits\n{}""")
+            wsk.trigger.get(name, fieldFilter = Some("invalid"), expectedExitCode = ERROR_EXIT).stderr should include("error: Invalid field filter 'invalid'.")
     }
 
     behavior of "Wsk Rule CLI"
@@ -617,7 +614,7 @@ class WskBasicTests
     it should "create a rule, and get its individual fields" in withAssetCleaner(wskprops) {
         val ruleName = "ruleFields"
         val triggerName = "ruleTriggerFields"
-        val actionName = "ruleActionFields";val paramInput = Map("payload" -> "test".toJson)
+        val actionName = "ruleActionFields"; val paramInput = Map("payload" -> "test".toJson)
         val successMsg = s"ok: got rule $ruleName, displaying field"
 
         (wp, assetHelper) =>
@@ -635,11 +632,17 @@ class WskBasicTests
             val ns_regex_list = wsk.namespace.list().stdout.trim.replace('\n', '|')
 
             wsk.rule.get(ruleName, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns_regex_list""")
-            wsk.rule.get(ruleName, fieldFilter = Some("name")).stdout should include (s"""$successMsg name\n"$ruleName"""")
-            wsk.rule.get(ruleName, fieldFilter = Some("version")).stdout should include (s"""$successMsg version\n"0.0.1"""")
-            wsk.rule.get(ruleName, fieldFilter = Some("status")).stdout should include (s"""$successMsg status\n"active"""")
-            wsk.rule.get(ruleName, fieldFilter = Some("trigger")).stdout should include regex (s"""$successMsg trigger\n"$triggerName"""")
-            wsk.rule.get(ruleName, fieldFilter = Some("action")).stdout should include regex (s"""$successMsg action\n"$actionName"""")
+            wsk.rule.get(ruleName, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$ruleName"""")
+            wsk.rule.get(ruleName, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+            wsk.rule.get(ruleName, fieldFilter = Some("status")).stdout should include(s"""$successMsg status\n"active"""")
+            val trigger = wsk.rule.get(ruleName, fieldFilter = Some("trigger")).stdout
+            trigger should include regex (s"""$successMsg trigger\n""")
+            trigger should include(triggerName)
+            trigger should not include (actionName)
+            val action = wsk.rule.get(ruleName, fieldFilter = Some("action")).stdout
+            action should include regex (s"""$successMsg action\n""")
+            action should include(actionName)
+            action should not include (triggerName)
     }
 
     behavior of "Wsk Namespace CLI"
@@ -681,15 +684,15 @@ class WskBasicTests
                 activation =>
                     val successMsg = s"ok: got activation ${activation.activationId}, displaying field"
                     wsk.activation.get(activation.activationId, fieldFilter = Some("namespace")).stdout should include regex (s"""(?i)$successMsg namespace\n$ns_regex_list""")
-                    wsk.activation.get(activation.activationId, fieldFilter = Some("name")).stdout should include (s"""$successMsg name\n"$name"""")
-                    wsk.activation.get(activation.activationId, fieldFilter = Some("version")).stdout should include (s"""$successMsg version\n"0.0.1"""")
-                    wsk.activation.get(activation.activationId, fieldFilter = Some("publish")).stdout should include (s"""$successMsg publish\nfalse""")
+                    wsk.activation.get(activation.activationId, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
+                    wsk.activation.get(activation.activationId, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
+                    wsk.activation.get(activation.activationId, fieldFilter = Some("publish")).stdout should include(s"""$successMsg publish\nfalse""")
                     wsk.activation.get(activation.activationId, fieldFilter = Some("subject")).stdout should include regex (s"""(?i)$successMsg subject\n$ns_regex_list""")
-                    wsk.activation.get(activation.activationId, fieldFilter = Some("activationid")).stdout should include (s"""$successMsg activationid\n"${activation.activationId}""")
+                    wsk.activation.get(activation.activationId, fieldFilter = Some("activationid")).stdout should include(s"""$successMsg activationid\n"${activation.activationId}""")
                     wsk.activation.get(activation.activationId, fieldFilter = Some("start")).stdout should include regex (s"""$successMsg start\n\\d""")
                     wsk.activation.get(activation.activationId, fieldFilter = Some("end")).stdout should include regex (s"""$successMsg end\n\\d""")
                     wsk.activation.get(activation.activationId, fieldFilter = Some("duration")).stdout should include regex (s"""$successMsg duration\n\\d""")
-                    wsk.activation.get(activation.activationId, fieldFilter = Some("annotations")).stdout should include (s"""$successMsg annotations\n[]""")
+                    wsk.activation.get(activation.activationId, fieldFilter = Some("annotations")).stdout should include(s"""$successMsg annotations\n[]""")
             }
     }
 }

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -344,6 +344,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         }
     }
 
+    private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
     private def seqParameters(seq: Vector[FullyQualifiedEntityName]) = Parameters("_actions", seq.toJson)
 
     // this test is sneaky; the installation of the sequence is done directly in the db

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -38,7 +38,7 @@ import whisk.core.controller.WhiskActionsApi
 import whisk.core.controller.WhiskServices
 import whisk.core.database.DocumentFactory
 import whisk.core.database.test.DbUtils
-import whisk.core.entitlement.{ Collection, EntitlementService, LocalEntitlementService }
+import whisk.core.entitlement._
 import whisk.core.entity._
 import whisk.core.iam.NamespaceProvider
 import whisk.core.loadBalancer.LoadBalancer
@@ -65,8 +65,9 @@ protected trait ControllerTestCommon
     assert(whiskConfig.isValid)
 
     override val loadBalancer = new DegenerateLoadBalancerService(whiskConfig, InfoLevel)
+
     override val iam = new NamespaceProvider(whiskConfig, forceLocal = true)
-    override val entitlementService: EntitlementService = new LocalEntitlementService(whiskConfig, loadBalancer, iam)
+    override val entitlementProvider: EntitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer, iam)
 
     override val activationIdFactory = new ActivationId.ActivationIdGenerator() {
         // need a static activation id to test activations api
@@ -144,7 +145,7 @@ protected trait ControllerTestCommon
     entityStore.setVerbosity(InfoLevel)
     activationStore.setVerbosity(InfoLevel)
     authStore.setVerbosity(InfoLevel)
-    entitlementService.setVerbosity(InfoLevel)
+    entitlementProvider.setVerbosity(InfoLevel)
 
     val ACTIONS = Collection(Collection.ACTIONS)
     val TRIGGERS = Collection(Collection.TRIGGERS)

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -20,25 +20,11 @@ import scala.concurrent.duration.DurationInt
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import spray.http.StatusCodes._
-import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.httpx.SprayJsonSupport.sprayJsonUnmarshaller
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.listFormat
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsObject
-import spray.json.pimpAny
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import whisk.core.controller.WhiskActionsApi
-import whisk.core.entity.ActionLimits
-import whisk.core.entity.Exec
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Parameters
-import whisk.core.entity.WhiskAction
-import whisk.core.entity.WhiskActionPut
-import whisk.core.entity.AuthKey
-import whisk.core.entity.WhiskAuth
-import whisk.core.entity.Subject
-import whisk.core.entity.WhiskPackage
+import whisk.core.entity._
 import whisk.core.entitlement.Resource
 import whisk.core.entitlement.Privilege._
 import scala.concurrent.Await
@@ -311,7 +297,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, binding)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, READ, pkgaccess), 1 second)
+        Await.result(entitlementProvider.grant(auser.subject, READ, pkgaccess), 1 second)
         Get(s"$collectionPath/${binding.name}/${action.name}") ~> sealRoute(routes(auser)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskAction]
@@ -455,7 +441,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         put(entityStore, reference)
         put(entityStore, action)
         val pkgaccess = Resource(provider.namespace, PACKAGES, Some(provider.name()))
-        Await.result(entitlementService.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
+        Await.result(entitlementProvider.grant(auser.subject, ACTIVATE, pkgaccess), 1 second)
         Post(s"$collectionPath/${reference.name}/${action.name}", content) ~> sealRoute(routes(auser)) ~> check {
             status should be(Accepted)
             val response = responseAs[JsObject]

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -530,6 +530,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, provider)
         Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)
+            responseAs[ErrorResponse].error should include(Messages.packageCannotBecomeBinding)
         }
     }
 
@@ -541,6 +542,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         put(entityStore, reference)
         Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
+            responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
         }
     }
 
@@ -614,10 +616,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject delete non-empty package" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
-        val reference = WhiskPackage(namespace, aname, provider.bind)
         val action = WhiskAction(provider.namespace.addpath(provider.name), aname, Exec.js("??"))
         put(entityStore, provider)
-        put(entityStore, reference)
         put(entityStore, action)
         whisk.utils.retry {
             Get(s"$collectionPath/${provider.name}") ~> sealRoute(routes(creds)) ~> check {

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -403,7 +403,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val binding = Some(Binding(namespace, aname))
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(NotFound)
+            status should be(BadRequest)
             responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
         }
     }
@@ -540,7 +540,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val content = WhiskPackagePut(reference.binding)
         put(entityStore, reference)
         Put(s"$collectionPath/${reference.name}?overwrite=true", content) ~> sealRoute(routes(creds)) ~> check {
-            status should be(NotFound)
+            status should be(BadRequest)
         }
     }
 
@@ -645,11 +645,9 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         }
     }
 
-    /*
     it should "reject bind to non-package" in {
         implicit val tid = transid()
         val action = WhiskAction(namespace, aname, Exec.js("??"))
-        //val reference = WhiskPackage(namespace, aname, Some(action.fullyQualifiedName(false)))
         val reference = WhiskPackage(namespace, aname, Some(Binding(action.namespace, action.name)))
         val content = WhiskPackagePut(reference.binding)
 
@@ -659,7 +657,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Conflict)
             responseAs[ErrorResponse].error should include(Messages.requestedBindingIsNotValid)
         }
-    }*/
+    }
 
     it should "report proper error when record is corrupted on delete" in {
         implicit val tid = transid()

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -132,7 +132,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
     it should "report Conflict if the name was of a different type" in {
         implicit val tid = transid()
-        val rule = WhiskRule(namespace, aname, aname, aname)
+        val rule = WhiskRule(namespace, aname, FullyQualifiedEntityName(namespace, aname), FullyQualifiedEntityName(namespace, aname))
         put(entityStore, rule)
         Get(s"/$namespace/${collection.path}/${rule.name}") ~> sealRoute(routes(creds)) ~> check {
             status should be(Conflict)

--- a/tests/src/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/whisk/core/entity/test/DatastoreTests.scala
@@ -63,6 +63,8 @@ class DatastoreTests extends FlatSpec
         EntityName(s"$n$counter")
     }
 
+    def afullname(implicit namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
+
     after {
         cleanup()
     }
@@ -131,8 +133,8 @@ class DatastoreTests extends FlatSpec
         implicit val tid = transid()
         implicit val basename = EntityName("create rule")
         val rules = Seq(
-            WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action")),
-            WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action")))
+            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")),
+            WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action")))
         val docs = rules.map { entity =>
             putGetCheck(datastore, entity, WhiskRule)
         }
@@ -176,13 +178,13 @@ class DatastoreTests extends FlatSpec
     it should "reject rule with null arguments" in {
         val name = EntityName("bad rule")
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(null), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(null)), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(""), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName("")), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
         intercept[IllegalArgumentException] {
-            WhiskRule(namespace, name, EntityName(" "), EntityName(null))
+            WhiskRule(namespace, name, FullyQualifiedEntityName(namespace, EntityName(" ")), FullyQualifiedEntityName(namespace, EntityName(null)))
         }
     }
 
@@ -216,7 +218,7 @@ class DatastoreTests extends FlatSpec
     it should "update rule with a revision" in {
         implicit val tid = transid()
         implicit val basename = EntityName("update rule")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         val docinfo = putGetCheck(datastore, rule, WhiskRule, false)._2.docinfo
         val revRule = WhiskRule(namespace, rule.name, rule.trigger, rule.action).revision[WhiskRule](docinfo.rev)
         putGetCheck(datastore, revRule, WhiskRule)
@@ -264,7 +266,7 @@ class DatastoreTests extends FlatSpec
     it should "fail with document conflict when trying to write the same rule twice without a revision" in {
         implicit val tid = transid()
         implicit val basename = EntityName("create rule twice")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         putGetCheck(datastore, rule, WhiskRule)
         intercept[DocumentConflictException] {
             putGetCheck(datastore, rule, WhiskRule)
@@ -320,7 +322,7 @@ class DatastoreTests extends FlatSpec
     it should "fail with document does not exist when trying to delete the same rule twice" in {
         implicit val tid = transid()
         implicit val basename = EntityName("delete rule twice")
-        val rule = WhiskRule(namespace, aname, EntityName("a trigger"), EntityName("an action"))
+        val rule = WhiskRule(namespace, aname, afullname(namespace, "a trigger"), afullname(namespace, "an action"))
         val doc = putGetCheck(datastore, rule, WhiskRule, false)._1
         assert(Await.result(WhiskRule.del(datastore, doc), dbOpTimeout))
         intercept[NoDocumentException] {

--- a/tests/src/whisk/core/entity/test/MigrationEntities.scala
+++ b/tests/src/whisk/core/entity/test/MigrationEntities.scala
@@ -32,8 +32,8 @@ import whisk.core.entity._
 case class OldWhiskRule(
     namespace: EntityPath,
     override val name: EntityName,
-    trigger: types.Trigger,
-    action: types.Action,
+    trigger: EntityName,
+    action: EntityName,
     status: Status,
     version: SemVer = SemVer(),
     publish: Boolean = false,
@@ -42,7 +42,12 @@ case class OldWhiskRule(
 
     def toJson = OldWhiskRule.serdes.write(this).asJsObject
 
-    def toWhiskRule = WhiskRule(namespace, name, trigger, action, version, publish, annotations)
+    def toWhiskRule = {
+        WhiskRule(namespace, name,
+            FullyQualifiedEntityName(namespace, trigger),
+            FullyQualifiedEntityName(namespace, action),
+            version, publish, annotations)
+    }
 }
 
 object OldWhiskRule

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -199,8 +199,8 @@ var ruleCreateCmd = &cobra.Command{
 
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        triggerName := args[1]
-        actionName := args[2]
+        triggerName := getQualifiedName(args[1], Properties.Namespace)
+        actionName := getQualifiedName(args[2], Properties.Namespace)
 
         rule := &whisk.Rule{
             Name:    ruleName,
@@ -257,8 +257,8 @@ var ruleUpdateCmd = &cobra.Command{
 
         client.Namespace = qName.namespace
         ruleName := qName.entityName
-        triggerName := args[1]  //MWD qualified name?
-        actionName := args[2]   //MWD qualified name?
+        triggerName := getQualifiedName(args[1], Properties.Namespace)
+        actionName := getQualifiedName(args[2], Properties.Namespace)
 
         if (flags.common.shared == "yes") {
             shared = true

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -35,8 +35,8 @@ type Rule struct {
     Version   string    `json:"version,omitempty"`
     Publish   bool      `json:"publish,omitempty"`
     Status  string      `json:"status"`
-    Trigger string      `json:"trigger"`
-    Action  string      `json:"action"`
+    Trigger interface{} `json:"trigger"`
+    Action  interface{} `json:"action"`
 }
 
 type RuleListOptions struct {


### PR DESCRIPTION
Fixes #239.
This required some refactoring of the entitlement path which allowed for consolidation of entitlement checks on referenced entities.

PG2/613 and PG1/882.