### PR TITLE
Measure bytesize of strings as if encoded in UTF-8.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Size.scala
@@ -16,6 +16,8 @@
 
 package whisk.core.entity
 
+import java.nio.charset.StandardCharsets
+
 object SizeUnits extends Enumeration {
 
     sealed abstract class Unit() {
@@ -98,11 +100,15 @@ object size {
     }
 
     implicit class SizeString(n: String) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n.length * 2, unit)
+        def sizeIn(unit: SizeUnits.Unit): ByteSize = ByteSize(n.getBytes(StandardCharsets.UTF_8).length, unit)
     }
 
     implicit class SizeOptionString(n: Option[String]) extends SizeConversion {
-        def sizeIn(unit: SizeUnits.Unit): ByteSize = n map { s => ByteSize(s.length * 2, unit) } getOrElse ByteSize(0, unit)
+        def sizeIn(unit: SizeUnits.Unit): ByteSize = n map { s =>
+            s.sizeIn(unit)
+        } getOrElse {
+            ByteSize(0, unit)
+        }
     }
 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -45,8 +45,12 @@ import whisk.core.entity.Parameters
 import whisk.http.ErrorResponse.terminate
 
 protected[controller] trait ValidateEntitySize extends Directives {
-    protected def validateSize(check: ⇒ Boolean)(implicit tid: TransactionId) = new Directive0 {
-        def happly(f: HNil ⇒ Route) = if (check) f(HNil) else terminate(RequestEntityTooLarge, "request entity too large")
+    protected def validateSize(check: => Boolean)(implicit tid: TransactionId) = new Directive0 {
+        def happly(f: HNil => Route) = if (check) {
+            f(HNil)
+        } else {
+            terminate(RequestEntityTooLarge, "request entity too large")
+        }
     }
 }
 

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -249,7 +249,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject create with exec which is too big" in {
         implicit val tid = transid()
-        val code = "a" * ((actionLimit.toBytes / 2L).toInt + 1)
+        val code = "a" * (actionLimit.toBytes.toInt + 1)
         val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
         Put(s"$collectionPath/${aname}", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(RequestEntityTooLarge)
@@ -260,7 +260,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     it should "reject update with exec which is too big" in {
         implicit val tid = transid()
         val oldCode = "function main()"
-        val code = "a" * ((actionLimit.toBytes / 2L).toInt + 1)
+        val code = "a" * (actionLimit.toBytes.toInt + 1)
         val action = WhiskAction(namespace, aname, Exec.js("??"))
         val content = s"""{"exec":{"kind":"python","code":"$code"}}""".stripMargin.parseJson.asJsObject
         put(entityStore, action)
@@ -272,7 +272,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject create with parameters which are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -285,7 +285,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     it should "reject create with annotations which are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -435,7 +435,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
     it should "reject create package reference when annotations are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -448,7 +448,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
     it should "reject create package reference when parameters are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -461,7 +461,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
     it should "reject update package reference when parameters are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -317,7 +317,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         val trigger = WhiskTrigger(namespace, aname())
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
 
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -342,7 +342,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         val action = WhiskAction(namespace, aname(), Exec.js("??"))
         val rule = WhiskRule(namespace, aname(), trigger.fullyQualifiedName(false), action.fullyQualifiedName(false))
 
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (Parameters.sizeLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -196,7 +196,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
     it should "reject create with parameters which are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -209,7 +209,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
     it should "reject create with annotations which are too big" in {
         implicit val tid = transid()
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)
@@ -223,7 +223,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     it should "reject update with parameters which are too big" in {
         implicit val tid = transid()
         val trigger = WhiskTrigger(namespace, aname)
-        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 2 / 20 + Math.pow(10, 9) + 2) toLong)
+        val keys: List[Long] = List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
         val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
         } reduce (_ ++ _)

--- a/tests/src/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/whisk/core/limits/ActionLimitsTests.scala
@@ -146,7 +146,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
             val actionCode = new File(s"$testActionsDir${File.separator}$name.js")
             actionCode.createNewFile()
             val pw = new PrintWriter(actionCode)
-            pw.write("a" * ((actionCodeLimit.toBytes / 2) + 1).toInt)
+            pw.write("a" * (actionCodeLimit.toBytes + 1).toInt)
             pw.close
 
             assetHelper.withCleaner(wsk.action, name, confirmDelete = false) {


### PR DESCRIPTION
Previous implementation took the conservative estimate that every char is two bytes. While this may fit the JVM model, it violates user expectations that, for instance, base64-encoded binary files take 1 byte per character.

Fixes #1543.