### PR TITLE
normalize context available in all action runtimes

### DIFF
--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -97,7 +97,7 @@ class ActionRunner:
         # make sure to include all the env vars passed in by the invoker
         env = os.environ
         if 'authKey' in message:
-            env['AUTH_KEY'] = message['authKey']
+            env['__OW_APIKEY'] = message['authKey']
         return env
 
     # runs the action, called iff self.verify() is True.

--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -91,12 +91,12 @@ class ActionRunner:
         return (os.path.isfile(self.binary) and os.access(self.binary, os.X_OK))
 
     # constructs an environment for the action to run in
-    # @param message is a JSON object received from invoker (should contain 'value' and 'apikey' and other metadata)
+    # @param message is a JSON object received from invoker (should contain 'value' and 'api_key' and other metadata)
     # @return an environment dictionary for the action process
     def env(self, message):
         # make sure to include all the env vars passed in by the invoker
         env = os.environ
-        for p in [ 'apikey', 'namespace', 'action_name', 'activation_id', 'deadline' ]:
+        for p in [ 'api_key', 'namespace', 'action_name', 'activation_id', 'deadline' ]:
              if p in message:
                 env['__OW_%s' % p.upper()] = message[p]
         return env

--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -91,13 +91,14 @@ class ActionRunner:
         return (os.path.isfile(self.binary) and os.access(self.binary, os.X_OK))
 
     # constructs an environment for the action to run in
-    # @param message is a JSON object received from invoker (should contain 'value' and 'authKey')
+    # @param message is a JSON object received from invoker (should contain 'value' and 'apikey' and other metadata)
     # @return an environment dictionary for the action process
     def env(self, message):
         # make sure to include all the env vars passed in by the invoker
         env = os.environ
