### PR TITLE
Posible undefined error for the node whisk.invoke

### DIFF
--- a/core/nodejsActionBase/src/whisk.js
+++ b/core/nodejsActionBase/src/whisk.js
@@ -298,7 +298,12 @@ function post(packet, logger, acceptStatusCode) {
           } else if (!error) {
               // activation failed, set error to API host error response.
               if (!body.error) {
-                  error = result.error === undefined ? 'an error has occurred' : result.error;
+                  if (result && result.error) {
+                      error = result.error;
+                  }
+                  else {
+                      error = 'an error has occurred';
+                  }
               }
               else {
                   error = body.error + ' (code ' + body.code + ')';


### PR DESCRIPTION
Current code does not handle situation where result is undefined when it checks result.error