### PR TITLE
give zookeeper a second to respond before closing connection during ruok query

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -12,7 +12,7 @@
       - "{{ zookeeper.port }}:2181"
 
 - name: wait until the Zookeeper in this host is up and running
-  action: shell echo ruok | nc -w 3 -q 3 {{ inventory_hostname }} {{ zookeeper.port }}
+  action: shell echo ruok | nc -w 3 -i 1 {{ inventory_hostname }} {{ zookeeper.port }}
   register: result
   until: (result.rc == 0) and (result.stdout == 'imok')
   retries: 36


### PR DESCRIPTION
the -q option does only exist in bsd versions of netcat. -i exists in both gnu and bsd versions. so using it in all cases for simplicity.