-        if 'authKey' in message:
-            env['__OW_APIKEY'] = message['authKey']
+        for p in [ 'apikey', 'namespace', 'action_name', 'activation_id', 'deadline' ]:
+             if p in message:
+                env['__OW_%s' % p.upper()] = message[p]
         return env
 
     # runs the action, called iff self.verify() is True.

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -652,7 +652,7 @@ class ContainerPool(
     }
 
     private def getContainerEnvironment(): Map[String, String] = {
-        Map("__OW_APIHOST" -> config.edgeHost)
+        Map("__OW_API_HOST" -> config.edgeHost)
     }
 
     private val defaultMaxIdle = 10

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -652,7 +652,7 @@ class ContainerPool(
     }
 
     private def getContainerEnvironment(): Map[String, String] = {
-        Map(WhiskConfig.asEnvVar(WhiskConfig.edgeHostName) -> config.edgeHost)
+        Map("__OW_APIHOST" -> config.edgeHost)
     }
 
     private val defaultMaxIdle = 10

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -81,7 +81,7 @@ class WhiskContainer(
     private def constructActivationMetadata(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration): JsObject = {
         JsObject(
             "value" -> args,
-            "apikey" -> msg.authkey.compact.toJson,
+            "api_key" -> msg.authkey.compact.toJson,
             "namespace" -> msg.action.path.root.toJson,
             "action_name" -> msg.action.qualifiedNameWithLeadingSlash.toJson,
             "activation_id" -> msg.activationId.toString.toJson,

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -20,32 +20,30 @@ import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.duration.DurationInt
-
 import scala.concurrent.Await
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.DurationInt
-
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 import akka.actor.ActorSystem
 import akka.event.Logging.LogLevel
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling._
 import akka.stream.ActorMaterializer
-
-import spray.json.JsObject
-import spray.json.JsString
-import whisk.common.TransactionId
-import whisk.core.entity.ActionLimits
-import whisk.common.LoggingMarkers
-import whisk.common.PrintStreamEmitter
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 import whisk.common.HttpUtils
+import whisk.common.LoggingMarkers
 import whisk.common.NewHttpUtils
+import whisk.common.PrintStreamEmitter
+import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.entity._
+import whisk.core.entity.ActionLimits
 
 /**
  * Reifies a whisk container - one that respects the whisk container API.
@@ -80,18 +78,30 @@ class WhiskContainer(
         result
     }
 
+    private def constructActivationMetadata(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration): JsObject = {
+        JsObject(
+            "value" -> args,
+            "apikey" -> msg.authkey.compact.toJson,
+            "namespace" -> msg.action.path.root.toJson,
+            "action_name" -> msg.action.qualifiedNameWithLeadingSlash.toJson,
+            "activation_id" -> msg.activationId.toString.toJson,
+            // compute deadline on invoker side avoids discrepancies inside container
+            // but potentially under-estimates actual deadline
+            "deadline" -> (Instant.now(Clock.systemUTC()).toEpochMilli + timeout.toMillis).toString.toJson)
+    }
+
     /**
      * Sends a run command to action container to run once.
      *
      * @param state the value of the status to compare the actual state against
      * @return triple of start time, end time, response for user action.
      */
-    def run(args: JsObject, meta: JsObject, authKey: String, timeout: FiniteDuration, actionName: String, activationId: String)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
-        val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName $details")
-        val result = sendPayload("/run", JsObject(meta.fields + ("value" -> args) + ("authKey" -> JsString(authKey))), timeout)
+    def run(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
+        val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to ${msg.action} $details")
+        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout)
         // Use start and end time of the activation
         val RunResult(Interval(startActivation, endActivation), _) = result
-        transid.finished("Invoker", startMarker.copy(startActivation), s"finished running activation id: $activationId", endTime = endActivation)
+        transid.finished("Invoker", startMarker.copy(startActivation), s"finished running activation id: $msg.activationId", endTime = endActivation)
         result
     }
 
@@ -101,7 +111,16 @@ class WhiskContainer(
     def run(payload: String, activationId: String)(implicit system: ActorSystem): RunResult = {
         val params = JsObject("payload" -> JsString(payload))
         val meta = JsObject("activationId" -> JsString(activationId))
-        run(params, meta, "no_auth_key", 30000.milliseconds, "no_action", "no_activation_id")(system, TransactionId.testing)
+        val msg = ActivationMessage(
+            TransactionId.testing,
+            FullyQualifiedEntityName(EntityPath("no_namespace"), EntityName("no_action")),
+            DocRevision(),
+            Subject(),
+            AuthKey(),
+            ActivationId(),
+            EntityPath("no_namespace"),
+            None)
+        run(msg, params, 30000.milliseconds)(system, TransactionId.testing)
     }
 
     /**

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -222,7 +222,7 @@ class Invoker(
             val boundParams = action.parameters.toJsObject
             val params = JsObject(boundParams.fields ++ payload.fields)
             val timeout = action.limits.timeout.duration
-            con.run(params, msg.meta, auth.compact, timeout, action.fullyQualifiedName(true).toString, msg.activationId.toString)
+            con.run(msg, params,  timeout)
         }
 
         initResultOpt match {

--- a/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
+++ b/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
@@ -124,7 +124,7 @@ public class Proxy {
                 HashMap<String, String> env = new HashMap<String, String>();
                 try {
                     String authKey = ie.getAsJsonObject().getAsJsonPrimitive("authKey").getAsString();
-                    env.put("AUTH_KEY", authKey);
+                    env.put("__OW_APIKEY", authKey);
                 } catch (Exception e) {}
 
                 Thread.currentThread().setContextClassLoader(loader);

--- a/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
+++ b/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
@@ -122,10 +122,12 @@ public class Proxy {
                 JsonObject inputObject = ie.getAsJsonObject().getAsJsonObject("value");
 
                 HashMap<String, String> env = new HashMap<String, String>();
-                try {
-                    String authKey = ie.getAsJsonObject().getAsJsonPrimitive("authKey").getAsString();
-                    env.put("__OW_APIKEY", authKey);
-                } catch (Exception e) {}
+                for (String p : new String[] { "apikey", "namespace", "action_name", "activation_id", "deadline" }) {
+                    try {
+                        String val = ie.getAsJsonObject().getAsJsonPrimitive(p).getAsString();
+                        env.put(String.format("__OW_%s", p.toUpperCase()), val);
+                    } catch (Exception e) {}
+                }
 
                 Thread.currentThread().setContextClassLoader(loader);
                 System.setSecurityManager(new WhiskSecurityManager());

--- a/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
+++ b/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
@@ -122,7 +122,7 @@ public class Proxy {
                 JsonObject inputObject = ie.getAsJsonObject().getAsJsonObject("value");
 
                 HashMap<String, String> env = new HashMap<String, String>();
-                for (String p : new String[] { "apikey", "namespace", "action_name", "activation_id", "deadline" }) {
+                for (String p : new String[] { "api_key", "namespace", "action_name", "activation_id", "deadline" }) {
                     try {
                         String val = ie.getAsJsonObject().getAsJsonPrimitive(p).getAsString();
                         env.put(String.format("__OW_%s", p.toUpperCase()), val);

--- a/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
+++ b/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.HashMap;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -120,11 +121,17 @@ public class Proxy {
                 JsonElement ie = parser.parse(new BufferedReader(new InputStreamReader(is, "UTF-8")));
                 JsonObject inputObject = ie.getAsJsonObject().getAsJsonObject("value");
 
+                HashMap<String, String> env = new HashMap<String, String>();
+                try {
+                    String authKey = ie.getAsJsonObject().getAsJsonPrimitive("authKey").getAsString();
+                    env.put("AUTH_KEY", authKey);
+                } catch (Exception e) {}
+
                 Thread.currentThread().setContextClassLoader(loader);
                 System.setSecurityManager(new WhiskSecurityManager());
 
                 // User code starts running here.
-                JsonObject output = loader.invokeMain(inputObject);
+                JsonObject output = loader.invokeMain(inputObject, env);
                 // User code finished running here.
 
                 if(output == null) {

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -43,7 +43,7 @@ nano@6.2.0 \
 node-uuid@1.4.7 \
 nodemailer@2.5.0 \
 oauth2-server@2.4.1 \
-openwhisk@2.5.0 \
+openwhisk@2.6.0 \
 pkgcloud@1.3.0 \
 process@0.11.3 \
 pug@">2.0.0-alpha <2.0.1" \

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -43,6 +43,7 @@ nano@6.2.0 \
 node-uuid@1.4.7 \
 nodemailer@2.5.0 \
 oauth2-server@2.4.1 \
+openwhisk@2.5.0 \
 pkgcloud@1.3.0 \
 process@0.11.3 \
 pug@">2.0.0-alpha <2.0.1" \

--- a/core/nodejsAction/Dockerfile
+++ b/core/nodejsAction/Dockerfile
@@ -34,6 +34,7 @@ mustache@2.1.3 \
 nano@5.10.0 \
 node-uuid@1.4.2 \
 oauth2-server@2.4.0 \
+openwhisk@2.5.0 \
 process@0.11.0 \
 request@2.60.0 \
 rimraf@2.5.1 \

--- a/core/nodejsAction/Dockerfile
+++ b/core/nodejsAction/Dockerfile
@@ -34,7 +34,7 @@ mustache@2.1.3 \
 nano@5.10.0 \
 node-uuid@1.4.2 \
 oauth2-server@2.4.0 \
-openwhisk@2.5.0 \
+openwhisk@2.6.0 \
 process@0.11.0 \
 request@2.60.0 \
 rimraf@2.5.1 \

--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -16,8 +16,7 @@
 
 var config = {
         'port': 8080,
-        'edgeHost': process.env.EDGE_HOST,
-        'authKey' : process.env.AUTH_KEY
+        'edgeHost': process.env.EDGE_HOST
 };
 
 var bodyParser = require('body-parser');

--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -16,7 +16,7 @@
 
 var config = {
         'port': 8080,
-        'edgeHost': process.env.__OW_APIHOST
+        'edgeHost': process.env.__OW_API_HOST
 };
 
 var bodyParser = require('body-parser');

--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -16,7 +16,7 @@
 
 var config = {
         'port': 8080,
-        'edgeHost': process.env.EDGE_HOST
+        'edgeHost': process.env.__OW_APIHOST
 };
 
 var bodyParser = require('body-parser');

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -125,7 +125,7 @@ function NodeActionRunner(whisk) {
                 }
             }
         );
-    };
+    }
 
     // Helper function to copy a base64-encoded zip file to a temporary location,
     // decompress it into temporary directory, and return the name of that directory.

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -26,7 +26,7 @@ var fs = require('fs');
 var path = require('path');
 
 function NodeActionRunner(whisk) {
-    // Use this ref inside lambdas etc.
+    // Use this ref inside closures etc.
     var thisRunner = this;
 
     this.userScriptName = undefined;
@@ -101,7 +101,7 @@ function NodeActionRunner(whisk) {
                     reject(e);
                 }
 
-                if (result !== thisRunner.whisk.async()) {
+                if (result !== thisRunner.whisk.async(false)) {
                     // This branch handles all direct (non-async) returns, as well
                     // as returned Promises.
 

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -148,7 +148,7 @@ function NodeActionService(config, logger) {
         var ids = (req.body || {}).meta;
         var args = (req.body || {}).value;
         var authKey = (req.body || {}).authKey;
-        userCodeRunner.whisk.setAuthKey(authKey)
+        userCodeRunner.whisk.setAuthKey(authKey, false)
 
         return userCodeRunner.run(args).then(function(response) {
             writeMarkers();
@@ -167,15 +167,7 @@ function NodeActionService(config, logger) {
 }
 
 function newWhiskContext(config, logger) {
-    var apihost = undefined;
-
-    if (config.edgeHost) {
-        var edgeHostParts = config.edgeHost.split(':');
-        var protocol = (edgeHostParts.length >= 2  &&  edgeHostParts[1] == '443') ? 'https' : 'http';
-        apihost = protocol + '://' + config.edgeHost;
-    }
-
-    return new whisk(apihost, logger);
+    return new whisk(config.edgeHost, logger);
 }
 
 NodeActionService.getService = function(config, logger) {

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -145,12 +145,15 @@ function NodeActionService(config, logger) {
     }
 
     function doRun(req) {
-        var ids = (req.body || {}).meta;
-        var args = (req.body || {}).value;
-        var authKey = (req.body || {}).authKey;
-        userCodeRunner.whisk.setAuthKey(authKey, false)
+        var msg = req.body || {};
 
-        return userCodeRunner.run(args).then(function(response) {
+        userCodeRunner.whisk.setAuthKey(msg['apikey'], false);
+        var props = [ 'apikey', 'namespace', 'action_name', 'activation_id', 'deadline' ];
+        props.map(function (p) {
+            process.env['__OW_' + p.toUpperCase()] = msg[p];
+        });
+
+        return userCodeRunner.run(msg.value).then(function(response) {
             writeMarkers();
             return response;
         }).catch(function (error) {

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -147,8 +147,8 @@ function NodeActionService(config, logger) {
     function doRun(req) {
         var msg = req.body || {};
 
-        userCodeRunner.whisk.setAuthKey(msg['apikey'], false);
-        var props = [ 'apikey', 'namespace', 'action_name', 'activation_id', 'deadline' ];
+        userCodeRunner.whisk.setAuthKey(msg['api_key'], false);
+        var props = [ 'api_key', 'namespace', 'action_name', 'activation_id', 'deadline' ];
         props.map(function (p) {
             process.env['__OW_' + p.toUpperCase()] = msg[p];
         });

--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -28,10 +28,10 @@ var request = require('request');
  */
 function Whisk(apihost, logger) {
 
-    // export EDGE_HOST to environment
+    // export __OW_APIHOST to environment
     {
         apihost = apihost || '';
-        process.env['EDGE_HOST'] = apihost;
+        process.env['__OW_APIHOST'] = apihost;
         var edgeHostParts = apihost.split(':');
         var protocol = (edgeHostParts.length >= 2  &&  edgeHostParts[1] == '443') ? 'https' : 'http';
         apihost = protocol + '://' + apihost;
@@ -75,8 +75,8 @@ function Whisk(apihost, logger) {
      * Gets the authorization key under which this action is running.
      */
     this.setAuthKey = function(key, warn) {
-        // export key to environment as AUTH_KEY
-        process.env['AUTH_KEY'] = key;
+        // export key to environment as __OW_APIKEY
+        process.env['__OW_APIKEY'] = key;
         if (warn !== false) {
             console.warn('[WARN] "whisk.setAuthKey" is deprecated. Use "openwhisk" package instead.');
         }

--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -31,7 +31,6 @@ function Whisk(apihost, logger) {
     // export __OW_APIHOST to environment
     {
         apihost = apihost || '';
-        process.env['__OW_APIHOST'] = apihost;
         var edgeHostParts = apihost.split(':');
         var protocol = (edgeHostParts.length >= 2  &&  edgeHostParts[1] == '443') ? 'https' : 'http';
         apihost = protocol + '://' + apihost;
@@ -75,8 +74,6 @@ function Whisk(apihost, logger) {
      * Gets the authorization key under which this action is running.
      */
     this.setAuthKey = function(key, warn) {
-        // export key to environment as __OW_APIKEY
-        process.env['__OW_APIKEY'] = key;
         if (warn !== false) {
             console.warn('[WARN] "whisk.setAuthKey" is deprecated. Use "openwhisk" package instead.');
         }

--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -28,6 +28,15 @@ var request = require('request');
  */
 function Whisk(apihost, logger) {
 
+    // export EDGE_HOST to environment
+    {
+        apihost = apihost || '';
+        process.env['EDGE_HOST'] = apihost;
+        var edgeHostParts = apihost.split(':');
+        var protocol = (edgeHostParts.length >= 2  &&  edgeHostParts[1] == '443') ? 'https' : 'http';
+        apihost = protocol + '://' + apihost;
+    }
+
     this.apikey = "uninit_apikey";
 
     var asyncSentinel = new function Async(){ async: true; };
@@ -58,13 +67,19 @@ function Whisk(apihost, logger) {
      * Gets the authorization key under which this action is running.
      */
     this.getAuthKey = function() {
+        console.warn('[WARN] "whisk.getAuthKey" is deprecated. Use "openwhisk" package instead.');
         return this.apikey;
     }
 
     /**
      * Gets the authorization key under which this action is running.
      */
-    this.setAuthKey = function(key) {
+    this.setAuthKey = function(key, warn) {
+        // export key to environment as AUTH_KEY
+        process.env['AUTH_KEY'] = key;
+        if (warn !== false) {
+            console.warn('[WARN] "whisk.setAuthKey" is deprecated. Use "openwhisk" package instead.');
+        }
         this.apikey = key;
     }
 
@@ -82,6 +97,7 @@ function Whisk(apihost, logger) {
      *             when error is not a falsey depending on invoke failure mode.
      */
     this.invoke = function(params) {
+        console.warn('[WARN] "whisk.invoke" is deprecated. Use "openwhisk" package instead.');
         var args = params || {};
         var action = parseQName(args.name || '');
         var parameters = args.parameters || {};
@@ -132,6 +148,7 @@ function Whisk(apihost, logger) {
      *             Activation, if defined, is an object { activationId: String }.
      */
     this.trigger = function(params) {
+        console.warn('[WARN] "whisk.trigger" is deprecated. Use "openwhisk" package instead.');
         var args = params || {};
         var event = parseQName(args.name || '');
         var parameters = args.parameters || {};
@@ -172,6 +189,7 @@ function Whisk(apihost, logger) {
      * Call `whisk.done` or `whisk.error` from your action instead.
      */
     this._terminate = function(response) {
+        console.warn('[WARN] "whisk._terminate" is deprecated. Actions should return Promises.');
         return response;
     }
 
@@ -186,6 +204,7 @@ function Whisk(apihost, logger) {
      * setting a value is equivalent to setting the empty object.
      */
     this.done = function(value) {
+        console.warn('[WARN] "whisk.done" is deprecated. Actions should return Promises.');
         var response = value;
 
         // All non-truthy responses are converted to the empty object.
@@ -211,6 +230,7 @@ function Whisk(apihost, logger) {
      * the value is not set, a generic error message is returned instead.
      */
     this.error = function(value) {
+        console.warn('[WARN] "whisk.error" is deprecated. Actions should return Promises.');
         var errorValue = value === undefined ? 'an error has occurred' : value;
         var response = { error: errorValue };
         logger && logger.info('[whisk]', 'error()', response);
@@ -218,7 +238,10 @@ function Whisk(apihost, logger) {
     }
 
     /** A sentinel to denote asynchronous activation. */
-    this.async = function() {
+    this.async = function(warn) {
+        if (warn !== false) {
+            console.warn('[WARN] "whisk.async" is deprecated. Actions should return Promises.');
+        }
         return asyncSentinel;
     }
 }
@@ -259,7 +282,7 @@ function post(packet, logger, acceptStatusCode) {
           logger && logger.info('[whisk]', 'post status:', response ? response.statusCode : undefined);
           // print the error to console.error to help post-mortem debugging
           // and inform the user if for example they neglected to check for error
-          error  && console.log('Warning: whisk activation request failed with the following error', error);
+          error  && console.warn('[WARN] whisk activation request failed with the following error', error);
 
           logger && logger.info('[whisk]', 'response body', body);
 

--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -28,7 +28,7 @@ var request = require('request');
  */
 function Whisk(apihost, logger) {
 
-    // export __OW_APIHOST to environment
+    // export __OW_API_HOST to environment
     {
         apihost = apihost || '';
         var edgeHostParts = apihost.split(':');

--- a/core/swift3Action/spm-build/Whisk.swift
+++ b/core/swift3Action/spm-build/Whisk.swift
@@ -65,16 +65,16 @@ class Whisk {
     
     /*
      * Initialize with host, port and authKey determined from environment variables
-     * EDGE_HOST and AUTH_KEY, respectively
+     * __OW_APIHOST and __OW_APIKEY, respectively
      */
     private class func initializeCommunication() -> (host : String, port : Int16, authKey : String) {
         let env = ProcessInfo.processInfo.environment
         
         var edgeHost : String!
-        if let edgeHostEnv : String = env["EDGE_HOST"] {
+        if let edgeHostEnv : String = env["__OW_APIHOST"] {
             edgeHost = "\(edgeHostEnv)"
         } else {
-            fatalError("EDGE_HOST environment variable was not set.")
+            fatalError("__OW_APIHOST environment variable was not set.")
         }
         
         let hostComponents = edgeHost.components(separatedBy: ":")
@@ -86,7 +86,7 @@ class Whisk {
         }
         
         var authKey = "authKey"
-        if let authKeyEnv : String = env["AUTH_KEY"] {
+        if let authKeyEnv : String = env["__OW_APIKEY"] {
             authKey = authKeyEnv
         }
         

--- a/core/swift3Action/spm-build/Whisk.swift
+++ b/core/swift3Action/spm-build/Whisk.swift
@@ -65,16 +65,16 @@ class Whisk {
     
     /*
      * Initialize with host, port and authKey determined from environment variables
-     * __OW_APIHOST and __OW_APIKEY, respectively
+     * __OW_API_HOST and __OW_API_KEY, respectively
      */
     private class func initializeCommunication() -> (host : String, port : Int16, authKey : String) {
         let env = ProcessInfo.processInfo.environment
         
         var edgeHost : String!
-        if let edgeHostEnv : String = env["__OW_APIHOST"] {
+        if let edgeHostEnv : String = env["__OW_API_HOST"] {
             edgeHost = "\(edgeHostEnv)"
         } else {
-            fatalError("__OW_APIHOST environment variable was not set.")
+            fatalError("__OW_API_HOST environment variable was not set.")
         }
         
         let hostComponents = edgeHost.components(separatedBy: ":")
@@ -86,11 +86,11 @@ class Whisk {
         }
         
         var authKey = "authKey"
-        if let authKeyEnv : String = env["__OW_APIKEY"] {
+        if let authKeyEnv : String = env["__OW_API_KEY"] {
             authKey = authKeyEnv
         }
         
-        return (host, port ,authKey)
+        return (host, port, authKey)
     }
     
     // actually do the POST call to the specified OpenWhisk URI path

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -284,7 +284,6 @@ JavaScript functions that run asynchronously may need to return the activation r
 
   Comparing the `start` and `end` time stamps in the activation record, you can see that this activation took slightly over two seconds to complete.
 
-
 ### Using actions to call an external API
 
 The examples so far have been self-contained JavaScript functions. You can also create an action that calls an external API.
@@ -768,3 +767,18 @@ You can clean up by deleting actions that you do not want to use.
   ```
   actions
   ```
+  
+## Accessing action metadata within the action body
+
+The action environment contains several properties that are specific to the running action.
+These allow the action to programmatically work with OpenWhisk assets via the REST API,
+or set an internal alarm when the action is about to use up its allotted time budget.
+The properties are accessible via the system environment for all supported runtimes:
+Node.js, Python, Swift, Java and Docker actions when using the OpenWhisk Docker skeleton.
+
+* `__OW_APIHOST` the API host for the OpenWhisk deployment running this action
+* `__OW_APIKEY` the API key for the subject invoking the action, this key may be a restricted API key
+* `__OW_NAMESPACE` the namespace for the _activation_ (this may not be the same as the namespace for the action)
+* `__OW_ACTION_NAME` the fully qualified name of the running action
+* `__OW_ACTIVATION_ID` the activation id for this running action instance
+* `__OW_DEADLINE` the approximate time when this action will have consumed its entire duration quota (measured in epoch milliseconds)

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -776,8 +776,8 @@ or set an internal alarm when the action is about to use up its allotted time bu
 The properties are accessible via the system environment for all supported runtimes:
 Node.js, Python, Swift, Java and Docker actions when using the OpenWhisk Docker skeleton.
 
-* `__OW_APIHOST` the API host for the OpenWhisk deployment running this action
-* `__OW_APIKEY` the API key for the subject invoking the action, this key may be a restricted API key
+* `__OW_API_HOST` the API host for the OpenWhisk deployment running this action
+* `__OW_API_KEY` the API key for the subject invoking the action, this key may be a restricted API key
 * `__OW_NAMESPACE` the namespace for the _activation_ (this may not be the same as the namespace for the action)
 * `__OW_ACTION_NAME` the fully qualified name of the running action
 * `__OW_ACTIVATION_ID` the activation id for this running action instance

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -141,7 +141,7 @@ function main(params) {
   } else if (params.payload == 1) {
      return {payload: 'Hello, World!'};
   } else if (params.payload == 2) {
-    return whisk.error();   // indicates abnormal completion
+    return {error: 'payload must be 0 or 1'};
   }
 }
 ```
@@ -193,57 +193,6 @@ It is possible for an action to be synchronous on some inputs and asynchronous o
 ```
 
 Notice that regardless of whether an activation is synchronous or asynchronous, the invocation of the action can be blocking or non-blocking.
-
-### Additional SDK methods
-
-The `whisk.invoke()` function invokes another action and returns a Promise for the resulting activation. It takes as an argument a dictionary that defines the following parameters:
-
-- *name*: The fully qualified name of the action to invoke,
-- *parameters*: A JSON object that represents the input to the invoked action. If omitted, defaults to an empty object.
-- *apiKey*: The authorization key with which to invoke the action. Defaults to `whisk.getAuthKey()`.
-- *blocking*: Whether the action should be invoked in blocking or non-blocking mode. When `blocking` is true, invoke will wait for the result of the invoked action before resolving the returned Promise. Defaults to `false`, indicating a non-blocking invocation.
-
-`whisk.invoke()` returns a Promise. In order to make the OpenWhisk system wait for the invoke to finish, you must return this Promise from your action's `main` function.
-- If the invocation fails, the promise will reject with an object describing the failed invocation. It will potentially have two fields:
-  - *error*: An object describing the error - usually a string.
-  - *activation*: An optional dictionary that may or may not be present depending on the nature of the invocation failure. If present, it will have the following fields:
-    - *activationId*: The activation ID:
-    - *result*: If the action was invoked in blocking mode: The action result as a JSON object, else `undefined`.
-- If the invocation succeeds, the promise will resolve with a dictionary describing the activation with fields *activationId* and *result* as described above.
-
-Below is an example of a blocking invocation that utilizes the returned promise:
-```javascript
-return whisk.invoke({
-  name: 'myAction',
-  blocking: true
-})
-.then(function (activation) {
-    // activation completed successfully, activation contains the result
-    console.log('Activation ' + activation.activationId + ' completed successfully and here is the result ' + activation.result);
-})
-.catch(function (reason) {
-    console.log('An error has occured ' + reason.error);
-
-    if(reason.activation) {
-      console.log('Please check activation ' + reason.activation.activationId + ' for details.');
-    } else {
-      console.log('Failed to create activation.');
-    }
-});
-```
-
-The `whisk.trigger()` function fires a trigger and returns a Promise for the resulting activation. It takes as an argument a JSON object with the following parameters:
-
-- *name*: The fully qualified name of trigger to invoke.
-- *parameters*: A JSON object that represents the input to the trigger. If omitted, defaults to an empty object.
-- *apiKey*: The authorization key with which to fire the trigger. Defaults to `whisk.getAuthKey()`.
-
-`whisk.trigger()` returns a Promise. If you require the OpenWhisk system to wait for the trigger to complete, you should return this Promise from your action's `main` function.
-
-- If the trigger fails, the promise will reject with an object describing the error.
-- If the trigger succeeds, the promise will resolve with a dictionary with an `activationId` field containing the activation ID.
-
-The `whisk.getAuthKey()` function returns the authorization key under which the action is running. Usually, you do not need to invoke this function directly because it is used implicitly by the `whisk.invoke()` and `whisk.trigger()` functions.
 
 ### JavaScript runtime environments
 

--- a/tests/dat/actions/asyncError.js
+++ b/tests/dat/actions/asyncError.js
@@ -1,13 +1,3 @@
 function main(params) {
-    var str = params.payload;
-
-    return whisk.invoke({
-        name: '!',    // Invalid action name
-        parameters: {
-            payload: str
-        },
-        blocking: true
-    }).then(function (activation) {
-        return {};
-    });
+    return Promise.reject({msg: 'failed activation on purpose'});
 }

--- a/tests/dat/actions/countdown.js
+++ b/tests/dat/actions/countdown.js
@@ -2,17 +2,19 @@
  * An action that invokes itself recursively, programmatically using the whisk
  * Javascript API.
  */
+var openwhisk = require('openwhisk')
+
 function main(params) {
+    var wsk = openwhisk({ignore_certs: true})
+
     var n = parseInt(params.n);
     console.log(n);
     if (n === 0) {
         console.log('Happy New Year!');
     } else if (n > 0) {
-        return whisk.invoke({
-            name : 'countdown',
-            parameters : {
-                n : n - 1
-            }
+        return wsk.actions.invoke({
+            actionName: process.env['__OW_ACTION_NAME'].split('/')[2],
+            params: { n: n - 1 }
         });
     }
 }

--- a/tests/dat/actions/countdown.js
+++ b/tests/dat/actions/countdown.js
@@ -13,7 +13,7 @@ function main(params) {
         console.log('Happy New Year!');
     } else if (n > 0) {
         return wsk.actions.invoke({
-            actionName: process.env['__OW_ACTION_NAME'].split('/')[2],
+            actionName: process.env['__OW_ACTION_NAME'],
             params: { n: n - 1 }
         });
     }

--- a/tests/dat/actions/helloContext.js
+++ b/tests/dat/actions/helloContext.js
@@ -1,7 +1,7 @@
 function main(args) {
     return {
-       "apihost": process.env['__OW_APIHOST'],
-       "apikey": process.env['__OW_APIKEY'],
+       "api_host": process.env['__OW_API_HOST'],
+       "api_key": process.env['__OW_API_KEY'],
        "namespace": process.env['__OW_NAMESPACE'],
        "action_name": process.env['__OW_ACTION_NAME'],
        "activation_id": process.env['__OW_ACTIVATION_ID'],

--- a/tests/dat/actions/helloContext.js
+++ b/tests/dat/actions/helloContext.js
@@ -1,0 +1,10 @@
+function main(args) {
+    return {
+       "apihost": process.env['__OW_APIHOST'],
+       "apikey": process.env['__OW_APIKEY'],
+       "namespace": process.env['__OW_NAMESPACE'],
+       "action_name": process.env['__OW_ACTION_NAME'],
+       "activation_id": process.env['__OW_ACTIVATION_ID'],
+       "deadline": process.env['__OW_DEADLINE']
+    }
+}

--- a/tests/dat/actions/helloDeadline.js
+++ b/tests/dat/actions/helloDeadline.js
@@ -1,0 +1,20 @@
+function main() {
+
+    var deadline = process.env['__OW_DEADLINE']
+    var timeleft = deadline - new Date().getTime()
+    console.log("deadline in " + timeleft + " msecs");
+
+    var timer = function () {
+       var timeleft = deadline - new Date().getTime()
+       console.log("deadline in " + timeleft + " msecs");
+    }
+    var alarm = setInterval(timer, 1000);
+
+    return new Promise(function(resolve, reject) {
+       setTimeout(function() {
+          clearInterval(alarm);
+          resolve({ timedout: true });
+       }, timeleft - 500);
+    })
+
+}

--- a/tests/dat/actions/helloOpenwhiskPackage.js
+++ b/tests/dat/actions/helloOpenwhiskPackage.js
@@ -1,0 +1,26 @@
+var openwhisk = require('openwhisk')
+
+function main(args) {
+    var wsk = openwhisk({namespace: '_', ignore_certs: args.ignore_certs})
+
+    return new Promise(function (resolve, reject) {
+        return wsk.actions.list().then(list => {
+            console.log("action list has this many actions:", list.length)
+            if (args.name) {
+                console.log('deleting')
+                return wsk.actions.delete({actionName: args.name}).then(result => {
+                    resolve({delete: true})
+                }).catch(function (reason) {
+                    console.log('error', reason)
+                    reject(reason)
+                })
+            } else {
+                console.log('ok')
+                resolve({list: true})
+            }
+        }).catch(function (reason) {
+            console.log('error', reason)
+            reject(reason);
+        })
+    })
+}

--- a/tests/dat/actions/helloOpenwhiskPackage.js
+++ b/tests/dat/actions/helloOpenwhiskPackage.js
@@ -1,7 +1,7 @@
 var openwhisk = require('openwhisk')
 
 function main(args) {
-    var wsk = openwhisk({namespace: '_', ignore_certs: args.ignore_certs})
+    var wsk = openwhisk({ignore_certs: args.ignore_certs})
 
     return new Promise(function (resolve, reject) {
         return wsk.actions.list().then(list => {

--- a/tests/dat/actions/helloPromise.js
+++ b/tests/dat/actions/helloPromise.js
@@ -1,0 +1,9 @@
+function main(args) {
+    return new Promise(function(resolve, reject) {
+        setTimeout(function() {
+            resolve({
+                done : true
+            });
+        }, 2000);
+    })
+}

--- a/tests/dat/actions/stdenv.py
+++ b/tests/dat/actions/stdenv.py
@@ -1,4 +1,4 @@
 import os
 
 def main(dict):
-    return { "auth": os.environ['__OW_APIKEY'], "edge": os.environ['__OW_APIHOST'] }
+    return { "auth": os.environ['__OW_API_KEY'], "edge": os.environ['__OW_API_HOST'] }

--- a/tests/dat/actions/stdenv.py
+++ b/tests/dat/actions/stdenv.py
@@ -1,4 +1,4 @@
 import os
 
 def main(dict):
-    return { "auth": os.environ['AUTH_KEY'], "edge": os.environ['EDGE_HOST'] }
+    return { "auth": os.environ['__OW_APIKEY'], "edge": os.environ['__OW_APIHOST'] }

--- a/tests/dat/actions/wcbin.js
+++ b/tests/dat/actions/wcbin.js
@@ -2,19 +2,22 @@
  * Return word count as a binary number. This demonstrates the use of a blocking
  * invoke.
  */
+var openwhisk = require('openwhisk')
+
 function main(params) {
+    var wsk = openwhisk({ignore_certs: true})
+
     var str = params.payload;
     console.log("The payload is '" + str + "'");
 
-    return whisk.invoke({
-        name: 'wc',
-        parameters: {
+    return wsk.actions.invoke({
+        actionName: 'wc',
+        params: {
             payload: str
         },
         blocking: true
-    }).then(function (activation) {
-        console.log('activation:', activation);
-        var wordsInDecimal = activation.result.count;
+    }).then(activation => {
+        var wordsInDecimal = activation.response.result.count;
         var wordsInBinary = wordsInDecimal.toString(2) + ' (base 2)';
         return {
             binaryCount: wordsInBinary

--- a/tests/src/actionContainers/ActionProxyContainerTests.scala
+++ b/tests/src/actionContainers/ActionProxyContainerTests.scala
@@ -81,19 +81,19 @@ class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSyst
     val stdEnvSamples = {
         val bash = """
                 |#!/bin/bash
-                |echo "{ \"auth\": \"$AUTH_KEY\", \"edge\": \"$EDGE_HOST\" }"
+                |echo "{ \"auth\": \"$__OW_APIKEY\", \"edge\": \"$__OW_APIHOST\" }"
             """.stripMargin.trim
 
         val python = """
                 |#!/usr/bin/env python
                 |import os
-                |print '{ "auth": "%s", "edge": "%s" }' % (os.environ['AUTH_KEY'], os.environ['EDGE_HOST'])
+                |print '{ "auth": "%s", "edge": "%s" }' % (os.environ['__OW_APIKEY'], os.environ['__OW_APIHOST'])
             """.stripMargin.trim
 
         val perl = """
                 |#!/usr/bin/env perl
-                |$a = $ENV{'AUTH_KEY'};
-                |$e = $ENV{'EDGE_HOST'};
+                |$a = $ENV{'__OW_APIKEY'};
+                |$e = $ENV{'__OW_APIHOST'};
                 |print "{ \"auth\": \"$a\", \"edge\": \"$e\" }";
             """.stripMargin.trim
 
@@ -249,7 +249,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
             it should s"run a ${s._1} script and confirm expected environment variables" in {
                 val auth = JsString("abc")
                 val edge = "xyz"
-                val env = Map("EDGE_HOST" -> edge)
+                val env = Map("__OW_APIHOST" -> edge)
 
                 val (out, err) = withActionContainer(env) { c =>
                     val (initCode, _) = c.init(initPayload(s._2))

--- a/tests/src/actionContainers/ActionProxyContainerTests.scala
+++ b/tests/src/actionContainers/ActionProxyContainerTests.scala
@@ -244,7 +244,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
     }
 
     /** Runs tests for code samples which are expected to return the expected standard environment {auth, edge}. */
-    def testEnv(stdEnvSamples: Seq[(String, String)], enforceEmptyOutputStream: Boolean = true) = {
+    def testEnv(stdEnvSamples: Seq[(String, String)], enforceEmptyOutputStream: Boolean = true, enforceEmptyErrorStream: Boolean = true) = {
         for (s <- stdEnvSamples) {
             it should s"run a ${s._1} script and confirm expected environment variables" in {
                 val auth = JsString("abc")
@@ -258,14 +258,14 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
                     val (runCode, out) = c.run(runPayload(JsObject(), Some(JsObject("authKey" -> auth))))
                     runCode should be(200)
                     out shouldBe defined
-                    out.get.fields("auth") shouldBe auth
                     out.get.fields("edge") shouldBe JsString(edge)
+                    out.get.fields("auth") shouldBe auth
                 }
 
                 checkStreams(out, err, {
                     case (o, e) =>
                         if (enforceEmptyOutputStream) o shouldBe empty
-                        e shouldBe empty
+                        if (enforceEmptyErrorStream) e shouldBe empty
                 })
             }
         }

--- a/tests/src/actionContainers/ActionProxyContainerTests.scala
+++ b/tests/src/actionContainers/ActionProxyContainerTests.scala
@@ -78,7 +78,7 @@ class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSyst
         val bash = """
                 |#!/bin/bash
                 |echo "{ \
-                |\"apihost\": \"$__OW_APIHOST\", \"apikey\": \"$__OW_APIKEY\", \
+                |\"api_host\": \"$__OW_API_HOST\", \"api_key\": \"$__OW_API_KEY\", \
                 |\"namespace\": \"$__OW_NAMESPACE\", \"action_name\": \"$__OW_ACTION_NAME\", \
                 |\"activation_id\": \"$__OW_ACTIVATION_ID\", \"deadline\": \"$__OW_DEADLINE\" }"
             """.stripMargin.trim
@@ -87,21 +87,21 @@ class ActionProxyContainerTests extends BasicActionRunnerTests with WskActorSyst
                 |#!/usr/bin/env python
                 |import os
                 |
-                |print '{ "apihost": "%s", "apikey": "%s", "namespace": "%s", "action_name" : "%s", "activation_id": "%s", "deadline": "%s" }' % (
-                |  os.environ['__OW_APIHOST'], os.environ['__OW_APIKEY'],
+                |print '{ "api_host": "%s", "api_key": "%s", "namespace": "%s", "action_name" : "%s", "activation_id": "%s", "deadline": "%s" }' % (
+                |  os.environ['__OW_API_HOST'], os.environ['__OW_API_KEY'],
                 |  os.environ['__OW_NAMESPACE'], os.environ['__OW_ACTION_NAME'],
                 |  os.environ['__OW_ACTIVATION_ID'], os.environ['__OW_DEADLINE'])
             """.stripMargin.trim
 
         val perl = """
                 |#!/usr/bin/env perl
-                |$a = $ENV{'__OW_APIHOST'};
-                |$b = $ENV{'__OW_APIKEY'};
+                |$a = $ENV{'__OW_API_HOST'};
+                |$b = $ENV{'__OW_API_KEY'};
                 |$c = $ENV{'__OW_NAMESPACE'};
                 |$d = $ENV{'__OW_ACTION_NAME'};
                 |$e = $ENV{'__OW_ACTIVATION_ID'};
                 |$f = $ENV{'__OW_DEADLINE'};
-                |print "{ \"apihost\": \"$a\", \"apikey\": \"$b\", \"namespace\": \"$c\", \"action_name\": \"$d\", \"activation_id\": \"$e\", \"deadline\": \"$f\" }";
+                |print "{ \"api_host\": \"$a\", \"api_key\": \"$b\", \"namespace\": \"$c\", \"action_name\": \"$d\", \"activation_id\": \"$e\", \"deadline\": \"$f\" }";
             """.stripMargin.trim
 
         // excluding perl as it not installed in alpine based image
@@ -255,8 +255,8 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
         for (s <- stdEnvSamples) {
             it should s"run a ${s._1} script and confirm expected environment variables" in {
                 val props = Seq(
-                    "apihost" -> "xyz",
-                    "apikey" -> "abc",
+                    "api_host" -> "xyz",
+                    "api_key" -> "abc",
                     "namespace" -> "zzz",
                     "action_name" -> "xxx",
                     "activation_id" -> "iii",

--- a/tests/src/actionContainers/JavaActionContainerTests.scala
+++ b/tests/src/actionContainers/JavaActionContainerTests.scala
@@ -43,7 +43,7 @@ class JavaActionContainerTests extends FlatSpec with Matchers with WskActorSyste
     it should s"run a java snippet and confirm expected environment variables" in {
         val auth = JsString("abc")
         val edge = "xyz"
-        val env = Map("EDGE_HOST" -> edge)
+        val env = Map("__OW_APIHOST" -> edge)
         val (out, err) = withJavaContainer({ c =>
             val jar = JarBuilder.mkBase64Jar(
                 Seq("example", "HelloWhisk.java") -> """
@@ -54,8 +54,8 @@ class JavaActionContainerTests extends FlatSpec with Matchers with WskActorSyste
                     | public class HelloWhisk {
                     |     public static JsonObject main(JsonObject args) {
                     |         JsonObject response = new JsonObject();
-                    |         response.addProperty("edge", System.getenv("EDGE_HOST"));
-                    |         response.addProperty("auth", System.getenv("AUTH_KEY"));
+                    |         response.addProperty("edge", System.getenv("__OW_APIHOST"));
+                    |         response.addProperty("auth", System.getenv("__OW_APIKEY"));
                     |         return response;
                     |     }
                     | }

--- a/tests/src/actionContainers/JavaActionContainerTests.scala
+++ b/tests/src/actionContainers/JavaActionContainerTests.scala
@@ -42,8 +42,8 @@ class JavaActionContainerTests extends FlatSpec with Matchers with WskActorSyste
     behavior of "Java action"
 
     it should s"run a java snippet and confirm expected environment variables" in {
-        val props = Seq("apihost" -> "xyz",
-            "apikey" -> "abc",
+        val props = Seq("api_host" -> "xyz",
+            "api_key" -> "abc",
             "namespace" -> "zzz",
             "action_name" -> "xxx",
             "activation_id" -> "iii",
@@ -59,8 +59,8 @@ class JavaActionContainerTests extends FlatSpec with Matchers with WskActorSyste
                     | public class HelloWhisk {
                     |     public static JsonObject main(JsonObject args) {
                     |         JsonObject response = new JsonObject();
-                    |         response.addProperty("apihost", System.getenv("__OW_APIHOST"));
-                    |         response.addProperty("apikey", System.getenv("__OW_APIKEY"));
+                    |         response.addProperty("api_host", System.getenv("__OW_API_HOST"));
+                    |         response.addProperty("api_key", System.getenv("__OW_API_KEY"));
                     |         response.addProperty("namespace", System.getenv("__OW_NAMESPACE"));
                     |         response.addProperty("action_name", System.getenv("__OW_ACTION_NAME"));
                     |         response.addProperty("activation_id", System.getenv("__OW_ACTIVATION_ID"));

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -74,8 +74,8 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         ("node", """
          |function main(args) {
          |    return {
-         |       "apihost": process.env['__OW_APIHOST'],
-         |       "apikey": process.env['__OW_APIKEY'],
+         |       "api_host": process.env['__OW_API_HOST'],
+         |       "api_key": process.env['__OW_API_KEY'],
          |       "namespace": process.env['__OW_NAMESPACE'],
          |       "action_name": process.env['__OW_ACTION_NAME'],
          |       "activation_id": process.env['__OW_ACTIVATION_ID'],

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -73,7 +73,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
     testEnv(Seq {
         ("node", """
          |function main(args) {
-         |    return { "auth": process.env['AUTH_KEY'], "edge": process.env['EDGE_HOST'] }
+         |    return { "auth": process.env['__OW_APIKEY'], "edge": process.env['__OW_APIHOST'] }
          }
          """.stripMargin.trim)
     })

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -201,7 +201,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         })
     }
 
-    it should "warn when using deperecated whisk object methods" in {
+    it should "warn when using deprecated whisk object methods" in {
         val (out, err) = withNodeJsContainer { c =>
             val code = """
                 | function main(args) {
@@ -228,7 +228,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         })
     }
 
-    it should "warn when using deperecated whisk.error" in {
+    it should "warn when using deprecated whisk.error" in {
         val (out, err) = withNodeJsContainer { c =>
             val code = """
                 | function main(args) {

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -31,6 +31,8 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
 
     lazy val nodejsContainerImageName = "nodejsaction"
 
+    val hasDeprecationWarnings = true
+
     override def withActionContainer(env: Map[String, String] = Map.empty)(code: ActionContainer => Unit) = {
         withContainer(nodejsContainerImageName, env)(code)
     }
@@ -66,6 +68,14 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
           |    return args
           |}
           """.stripMargin)
+    })
+
+    testEnv(Seq {
+        ("node", """
+         |function main(args) {
+         |    return { "auth": process.env['AUTH_KEY'], "edge": process.env['EDGE_HOST'] }
+         }
+         """.stripMargin.trim)
     })
 
     it should "fail to initialize with bad code" in {
@@ -158,7 +168,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o shouldBe empty
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
         })
     }
 
@@ -180,7 +190,58 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o shouldBe empty
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
+        })
+    }
+
+    it should "warn when using deperecated whisk object methods" in {
+        val (out, err) = withNodeJsContainer { c =>
+            val code = """
+                | function main(args) {
+                |     whisk.getAuthKey(whisk.setAuthKey('xxx'));
+                |     try { whisk.invoke(); } catch (e) {}
+                |     try { whisk.trigger();  } catch (e) {}
+                |     setTimeout(function () { whisk.done(); }, 1000);
+                |     return whisk.async();
+                | }
+            """.stripMargin
+
+            c.init(initPayload(code))._1 should be(200)
+
+            val (runCode, runRes) = c.run(runPayload(JsObject()))
+            runCode should be(200)
+        }
+
+        checkStreams(out, err, {
+            case (o, e) =>
+                o shouldBe empty
+                e should not be empty
+                val lines = e.split("\n")
+                lines.filter { l => l.startsWith("[WARN] \"whisk.") && l.contains("deprecated") }.length shouldBe 8
+        })
+    }
+
+    it should "warn when using deperecated whisk.error" in {
+        val (out, err) = withNodeJsContainer { c =>
+            val code = """
+                | function main(args) {
+                |     whisk.error("{warnme: true}");
+                | }
+            """.stripMargin
+
+            c.init(initPayload(code))._1 should be(200)
+
+            val (runCode, runRes) = c.run(runPayload(JsObject()))
+            runCode should be(200)
+        }
+
+        checkStreams(out, err, {
+            case (o, e) =>
+                o shouldBe empty
+                e should not be empty
+                val lines = e.split("\n")
+                lines.length shouldBe 1
+                lines.forall { l => l.startsWith("[WARN] \"whisk.") && l.contains("deprecated") }
         })
     }
 
@@ -205,7 +266,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o should include("more than once")
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
         })
     }
 
@@ -243,7 +304,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o shouldBe empty
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
         }, 3)
     }
 
@@ -268,7 +329,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o shouldBe empty
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
         })
     }
 
@@ -302,7 +363,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 o shouldBe empty
-                e shouldBe empty
+                if (!hasDeprecationWarnings) e shouldBe empty
         }, 2)
     }
 

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -73,8 +73,15 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
     testEnv(Seq {
         ("node", """
          |function main(args) {
-         |    return { "auth": process.env['__OW_APIKEY'], "edge": process.env['__OW_APIHOST'] }
-         }
+         |    return {
+         |       "apihost": process.env['__OW_APIHOST'],
+         |       "apikey": process.env['__OW_APIKEY'],
+         |       "namespace": process.env['__OW_NAMESPACE'],
+         |       "action_name": process.env['__OW_ACTION_NAME'],
+         |       "activation_id": process.env['__OW_ACTIVATION_ID'],
+         |       "deadline": process.env['__OW_DEADLINE']
+         |    }
+         |}
          """.stripMargin.trim)
     })
 

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -53,7 +53,14 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
         ("python", """
          |import os
          |def main(dict):
-         |    return { "auth": os.environ['__OW_APIKEY'], "edge": os.environ['__OW_APIHOST'] }
+         |    return {
+         |       "apihost": os.environ['__OW_APIHOST'],
+         |       "apikey": os.environ['__OW_APIKEY'],
+         |       "namespace": os.environ['__OW_NAMESPACE'],
+         |       "action_name": os.environ['__OW_ACTION_NAME'],
+         |       "activation_id": os.environ['__OW_ACTIVATION_ID'],
+         |       "deadline": os.environ['__OW_DEADLINE']
+         |    }
          """.stripMargin.trim)
     })
 

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -54,8 +54,8 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
          |import os
          |def main(dict):
          |    return {
-         |       "apihost": os.environ['__OW_APIHOST'],
-         |       "apikey": os.environ['__OW_APIKEY'],
+         |       "api_host": os.environ['__OW_API_HOST'],
+         |       "api_key": os.environ['__OW_API_KEY'],
          |       "namespace": os.environ['__OW_NAMESPACE'],
          |       "action_name": os.environ['__OW_ACTION_NAME'],
          |       "activation_id": os.environ['__OW_ACTIVATION_ID'],

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -53,7 +53,7 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
         ("python", """
          |import os
          |def main(dict):
-         |    return { "auth": os.environ['AUTH_KEY'], "edge": os.environ['EDGE_HOST'] }
+         |    return { "auth": os.environ['__OW_APIKEY'], "edge": os.environ['__OW_APIHOST'] }
          """.stripMargin.trim)
     })
 

--- a/tests/src/actionContainers/Swift3ActionContainerTests.scala
+++ b/tests/src/actionContainers/Swift3ActionContainerTests.scala
@@ -32,10 +32,10 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
          |     let env = ProcessInfo.processInfo.environment
          |     var auth = "???"
          |     var edge = "???"
-         |     if let authKey : String = env["AUTH_KEY"] {
+         |     if let authKey : String = env["__OW_APIKEY"] {
          |         auth = "\(authKey)"
          |     }
-         |     if let edgeHost : String = env["EDGE_HOST"] {
+         |     if let edgeHost : String = env["__OW_APIHOST"] {
          |         edge = "\(edgeHost)"
          |     }
          |     return ["auth": auth, "edge": edge]

--- a/tests/src/actionContainers/Swift3ActionContainerTests.scala
+++ b/tests/src/actionContainers/Swift3ActionContainerTests.scala
@@ -27,20 +27,8 @@ class Swift3ActionContainerTests extends SwiftActionContainerTests {
 
     override val enforceEmptyOutputStream = false
     override lazy val swiftContainerImageName = "swift3action"
-    override lazy val envCode =  """
-         |func main(args: [String: Any]) -> [String: Any] {
-         |     let env = ProcessInfo.processInfo.environment
-         |     var auth = "???"
-         |     var edge = "???"
-         |     if let authKey : String = env["__OW_APIKEY"] {
-         |         auth = "\(authKey)"
-         |     }
-         |     if let edgeHost : String = env["__OW_APIHOST"] {
-         |         edge = "\(edgeHost)"
-         |     }
-         |     return ["auth": auth, "edge": edge]
-         |}
-         """.stripMargin
+    override lazy val envCode = makeEnvCode("ProcessInfo.processInfo")
+
     override lazy val errorCode = """
                 | // You need an indirection, or swiftc detects the div/0
                 | // at compile-time. Smart.

--- a/tests/src/actionContainers/SwiftActionContainerTests.scala
+++ b/tests/src/actionContainers/SwiftActionContainerTests.scala
@@ -38,10 +38,10 @@ class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSyst
          |     let env = NSProcessInfo.processInfo().environment
          |     var auth = "???"
          |     var edge = "???"
-         |     if let authKey : String = env["AUTH_KEY"] {
+         |     if let authKey : String = env["__OW_APIKEY"] {
          |         auth = "\(authKey)"
          |     }
-         |     if let edgeHost : String = env["EDGE_HOST"] {
+         |     if let edgeHost : String = env["__OW_APIHOST"] {
          |         edge = "\(edgeHost)"
          |     }
          |     return ["auth": auth, "edge": edge]

--- a/tests/src/actionContainers/SwiftActionContainerTests.scala
+++ b/tests/src/actionContainers/SwiftActionContainerTests.scala
@@ -32,21 +32,38 @@ class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSyst
     // prints status messages and there doesn't seem to be a way to quiet them
     val enforceEmptyOutputStream = true
     lazy val swiftContainerImageName = "swiftaction"
+    lazy val envCode = makeEnvCode("NSProcessInfo.processInfo()")
 
-    lazy val envCode = """
+    def makeEnvCode(processInfo: String) = ("""
          |func main(args: [String: Any]) -> [String: Any] {
-         |     let env = NSProcessInfo.processInfo().environment
-         |     var auth = "???"
-         |     var edge = "???"
-         |     if let authKey : String = env["__OW_APIKEY"] {
-         |         auth = "\(authKey)"
+         |     let env = """+processInfo+""".environment
+         |     var a = "???"
+         |     var b = "???"
+         |     var c = "???"
+         |     var d = "???"
+         |     var e = "???"
+         |     var f = "???"
+         |     if let v : String = env["__OW_APIHOST"] {
+         |         a = "\(v)"
          |     }
-         |     if let edgeHost : String = env["__OW_APIHOST"] {
-         |         edge = "\(edgeHost)"
+         |     if let v : String = env["__OW_APIKEY"] {
+         |         b = "\(v)"
          |     }
-         |     return ["auth": auth, "edge": edge]
+         |     if let v : String = env["__OW_NAMESPACE"] {
+         |         c = "\(v)"
+         |     }
+         |     if let v : String = env["__OW_ACTION_NAME"] {
+         |         d = "\(v)"
+         |     }
+         |     if let v : String = env["__OW_ACTIVATION_ID"] {
+         |         e = "\(v)"
+         |     }
+         |     if let v : String = env["__OW_DEADLINE"] {
+         |         f = "\(v)"
+         |     }
+         |     return ["apihost": a, "apikey": b, "namespace": c, "action_name": d, "activation_id": e, "deadline": f]
          |}
-         """.stripMargin
+         """).stripMargin
 
     lazy val errorCode = """
                 | // You need an indirection, or swiftc detects the div/0

--- a/tests/src/actionContainers/SwiftActionContainerTests.scala
+++ b/tests/src/actionContainers/SwiftActionContainerTests.scala
@@ -43,10 +43,10 @@ class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSyst
          |     var d = "???"
          |     var e = "???"
          |     var f = "???"
-         |     if let v : String = env["__OW_APIHOST"] {
+         |     if let v : String = env["__OW_API_HOST"] {
          |         a = "\(v)"
          |     }
-         |     if let v : String = env["__OW_APIKEY"] {
+         |     if let v : String = env["__OW_API_KEY"] {
          |         b = "\(v)"
          |     }
          |     if let v : String = env["__OW_NAMESPACE"] {
@@ -61,7 +61,7 @@ class SwiftActionContainerTests extends BasicActionRunnerTests with WskActorSyst
          |     if let v : String = env["__OW_DEADLINE"] {
          |         f = "\(v)"
          |     }
-         |     return ["apihost": a, "apikey": b, "namespace": c, "action_name": d, "activation_id": e, "deadline": f]
+         |     return ["api_host": a, "api_key": b, "namespace": c, "action_name": d, "activation_id": e, "deadline": f]
          |}
          """).stripMargin
 

--- a/tests/src/system/basic/CLIPythonTests.scala
+++ b/tests/src/system/basic/CLIPythonTests.scala
@@ -72,7 +72,7 @@ class CLIPythonTests
 
     it should "invoke an invalid action and get error back" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val name = "basicInvoke"
+            val name = "bad code"
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("malformed.py")))
             }

--- a/tests/src/system/basic/WskActionTests.scala
+++ b/tests/src/system/basic/WskActionTests.scala
@@ -45,6 +45,22 @@ class WskActionTests
 
     behavior of "Whisk actions"
 
+    it should "invoke an action returning a promise" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "hello promise"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
+            }
+
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.status shouldBe "success"
+                    activation.response.result shouldBe Some(JsObject("done" -> true.toJson))
+                    activation.logs.get.mkString(" ") shouldBe empty
+            }
+    }
+
     it should "invoke an action with a space in the name" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "hello Async"

--- a/tests/src/system/basic/WskActionTests.scala
+++ b/tests/src/system/basic/WskActionTests.scala
@@ -185,7 +185,7 @@ class WskActionTests
             wsk.parseJsonString(rr.stdout).getFieldPath("exec", "code") shouldBe Some(JsString(""))
     }
 
-    it should "blocking invoke nested blocking actions" in withAssetCleaner(wskprops) {
+    it should "blocking invoke of nested blocking actions" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "nestedBlockingAction"
             val child = "wc"

--- a/tests/src/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/system/basic/WskBasicNodeTests.scala
@@ -113,6 +113,7 @@ class WskBasicNodeTests
             }
     }
 
+    // TODO: remove this tests and its assets when "whisk.js" is removed entirely as it is no longer necessary
     it should "Ensure that whisk.invoke() returns a promise" in withAssetCleaner(wskprops) {
         val expectedDuration = 3.seconds
 
@@ -165,6 +166,7 @@ class WskBasicNodeTests
             }
     }
 
+    // TODO: remove this tests and its assets when "whisk.js" is removed entirely as it is no longer necessary
     it should "Ensure that whisk.invoke() still uses a callback when provided one" in withAssetCleaner(wskprops) {
         val expectedDuration = 3.seconds
 
@@ -216,6 +218,7 @@ class WskBasicNodeTests
             }
     }
 
+    // TODO: remove this tests and its assets when "whisk.js" is removed entirely as it is no longer necessary
     it should "Ensure that whisk.trigger() still uses a callback when provided one" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // this action supplies a 'next' callback to whisk.trigger()
@@ -251,6 +254,7 @@ class WskBasicNodeTests
             }
     }
 
+    // TODO: remove this tests and its assets when "whisk.js" is removed entirely as it is no longer necessary
     it should "Ensure that whisk.trigger() returns a promise" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // this action supplies a 'next' callback to whisk.trigger()

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -16,19 +16,15 @@
 
 package system.basic
 
-import java.time.Instant
 import java.io.File
+import java.time.Instant
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import common.TestHelpers
 import common.TestUtils
-import common.TestUtils.CONFLICT
-import common.TestUtils.SUCCESS_EXIT
-import common.TestUtils.UNAUTHORIZED
-import common.TestUtils.FORBIDDEN
-import common.TestUtils.ERROR_EXIT
+import common.TestUtils._
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
@@ -359,15 +355,17 @@ class WskBasicTests
             }
     }
 
-    it should "create and invoke a blocking action resulting in an error response object" in withAssetCleaner(wskprops) {
+    it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "errorResponseObject"
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
             }
 
-            wsk.action.invoke(name, blocking = true, expectedExitCode = 246)
-                .stderr should include regex (""""error": "name '!' contains illegal characters \(code \d+\)"""")
+            val stderr = wsk.action.invoke(name, blocking = true, expectedExitCode = 246).stderr
+            CliActivation.serdes.read(stderr.parseJson).response.result shouldBe Some {
+                JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
+            }
     }
 
     it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) {

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -486,8 +486,8 @@ class WskBasicUsageTests
                 activation =>
                     activation.response.status shouldBe "success"
                     val fields = activation.response.result.get.convertTo[Map[String, String]]
-                    fields("apihost") shouldBe WhiskProperties.getEdgeHost + ":" + WhiskProperties.getEdgeHostApiPort
-                    fields("apikey") shouldBe wskprops.authKey
+                    fields("api_host") shouldBe WhiskProperties.getEdgeHost + ":" + WhiskProperties.getEdgeHostApiPort
+                    fields("api_key") shouldBe wskprops.authKey
                     fields("namespace") shouldBe user
                     fields("action_name") shouldBe s"/$user/$name"
                     fields("activation_id") shouldBe activation.activationId


### PR DESCRIPTION
This pull request does three things:

1. add deprecation notice to uses of `whisk.[invoke, trigger, etc]` in nodejs actions
2. adds npm openwhisk to the base image for nodejs actions
3. makes auth key and edge host available for java (the only runtime that was missing them)

These are part of proposal made in https://github.com/openwhisk/openwhisk/issues/616#issuecomment-261722521.