### PR TITLE
Fix API GW CLI swagger config file support

### DIFF
--- a/core/routemgmt/activateApi.js
+++ b/core/routemgmt/activateApi.js
@@ -296,7 +296,11 @@ function addRouteToGateway(gwInfo, gwApiDoc) {
         reject('Unable to configure the API Gateway: '+JSON.stringify(error));
       } else if (statusCode != 200) {
         console.error('addRouteToGateway: Response code: '+statusCode)
-        reject('Unable to configure the API Gateway: Response failure code: '+statusCode);
+        if (body) {
+          reject('Unable to configure the API Gateway (status code '+statusCode+'): '+body);
+        } else {
+          reject('Unable to configure the API Gateway: Response failure code: '+statusCode);
+        }
       } else if (!body) {
         console.error('addRouteToGateway: Unable to configure the API Gateway: No response body')
         reject('Unable to configure the API Gateway: No response received from the API Gateway');

--- a/core/routemgmt/createApi.js
+++ b/core/routemgmt/createApi.js
@@ -126,7 +126,7 @@ function main(message) {
     console.error('Got API DB error: ', err);
     if ( (err.error.error == "not_found" && err.error.statusCode == 404)) {  // err.error.reason == "missing" or "deleted"
       // No document.  Create an initial one - but ONLY if a /basepath was provided
-      if (message.basepath.indexOf('/') == 0) {
+      if (message.swagger || message.basepath.indexOf('/') == 0) {
         console.log('API document not found; creating a new one');
         newDoc = true;
         return makeTemplateDbApiDoc(message);
@@ -272,7 +272,7 @@ function getDbApiDoc(namespace, basepath, docid) {
       return Promise.resolve(activation.result.apis[0].value);
     } else if (activation && activation.result && activation.result.apis &&
                activation.result.apis.length > 1) {
-          console.error('Multiple API docs returned!');  // Only expected case is when >1 basepaths have the same API Name
+          console.error('Multiple API docs returned; only one expected');  // Only expected case is when >1 basepaths have the same API Name
           return Promise.reject({
             error: {
               statusCode: 409,
@@ -282,7 +282,7 @@ function getDbApiDoc(namespace, basepath, docid) {
           });
     } else {
       // No API document.  Simulate the DB 'not found' error.
-      console.error('Invalid API doc returned!');
+      console.error('API doc not found');
       return Promise.reject({
         error: {
           statusCode: 404,

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -755,15 +755,19 @@ class WskApi()
       * if the code is anything but DONTCARE_EXIT, assert the code is as expected
       */
     def create(
-        basepath: Option[String] = Some("/"),
-        relpath: String,
-        operation: String,
-        action: String,
+        basepath: Option[String] = None,
+        relpath: Option[String] = None,
+        operation: Option[String] = None,
+        action: Option[String] = None,
         apiname: Option[String] = None,
         swagger: Option[String] = None,
         expectedExitCode: Int = SUCCESS_EXIT)(
             implicit wp: WskProps): RunResult = {
-        val params = Seq(noun, "create", "--auth", wp.authKey, basepath.get, relpath, operation, action) ++
+        val params = Seq(noun, "create", "--auth", wp.authKey) ++
+          { basepath map { b => Seq(b) } getOrElse Seq() } ++
+          { relpath map { r => Seq(r) } getOrElse Seq() } ++
+          { operation map { o => Seq(o) } getOrElse Seq() } ++
+          { action map { aa => Seq(aa) } getOrElse Seq() } ++
           { apiname map { a => Seq("--apiname", a) } getOrElse Seq() } ++
           { swagger map { s => Seq("--config-file", s) } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode, showCmd = true)

--- a/tests/src/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/whisk/core/cli/test/ApiGwTests.scala
@@ -42,7 +42,7 @@ class ApiGwTests
     it should "reject an api commands with an invalid path parameter" in {
         val badpath = "badpath"
 
-        var rr = wsk.api.create(basepath = Some("/basepath"), relpath = badpath, operation = "GET", action = "action", expectedExitCode = ANY_ERROR_EXIT)
+        var rr = wsk.api.create(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
         rr.stderr should include (s"'${badpath}' must begin with '/'")
 
         rr = wsk.api.delete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
@@ -68,7 +68,7 @@ class ApiGwTests
         try {
             println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
 
-            var rr = wsk.api.create(basepath = Some(testbasepath), relpath = testrelpath, operation = testurlop, action = actionName, apiname = Some(testapiname))
+            var rr = wsk.api.create(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
             rr = wsk.api.list(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
             rr.stdout should include("ok: APIs")

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -40,7 +40,7 @@ var apiCmd = &cobra.Command{
 }
 
 var apiCreateCmd = &cobra.Command{
-    Use:           "create [BASE_PATH] API_PATH API_VERB ACTION",
+    Use:           "create ([BASE_PATH] API_PATH API_VERB ACTION] | --config-file CFG_FILE) ",
     Short:         wski18n.T("create a new API"),
     SilenceUsage:  true,
     SilenceErrors: true,
@@ -118,7 +118,7 @@ var apiCreateCmd = &cobra.Command{
                 for op, _  := range retApi.Swagger.Paths[path] {
                     whisk.Debug(whisk.DbgInfo, "Path operation: %s\n", op)
                     fmt.Fprintf(color.Output,
-                        wski18n.T("{{.ok}} created api {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
+                        wski18n.T("{{.ok}} created API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
                             map[string]interface{}{
                                 "ok": color.GreenString("ok:"),
                                 "path": path,

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -588,6 +588,13 @@ func parseSwaggerApi() (*whisk.Api, error) {
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return nil, whiskErr
     }
+    if _, ok := isValidBasepath(swaggerObj.BasePath); !ok {
+        whisk.Debug(whisk.DbgError, "Swagger file basePath is invalid.\n", flags.api.configfile, err)
+        errMsg := wski18n.T("Swagger file basePath must start with a leading slash (/)")
+        whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+            whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+        return nil, whiskErr
+    }
 
     api := new(whisk.Api)
     api.Namespace = client.Config.Namespace

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1296,8 +1296,12 @@
     "translation": "Error parsing swagger file '{{.name}}': {{.err}}"
   },
   {
-    "id": "Swagger file is invalid (missing basePath, info, paths, or swagger fields",
-    "translation": "Swagger file is invalid (missing basePath, info, paths, or swagger fields"
+    "id": "Swagger file is invalid (missing basePath, info, paths, or swagger fields)",
+    "translation": "Swagger file is invalid (missing basePath, info, paths, or swagger fields)"
+  },
+  {
+    "id": "Swagger file basePath must start with a leading slash (/)",
+    "translation": "Swagger file basePath must start with a leading slash (/)"
   },
   {
     "id": "API does not exist for basepath {{.basepath}}",


### PR DESCRIPTION
The following error was observed when creating APIs with a swagger configuration file

```
error: Unable to create API: API route creation failure: {"error":"API configuration failure: {\"message\":\"Cannot read property 'indexOf' of undefined\"....
```

This PR fixes that failure.