### PR TITLE
Fix SchedulerTests: Wait for the actor to be terminated

### DIFF
--- a/tests/src/whisk/common/SchedulerTests.scala
+++ b/tests/src/whisk/common/SchedulerTests.scala
@@ -31,6 +31,7 @@ import org.scalatest.junit.JUnitRunner
 import akka.actor.PoisonPill
 
 import common.WskActorSystem
+import scala.concurrent.Await
 
 @RunWith(classOf[JUnitRunner])
 class SchedulerTests extends FlatSpec with Matchers with WskActorSystem {
@@ -64,7 +65,9 @@ class SchedulerTests extends FlatSpec with Matchers with WskActorSystem {
         }
 
         waitForCalls()
-        scheduled ! PoisonPill
+        // This is equal to a scheduled ! PoisonPill
+        val shutdownTimeout = 10.seconds
+        Await.result(akka.pattern.gracefulStop(scheduled, shutdownTimeout, PoisonPill), shutdownTimeout)
 
         val countAfterKill = callCount
         callCount should be >= callsToProduce


### PR DESCRIPTION
This should fix race conditions with the Actor receiving messages before the PoisonPill.