### PR TITLE
make netcat wait for response from zookeeper before closing connection

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -12,7 +12,7 @@
       - "{{ zookeeper.port }}:2181"
 
 - name: wait until the Zookeeper in this host is up and running
-  action: shell echo ruok | nc -w 3 {{ inventory_hostname }} {{ zookeeper.port }}
+  action: shell echo ruok | nc -w 3 -q 3 {{ inventory_hostname }} {{ zookeeper.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == 'imok')
   retries: 36


### PR DESCRIPTION
we noticed on some systems nc returns immediately and does not wait for the "iamok" response before closing the connection. the `-q` param forces nc to wait for n seconds until it gets something on stdin.