### PR TITLE
Add openwhisk home as the location to search for whisk property

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -129,12 +129,16 @@ object WhiskConfig extends Logging {
                 else null
             } else null
 
-        val dir = sys.props.get("user.dir")
-        if (dir.isDefined) {
-            propfile(dir.get, true)
-        } else {
-            null
+        def propfileFromDir(dir: Option[String]): File = {
+            dir.map { propfile(_, true) } getOrElse null
         }
+
+        var dir = sys.props.get("user.dir")
+        val file = propfileFromDir(dir)
+        if (file == null) {
+            dir = sys.env.get("OPENWHISK_HOME")
+            propfileFromDir(dir)
+        } else file
     }
 
     /**


### PR DESCRIPTION
If this function is called by the scala code under the directory or parent directory, we can look up the whisk.property file even recursively until we find it. However, if other repo directories like openwhisk-catalog and openwhisk-package-kafka, are saved in the same level as openwhisk, we will fail to find the whisk.property file under openwhisk, but the test cases located under openwhisk-catalog and openwhisk-package-kafka, still need to read from whisk.property. Currently, we have to load this file by explicitly loading the path of OPENWHISK_HOME in openwhisk-catalog or openwhisk-package-kafka. If we can provide the option to read from OPENWHISK_HOME in WhiskConfig.scala, we do not need to get the OPENWHISK_HOME variable each time it is in need of the test cases under other repo directories. 