### PR TITLE
Add the method to get the credentials as a json object

### DIFF
--- a/tests/src/common/TestUtils.java
+++ b/tests/src/common/TestUtils.java
@@ -122,9 +122,7 @@ public class TestUtils {
      */
     public static Map<String, String> getVCAPcredentials(String vcapService) {
         try {
-            JsonArray vcapArray = getVCAPServices().get(vcapService).getAsJsonArray();
-            JsonObject vcapObject = vcapArray.get(0).getAsJsonObject();
-            JsonObject credentials = vcapObject.get("credentials").getAsJsonObject();
+            JsonObject credentials = getCredentials(vcapService);
             Map<String, String> map = new HashMap<String, String>();
             for (Map.Entry<String, JsonElement> entry : credentials.entrySet()) {
                 map.put(entry.getKey(), credentials.get(entry.getKey()).getAsString());
@@ -135,6 +133,18 @@ public class TestUtils {
             System.out.println("failed to parse VCAP" + t);
             return Collections.emptyMap();
         }
+    }
+
+    /**
+     * Gets a VCAP_SERVICES credentials as the json objects.
+     *
+     * @return VCAP credentials as a json object.
+     */
+    public static JsonObject getCredentials(String vcapService) {
+        JsonArray vcapArray = getVCAPServices().get(vcapService).getAsJsonArray();
+        JsonObject vcapObject = vcapArray.get(0).getAsJsonObject();
+        JsonObject credentials = vcapObject.get("credentials").getAsJsonObject();
+        return credentials;
     }
 
     /**


### PR DESCRIPTION
Since we are going to add the credentials for message hub in the
vcap file, we expect the property "kafka_brokers_sasl" as a list.
That is the reason why we need to get the credentials as a json
object instead of a hashmap.