### PR TITLE
Proper handling of Promise.reject().

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -115,7 +115,13 @@ function NodeActionRunner(whisk) {
                     }).catch(function (error) {
                         // A rejected Promise from the user code maps into a
                         // successful promise wrapping a whisk-encoded error.
-                        resolve({ error: error });
+
+                        // Special case if the user just called `reject()`.
+                        if (!error) {
+                            resolve({ error: {}})
+                        } else {
+                            resolve({ error: error });
+                        }
                     });
                 } else {
                     // Nothing to do in this 'else' branch. The user code returned the

--- a/tests/dat/actions/issue-1562.js
+++ b/tests/dat/actions/issue-1562.js
@@ -1,0 +1,6 @@
+// We expect this action to always result in errored activations.
+function main(args) {
+    return new Promise((resolve, reject) => {
+        reject();
+    });
+}

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -481,6 +481,21 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         })
     }
 
+    it should "support rejected promises with no message" in {
+        val (out, err) = withNodeJsContainer { c =>
+            val code = """
+                | function main(args) {
+                |     return new Promise(function (resolve, reject) {
+                |         reject();
+                |     });
+                | }""".stripMargin
+
+            c.init(initPayload(code))._1 should be(200)
+            val (runCode, runRes) = c.run(runPayload(JsObject()))
+            runRes.get.fields.get("error") shouldBe defined
+        }
+    }
+
     it should "support large-ish actions" in {
         val thought = " I took the one less traveled by, and that has made all the difference."
         val assignment = "    x = \"" + thought + "\";\n"

--- a/tests/src/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/system/basic/WskBasicNodeTests.scala
@@ -132,6 +132,23 @@ class WskBasicNodeTests
             }
     }
 
+    it should "Ensure that returning an empty rejected Promise results in an errored activation" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "jsEmptyRejectPromise"
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, Some(TestUtils.getTestActionFilename("issue-1562.js")))
+            }
+
+            withActivation(wsk.activation, wsk.action.invoke(name)) {
+                activation =>
+                    val response = activation.response
+                    response.success should be(false)
+                    response.result.get.fields.get("error") shouldBe defined
+            }
+    }
+
     // TODO: remove this tests and its assets when "whisk.js" is removed entirely as it is no longer necessary
     it should "Ensure that whisk.invoke() returns a promise" in withAssetCleaner(wskprops) {
         val expectedDuration = 3.seconds


### PR DESCRIPTION
Ensure that Promises rejected with no message result in failed activations.

Fixes #1562.