### PR TITLE
Adding Exit-Logging to all API calls

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -124,7 +124,7 @@ trait PrintStreamEmitter {
  * @param deltaToTransactionStart the time difference between now and the start of the Transaction
  * @param deltaToMarkerStart if this is an end marker, this is the time difference to the start marker
  */
-protected case class LogMarker(token: LogMarkerToken, deltaToTransactionStart: Long, deltaToMarkerStart: Option[Long] = None) {
+case class LogMarker(token: LogMarkerToken, deltaToTransactionStart: Long, deltaToMarkerStart: Option[Long] = None) {
     override def toString() = {
         val parts = Seq("marker", token.toString, deltaToTransactionStart) ++ deltaToMarkerStart
         "[" + parts.mkString(":") + "]"

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -48,6 +48,11 @@ import spray.routing.directives.LoggingMagnet.forMessageFromFullShow
 import whisk.common.Logging
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
+import akka.event.Logging
+import whisk.common.LoggingMarkers
+import whisk.common.LogMarkerToken
+import whisk.common.LogMarker
+import whisk.common.LogMarker
 
 /**
  * This trait extends the spray HttpService trait with logging and transaction counting
@@ -82,7 +87,9 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
     def receive = runRoute(
         assignId { implicit transid =>
             DebuggingDirectives.logRequest(logRequestInfo _) {
-                routes
+                DebuggingDirectives.logRequestResponse(logResponseInfo _) {
+                    routes
+                }
             }
         })
 
@@ -103,6 +110,19 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
         val q = req.uri.query.toString
         val l = loglevelForRoute(p)
         LogEntry(s"[$tid] $m $p $q", l)
+    }
+
+    protected def logResponseInfo(req: HttpRequest)(implicit tid: TransactionId): Any => Option[LogEntry] = {
+        case res: HttpResponse =>
+            val m = req.method.toString
+            val p = req.uri.path.toString
+            val l = loglevelForRoute(p)
+
+            val token = LogMarkerToken("http", s"${m.toLowerCase}.${res.status.intValue}", LoggingMarkers.count)
+            val marker = LogMarker(token, tid.deltaToStart, Some(tid.deltaToStart))
+
+            Some(LogEntry(s"[$tid] $marker", l))
+        case _ => None // other kind of responses
     }
 }
 


### PR DESCRIPTION
This adds the ability to analyze HTTP response codes and response times by the already known marker system.

Signed-off-by: Christian Bickel <cbickel@de.ibm.com>