### PR TITLE
Tighten container reclamation.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -17,6 +17,7 @@
 package whisk.http
 
 import scala.util.Try
+import scala.concurrent.duration.Duration
 
 import spray.http.StatusCode
 import spray.http.StatusCodes.Forbidden
@@ -76,6 +77,28 @@ object Messages {
 
     /** Error messages for bad requests where parameters do not conform. */
     val parametersNotAllowed = "Request defines parameters that are not allowed (e.g., reserved properties)."
+
+    /** Error messages for activations. */
+    val abnormalInitialization = "The action did not initialize and exited unexpectedly."
+    val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
+
+    def invalidInitResponse(actualResponse: String) = {
+        "The action failed during initialization" + {
+            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
+        }
+    }
+
+    def invalidRunResponse(actualResponse: String) = {
+        "The action did not produce a valid JSON response" + {
+            Option(actualResponse) filter { _.nonEmpty } map { s => s": $s" } getOrElse "."
+        }
+    }
+
+    def timedoutActivation(timeout: Duration, init: Boolean) = {
+        s"The action exceeded its time limits of ${timeout.toMillis} milliseconds" + {
+            if (!init) "." else " during initialization."
+        }
+    }
 }
 
 /** Replaces rejections with Json object containing cause and transaction id. */

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -44,6 +44,7 @@ import whisk.core.dispatcher.ActivationFeed.{ ActivationNotification, ContainerR
 import whisk.core.entity._
 import whisk.core.entity.size.{ SizeInt, SizeString }
 import whisk.http.BasicHttpService
+import whisk.http.Messages
 import whisk.utils.ExecutionContextFactory
 
 /**
@@ -383,7 +384,7 @@ class Invoker(
         failedInit: Boolean)(
             implicit transid: TransactionId): ActivationResponse = {
         if (interval.duration >= timeout) {
-            ActivationResponse.applicationError(ActivationResponse.timedoutActivation(timeout, failedInit))
+            ActivationResponse.applicationError(Messages.timedoutActivation(timeout, failedInit))
         } else if (!failedInit) {
             ActivationResponse.processRunResponseContent(response, this: Logging)
         } else {

--- a/tests/dat/actions/helloDeadline.js
+++ b/tests/dat/actions/helloDeadline.js
@@ -1,4 +1,4 @@
-function main() {
+function main(args) {
 
     var deadline = process.env['__OW_DEADLINE']
     var timeleft = deadline - new Date().getTime()
@@ -13,7 +13,11 @@ function main() {
     return new Promise(function(resolve, reject) {
        setTimeout(function() {
           clearInterval(alarm);
-          resolve({ timedout: true });
+          if (args.forceHang) {
+              // do not resolve the promise and make the action timeout
+          } else {
+              resolve({ timedout: true });
+          }
        }, timeleft - 500);
     })
 

--- a/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -344,7 +344,7 @@ class WskBasicUsageTests
             withActivation(wsk.activation, wsk.action.invoke(name)) {
                 activation =>
                     val response = activation.response
-                    response.result.get.fields("error") shouldBe ActivationResponse.abnormalInitialization
+                    response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
                     response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
             }
     }
@@ -363,7 +363,7 @@ class WskBasicUsageTests
             withActivation(wsk.activation, wsk.action.invoke(name)) {
                 activation =>
                     val response = activation.response
-                    response.result.get.fields("error") shouldBe ActivationResponse.timedoutActivation(3 seconds, true)
+                    response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
                     response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
             }
     }
@@ -378,7 +378,7 @@ class WskBasicUsageTests
             withActivation(wsk.activation, wsk.action.invoke(name)) {
                 activation =>
                     val response = activation.response
-                    response.result.get.fields("error") shouldBe ActivationResponse.abnormalRun
+                    response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
                     response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ContainerError)
             }
     }
@@ -530,7 +530,7 @@ class WskBasicUsageTests
                 activation =>
                     // the first action must fail with a timeout error
                     activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
-                    activation.response.result shouldBe Some(JsObject("error" -> "The action exceeded its time limits of 3000 milliseconds.".toJson))
+                    activation.response.result shouldBe Some(JsObject("error" -> Messages.timedoutActivation(3 seconds, false).toJson))
             }
 
             // run the action again, this time without forcing it to timeout

--- a/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
@@ -27,6 +27,7 @@ import spray.json.pimpAny
 import spray.json.pimpString
 import whisk.common.Logging
 import whisk.core.entity.ActivationResponse._
+import whisk.http.Messages._
 
 @RunWith(classOf[JUnitRunner])
 class ActivationResponseTests extends FlatSpec with Matchers {
@@ -38,14 +39,14 @@ class ActivationResponseTests extends FlatSpec with Matchers {
     it should "interpret failed init that does not response" in {
         val ar = processInitResponseContent(None, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalInitialization
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalInitialization.toJson
     }
 
     it should "interpret failed init that responds with null string" in {
         val response = Some(500, null)
         val ar = processInitResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2).toJson
         ar.result.get.toString should not include regex("null")
     }
 
@@ -53,7 +54,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, "")
         val ar = processInitResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2).toJson
         ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
     }
 
@@ -61,7 +62,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, "true")
         val ar = processInitResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2).toJson
         ar.result.get.toString should include(response.get._2)
     }
 
@@ -69,7 +70,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, Vector(1).toJson.compactPrint)
         val ar = processInitResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2).toJson
         ar.result.get.toString should include(response.get._2)
     }
 
@@ -84,7 +85,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, Map("foobar" -> "baz").toJson.compactPrint)
         val ar = processInitResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidInitResponse(response.get._2).toJson
         ar.result.get.toString should include("baz")
     }
 
@@ -98,14 +99,14 @@ class ActivationResponseTests extends FlatSpec with Matchers {
     it should "interpret failed run that does not response" in {
         val ar = processRunResponseContent(None, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalRun
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe abnormalRun.toJson
     }
 
     it should "interpret failed run that responds with null string" in {
         val response = Some(500, null)
         val ar = processRunResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2).toJson
         ar.result.get.toString should not include regex("null")
     }
 
@@ -113,7 +114,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, "")
         val ar = processRunResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2).toJson
         ar.result.get.asJsObject.fields(ERROR_FIELD).toString.endsWith(".\"") shouldBe true
     }
 
@@ -121,7 +122,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, "true")
         val ar = processRunResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2).toJson
         ar.result.get.toString should include(response.get._2)
     }
 
@@ -129,7 +130,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, Vector(1).toJson.compactPrint)
         val ar = processRunResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2).toJson
         ar.result.get.toString should include(response.get._2)
     }
 
@@ -144,7 +145,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
         val response = Some(500, Map("foobar" -> "baz").toJson.compactPrint)
         val ar = processRunResponseContent(response, logger)
         ar.statusCode shouldBe ContainerError
-        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2)
+        ar.result.get.asJsObject.fields(ERROR_FIELD) shouldBe invalidRunResponse(response.get._2).toJson
         ar.result.get.toString should include("baz")
     }
 

--- a/tests/src/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/whisk/core/limits/ActionLimitsTests.scala
@@ -17,6 +17,7 @@
 package whisk.core.limits
 
 import java.io.File
+import java.io.PrintWriter
 
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
@@ -31,18 +32,14 @@ import common.WhiskProperties
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.DefaultJsonProtocol._
-import spray.json.pimpAny
-import java.io.PrintWriter
-import whisk.core.entity.Exec
-import spray.json.DefaultJsonProtocol.LongJsonFormat
-import common.TestUtils
-import whisk.core.entity.size.SizeInt
-import whisk.core.entity.size.SizeString
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import whisk.core.entity.ActivationResponse
+import spray.json.pimpAny
+import whisk.core.entity.Exec
 import whisk.core.entity.LogLimit
+import whisk.core.entity.size.SizeInt
+import whisk.core.entity.size.SizeString
+import whisk.http.Messages
 
 @RunWith(classOf[JUnitRunner])
 class ActionLimitsTests extends TestHelpers with WskTestHelpers {
@@ -72,7 +69,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
             val run = wsk.action.invoke(name, Map("payload" -> allowedActionDuration.plus(1 second).toMillis.toJson))
             withActivation(wsk.activation, run) {
                 _.response.result.get.fields("error") shouldBe {
-                    ActivationResponse.timedoutActivation(allowedActionDuration, false)
+                    Messages.timedoutActivation(allowedActionDuration, false).toJson
                 }
             }
     }


### PR DESCRIPTION
If the result of running an action in the container is not successful, delete the container. Makes this is true for both failed init and run.

Fixes #1554 but need to engineer a proper test.