### PR TITLE
Warn user when consul configuration fails.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -158,6 +158,8 @@ object WhiskConfig extends Logging {
                     val kvp = ConsulKV.WhiskProps.whiskProps + "/" + p.replace('.', '_').toUpperCase
                     whiskProps.get(kvp) foreach { properties += p -> _ }
                 }
+            } recover {
+                case ex => warn(this, s"failed to read properties from consul: ${ex.getMessage}")
             }
             case _ => info(this, "no consul server defined")
         }


### PR DESCRIPTION
It may happen that we cannot read configuration from consul, in such
cases (server is down / unreachable / etc.) log a warning to inform the
user of the issue.

This happened to me on my first deployment, and I was startled at why
the controller was unable to pull its configuration from consul.

I have sent a signed CLA as is asked int CONTRIBUTING.md