### PR TITLE
Update NodeJS runtimes and packages to latest

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -1,7 +1,7 @@
 FROM nodejsactionbase
 
 # based on https://github.com/nodejs/docker-node
-ENV NODE_VERSION 6.7.0
+ENV NODE_VERSION 6.9.1
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
@@ -19,51 +19,59 @@ RUN rm -rf .project .settings build.xml Dockerfile README node_modules logs
 RUN npm install .
 
 RUN npm install \
-apn@1.7.5 \
-async@1.5.2 \
-body-parser@1.15.1 \
+apn@2.1.2 \
+async@2.1.4 \
+body-parser@1.15.2 \
 btoa@1.1.2 \
-cheerio@0.20.0 \
-cloudant@1.4.1 \
+cheerio@0.22.0 \
+cloudant@1.6.2 \
 commander@2.9.0 \
-consul@0.25.0 \
-cookie-parser@1.4.2 \
+consul@0.27.0 \
+cookie-parser@1.4.3 \
 cradle@0.7.1 \
-errorhandler@1.4.3 \
-express@4.13.4 \
-express-session@1.12.1 \
-gm@1.22.0 \
+errorhandler@1.5.0 \
+express@4.14.0 \
+express-session@1.14.2 \
+glob@7.1.1 \
+gm@1.23.0 \
 lodash@4.17.2 \
-log4js@0.6.36 \
-iconv-lite@0.4.13 \
+log4js@0.6.38 \
+iconv-lite@0.4.15 \
+marked@0.3.6 \
 merge@1.2.0 \
-moment@2.13.0 \
-mustache@2.2.1 \
+moment@2.17.0 \
+mongodb@2.2.11 \
+mustache@2.3.0 \
 nano@6.2.0 \
 node-uuid@1.4.7 \
-nodemailer@2.5.0 \
+nodemailer@2.6.4 \
 oauth2-server@2.4.1 \
-pkgcloud@1.3.0 \
-process@0.11.3 \
-pug@">2.0.0-alpha <2.0.1" \
-request@2.72.0 \
+pkgcloud@1.4.0 \
+process@0.11.9 \
+pug@">=2.0.0-beta6 <2.0.1" \
+redis@2.6.3 \
+request@2.79.0 \
 request-promise@4.1.1 \
-rimraf@2.5.2 \
-semver@5.1.0 \
-sendgrid@3.0.11 \
-serve-favicon@2.3.0 \
-socket.io@1.4.6 \
-socket.io-client@1.4.6 \
-superagent@1.8.3 \
+rimraf@2.5.4 \
+semver@5.3.0 \
+sendgrid@4.7.1 \
+serve-favicon@2.3.2 \
+socket.io@1.6.0 \
+socket.io-client@1.6.0 \
+superagent@3.0.0 \
 swagger-tools@0.10.1 \
-tmp@0.0.28 \
-twilio@2.9.1 \
+tmp@0.0.31 \
+twilio@2.11.1 \
+underscore@1.8.3 \
+uuid@3.0.0 \
+validator@6.1.0 \
 watson-developer-cloud@2.9.0 \
 when@3.7.7 \
-ws@1.1.0 \
-xml2js@0.4.16 \
+winston@2.3.0 \
+ws@1.1.1 \
+xml2js@0.4.17 \
 xmlhttprequest@1.8.0 \
-yauzl@2.4.2
+yauzl@2.7.0
 
 # See app.js
 CMD node app.js

--- a/core/nodejsAction/Dockerfile
+++ b/core/nodejsAction/Dockerfile
@@ -1,7 +1,7 @@
 FROM nodejsactionbase
 
 # based on https://github.com/nodejs/docker-node
-ENV NODE_VERSION 0.12.16
+ENV NODE_VERSION 0.12.17
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
@@ -14,7 +14,7 @@ RUN npm install .
 RUN npm install \
 apn@1.7.4 \
 async@1.5.2 \
-body-parser@1.12.0 \
+body-parser@1.15.2 \
 btoa@1.1.2 \
 cheerio@0.20.0 \
 cloudant@1.4.1 \
@@ -23,11 +23,11 @@ consul@0.18.1 \
 cookie-parser@1.3.4 \
 cradle@0.6.7 \
 errorhandler@1.3.5 \
-express@4.12.2 \
+express@4.14.0 \
 express-session@1.11.1 \
 gm@1.20.0 \
 jade@1.9.2 \
-log4js@0.6.25 \
+log4js@0.6.38 \
 merge@1.2.0 \
 moment@2.8.1 \
 mustache@2.1.3 \
@@ -35,7 +35,7 @@ nano@5.10.0 \
 node-uuid@1.4.2 \
 oauth2-server@2.4.0 \
 process@0.11.0 \
-request@2.60.0 \
+request@2.79.0 \
 rimraf@2.5.1 \
 semver@4.3.6 \
 serve-favicon@2.2.0 \

--- a/core/nodejsActionBase/package.json
+++ b/core/nodejsActionBase/package.json
@@ -2,10 +2,10 @@
   "name": "nodejsAction",
   "version": "0.0.1",
   "dependencies": {
-    "body-parser": "^1.11.0",
-    "btoa": "^1.1.2",
-    "express": "^4.11.2",
-    "log4js": "^0.6.20",
-    "request": "^2.60.0"
+    "body-parser": "1.15.2",
+    "btoa": "1.1.2",
+    "express": "4.14.0",
+    "log4js": "0.6.38",
+    "request": "2.79.0"
   }
 }


### PR DESCRIPTION
- Updates NodeJS6 to LTS for 6.x (today [6.9.1](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-10-19-version-691-boron-lts-thealphanerd))
- Updates NodeJS0.12 to 0.1.2.17 to pick up a [security fix](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md#2016-10-18-version-01217-maintenance-rvagg)  
- Updates NPM Packages to latest versions (for nodejs6)
- Add some popular NPM packages (for nodejs6)
  - winston (MIT)
  - underscore (MIT)
  - uuid (MIT)
  - validator (MIT)
  - redis (MIT)
  - marked (MIT)
  - glob (ISC)
- Pinned the versions of npm packages for that the proxy server since it was using "^x.x.x"
  - log4js needs to remain 0.x since 1.x doesn't support nodejs 0.12 and our proxy is share for now