### PR TITLE
Dusting

### DIFF
--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -101,7 +101,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](
     }
 
     override protected[database] def del(doc: DocInfo)(implicit transid: TransactionId): Future[Boolean] = {
-        require(doc != null && doc.rev() != null, "doc revision required for delete")
+        require(doc != null && doc.rev.asString != null, "doc revision required for delete")
 
         val start = transid.started(this, LoggingMarkers.DATABASE_DELETE, s"[DEL] '$dbName' deleting document: '$doc'")
 

--- a/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
+++ b/common/scala/src/main/scala/whisk/core/entitlement/Privilege.scala
@@ -16,6 +16,8 @@
 
 package whisk.core.entitlement
 
+import scala.util.Try
+
 import spray.json.DeserializationException
 import spray.json.JsString
 import spray.json.JsValue
@@ -33,9 +35,11 @@ protected[core] object Privilege extends Enumeration {
     implicit val serdes = new RootJsonFormat[Privilege] {
         def write(p: Privilege) = JsString(p.toString)
 
-        def read(json: JsValue) = json match {
-            case JsString(str) => Privilege.withName(str)
-            case _             => throw new DeserializationException("Privilege must be a string")
+        def read(json: JsValue) = Try {
+            val JsString(str) = json
+            Privilege.withName(str.trim.toUpperCase)
+        } getOrElse {
+            throw new DeserializationException("Privilege must be a valid string")
         }
     }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -67,9 +67,7 @@ protected[core] class DocRevision private (val rev: String) extends AnyVal {
  * @param rev the document revision, optional; this is an opaque value determined by the datastore
  */
 protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision()) {
-    override def toString =
-        s"""|id: $id
-            |rev: $rev""".stripMargin.replace("\n", ", ")
+    override def toString = s"id: $id, rev: $rev"
 
     override def hashCode = {
         if (rev.empty) {

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -34,7 +34,7 @@ import spray.json.deserializationError
  * @param id the document id, required not null
  */
 protected[core] class DocId private (val id: String) extends AnyVal {
-    def apply() = id
+    def asString = id // to make explicit that this is a string conversion
     protected[core] def asDocInfo = DocInfo(this)
     protected[core] def asDocInfo(rev: DocRevision) = DocInfo(this, rev)
     protected[entity] def toJson = JsString(id)
@@ -52,7 +52,7 @@ protected[core] class DocId private (val id: String) extends AnyVal {
  * @param rev the document revision, optional
  */
 protected[core] class DocRevision private (val rev: String) extends AnyVal {
-    def apply() = rev
+    def asString = rev // to make explicit that this is a string conversion
     def empty = rev == null
     override def toString = rev
 }
@@ -67,17 +67,15 @@ protected[core] class DocRevision private (val rev: String) extends AnyVal {
  * @param rev the document revision, optional; this is an opaque value determined by the datastore
  */
 protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision()) {
-    def apply() = id()
-
     override def toString =
-        s"""|id: ${id()}
-            |rev: ${rev()}""".stripMargin.replace("\n", ", ")
+        s"""|id: $id
+            |rev: $rev""".stripMargin.replace("\n", ", ")
 
     override def hashCode = {
         if (rev.empty) {
             id.hashCode
         } else {
-            "$id.$rev".hashCode
+            s"$id.$rev".hashCode
         }
     }
 }

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -168,7 +168,8 @@ protected[core] object EntityPath {
 protected[core] class EntityName private (val name: String) extends AnyVal {
     def apply() = name
     def toJson = JsString(name)
-    def toPath = EntityPath(name)
+    def toPath: EntityPath = EntityPath(name)
+    def addPath(e: EntityName): EntityPath = toPath.addPath(e)
     override def toString = name
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -97,7 +97,7 @@ protected[core] class EntityPath private (private val path: Seq[String]) extends
 
     def toDocId = DocId(namespace)
     def toJson = JsString(namespace)
-    def apply() = namespace
+    def asString = namespace // to make explicit that this is a string conversion
     override def toString = namespace
 }
 
@@ -166,7 +166,7 @@ protected[core] object EntityPath {
  * before creating a new instance.
  */
 protected[core] class EntityName private (val name: String) extends AnyVal {
-    def apply() = name
+    def asString = name // to make explicit that this is a string conversion
     def toJson = JsString(name)
     def toPath: EntityPath = EntityPath(name)
     def addPath(e: EntityName): EntityPath = toPath.addPath(e)

--- a/common/scala/src/main/scala/whisk/core/entity/FullyQualifiedEntityName.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/FullyQualifiedEntityName.scala
@@ -47,10 +47,10 @@ protected[core] case class FullyQualifiedEntityName(path: EntityPath, name: Enti
 
     def toDocId = DocId(qualifiedName)
     def qualifiedNameWithLeadingSlash: String = EntityPath.PATHSEP + qualifiedName
-    def apply() = path.addPath(name) + version.map("@" + _.toString).getOrElse("")
+    def asString = path.addPath(name) + version.map("@" + _.toString).getOrElse("")
 
     override def size = qualifiedName.sizeInBytes
-    override def toString = apply()
+    override def toString = asString
     override def hashCode = qualifiedName.hashCode
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/Subject.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Subject.scala
@@ -25,7 +25,7 @@ import spray.json.deserializationError
 import whisk.core.entitlement.Privilege
 
 protected[core] class Subject private (private val subject: String) extends AnyVal {
-    protected[core] def apply() = subject
+    protected[core] def asString = subject // to make explicit that this is a string conversion
     protected[entity] def toJson = JsString(subject)
     protected[core] def toIdentity(authkey: AuthKey) = Identity(this, EntityName(subject), authkey, Privilege.ALL)
     override def toString = subject

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuth.scala
@@ -56,7 +56,7 @@ case class WhiskAuth(
             |auth: $authkey""".stripMargin.replace("\n", ", ")
     }
 
-    override def docid = DocId(subject())
+    override def docid = DocId(subject.asString)
 
     def toJson = JsObject(
         "subject" -> subject.toJson,
@@ -87,7 +87,7 @@ object WhiskAuth extends DocumentFactory[WhiskAuth] {
     def get(datastore: ArtifactStore[WhiskAuth], subject: Subject, fromCache: Boolean)(
         implicit transid: TransactionId): Future[Identity] = {
         implicit val ec = datastore.executionContext
-        super.get(datastore, DocId(subject()), fromCache = fromCache).map(_.toIdentity)
+        super.get(datastore, DocId(subject.asString), fromCache = fromCache).map(_.toIdentity)
     }
 
     def get(datastore: ArtifactStore[WhiskAuth], uuid: UUID)(

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAuthV2.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAuthV2.scala
@@ -52,7 +52,7 @@ case class WhiskAuthV2(
     namespaces: Set[WhiskNamespace])
     extends WhiskDocument {
 
-    override def docid = DocId(subject())
+    override def docid = DocId(subject.asString)
 
     def toJson = JsObject(
         "subject" -> subject.toJson,

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -43,7 +43,7 @@ case class WhiskPackagePut(
      * Resolves the binding if it contains the default namespace.
      */
     protected[core] def resolve(namespace: EntityName): WhiskPackagePut = {
-        WhiskPackagePut(binding.map(_.resolve(namespace.toPath)), parameters, version, publish, annotations)
+        WhiskPackagePut(binding.map(_.resolve(namespace)), parameters, version, publish, annotations)
     }
 }
 
@@ -101,7 +101,7 @@ case class WhiskPackage(
     /**
      * Gets binding for package iff this is not already a package reference.
      */
-    def bind = binding map { _ => None } getOrElse Some { Binding(namespace, name) }
+    def bind = binding map { _ => None } getOrElse Some { Binding(namespace.root, name) }
 
     /**
      * Adds actions to package. The actions list is filtered so that only actions that
@@ -202,8 +202,8 @@ object WhiskPackage
  * A package binding holds a reference to the providing package
  * namespace and package name.
  */
-case class Binding(namespace: EntityPath, name: EntityName) {
-    def fullyQualifiedName = FullyQualifiedEntityName(namespace, name)
+case class Binding(namespace: EntityName, name: EntityName) {
+    def fullyQualifiedName = FullyQualifiedEntityName(namespace.toPath, name)
     def docid = fullyQualifiedName.toDocId
     override def toString = fullyQualifiedName.toString
 
@@ -211,8 +211,8 @@ case class Binding(namespace: EntityPath, name: EntityName) {
      * Returns a Binding namespace if it is the default namespace
      * to the given one, otherwise this is an identity.
      */
-    def resolve(ns: EntityPath): Binding = {
-        namespace match {
+    def resolve(ns: EntityName): Binding = {
+        namespace.toPath match {
             case EntityPath.DEFAULT => Binding(ns, name)
             case _                  => this
         }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -80,7 +80,7 @@ case class WhiskPackage(
      * Merges parameters into existing set of parameters for package.
      * Existing parameters supersede those in p.
      */
-    def inherit(p: Parameters) = {
+    def inherit(p: Parameters): WhiskPackage = {
         WhiskPackage(namespace, name, binding, p ++ parameters, version, publish, annotations)
     }
 
@@ -88,7 +88,7 @@ case class WhiskPackage(
      * Merges parameters into existing set of parameters for package.
      * The parameters from p supersede parameters from this.
      */
-    def mergeParameters(p: Parameters) = {
+    def mergeParameters(p: Parameters): WhiskPackage = {
         WhiskPackage(namespace, name, binding, parameters ++ p, version, publish, annotations)
     }
 
@@ -96,18 +96,24 @@ case class WhiskPackage(
      * Gets the full path for the package.
      * This is equivalent to calling this this.fullyQualifiedName(withVersion = false).fullPath.
      */
-    def fullPath = namespace.addPath(name)
+    def fullPath: EntityPath = namespace.addPath(name)
 
     /**
      * Gets binding for package iff this is not already a package reference.
      */
-    def bind = binding map { _ => None } getOrElse Some { Binding(namespace.root, name) }
+    def bind: Option[Binding] = {
+        if (binding.isDefined) {
+            None
+        } else {
+            Some(Binding(namespace.root, name))
+        }
+    }
 
     /**
      * Adds actions to package. The actions list is filtered so that only actions that
      * match the package are included (must match package namespace/name).
      */
-    def withActions(actions: List[WhiskAction] = List()) = {
+    def withActions(actions: List[WhiskAction] = List()): WhiskPackageWithActions = {
         withPackageActions(actions filter { a =>
             val pkgns = binding map { b => b.namespace.addPath(b.name) } getOrElse { namespace.addPath(name) }
             a.namespace == pkgns
@@ -121,7 +127,7 @@ case class WhiskPackage(
      * is it defined the property "feed" in the annotation. The value of the property is ignored
      * for this check.
      */
-    def withPackageActions(actions: List[WhiskPackageAction] = List()) = {
+    def withPackageActions(actions: List[WhiskPackageAction] = List()): WhiskPackageWithActions = {
         val actionGroups = actions map { a =>
             //  group into "actions" and "feeds"
             val feed = a.annotations(Parameters.Feed) map { _ => true } getOrElse false

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -503,8 +503,8 @@ trait WhiskActionsApi
     private def mergeActionWithPackageAndDispatch(method: HttpMethod, user: Identity, action: EntityName, ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
         implicit transid: TransactionId): RequestContext => Unit = {
         wp.binding map {
-            case Binding(ns, n) =>
-                val docid = FullyQualifiedEntityName(ns, n).toDocId
+            case b: Binding =>
+                val docid = b.fullyQualifiedName.toDocId
                 info(this, s"fetching package '$docid' for reference")
                 // already checked that subject is authorized for package and binding;
                 // this fetch is redundant but should hit the cache to ameliorate cost

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -516,7 +516,7 @@ trait WhiskActionsApi
             // operation without further entitlement checks
             val params = { ref map { _ inherit wp.parameters } getOrElse wp } parameters
             val ns = wp.namespace.addPath(wp.name) // the package namespace
-            val resource = Resource(ns, collection, Some { action() }, Some { params })
+            val resource = Resource(ns, collection, Some { action.asString }, Some { params })
             val right = collection.determineRight(method, resource.entity)
             info(this, s"merged package parameters and rebased action to '$ns")
             dispatchOp(user, right, resource)

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -92,7 +92,7 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
     /** Extracts namespace for user from the matched path segment. */
     protected def namespace(user: Identity, ns: String) = {
         validate(isNamespace(ns), "namespace contains invalid characters") &
-            extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace() else ns))
+            extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace.asString else ns))
     }
 
     /** Extracts the HTTP method which is used to determine privilege for resource. */

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -107,14 +107,14 @@ trait WhiskCollectionAPI
                     // entitled to them which for now means they own the namespace. If the
                     // subject does not own the namespace, then exclude packages that are private
                     val checkIfSubjectOwnsResource = if (listRequiresPrivateEntityFilter) {
-                        if (resource.namespace.root() == user.subject()) {
+                        if (resource.namespace.root.asString == user.subject.asString) {
                             // bypass iam if namespace is owned by subject
                             // don't need to exclude private packages owned by subject
                             Future.successful(false)
                         } else {
                             iam.namespaces(user.subject) map {
                                 // don't need to exclude private packages in any namespace owned by subject
-                                _.contains(resource.namespace.root()) == false
+                                _.contains(resource.namespace.root.asString) == false
                             }
                         }
                     } else Future.successful(false)

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -286,8 +286,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
      */
     private def mergePackageWithBinding(ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(implicit transid: TransactionId): RequestContext => Unit = {
         wp.binding map {
-            case Binding(ns, n) =>
-                val docid = FullyQualifiedEntityName(ns, n).toDocId
+            case b: Binding =>
+                val docid = b.fullyQualifiedName.toDocId
                 info(this, s"fetching package '$docid' for reference")
                 getEntity(WhiskPackage, entityStore, docid, Some {
                     mergePackageWithBinding(Some { wp }) _

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -175,12 +175,12 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
                                     info(this, s"[POST] rule ${ruleName} activated, writing activation record to datastore")
                                     WhiskActivation.put(activationStore, ruleActivation)
 
-                                    val actionNamespace = rule.action.path.root()
+                                    val actionNamespace = rule.action.path.root.asString
                                     val actionPath = {
                                         rule.action.path.relativePath.map {
-                                            pkg => (Path.SingleSlash + pkg.namespace) / rule.action.name()
+                                            pkg => (Path.SingleSlash + pkg.namespace) / rule.action.name.asString
                                         } getOrElse {
-                                            Path.SingleSlash + rule.action.name()
+                                            Path.SingleSlash + rule.action.name.asString
                                         }
                                     }.toString
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActionCollection.scala
@@ -33,7 +33,7 @@ class ActionCollection(entityStore: EntityStore) extends Collection(Collection.A
      */
     protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
         implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
-        val isOwner = namespaces.contains(resource.namespace.root())
+        val isOwner = namespaces.contains(resource.namespace.root.asString)
         resource.entity map {
             name =>
                 right match {

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -58,7 +58,7 @@ class ActivationThrottler(consulServer: String, loadBalancer: LoadBalancer, conc
     /**
      * Checks whether the operation should be allowed to proceed.
      */
-    def check(subject: Subject): Boolean = userActivationCounter.getOrElse(subject(), 0L) < concurrencyLimit
+    def check(subject: Subject): Boolean = userActivationCounter.getOrElse(subject.asString, 0L) < concurrencyLimit
 
     /**
      * Checks whether the system is in a generally overloaded state.

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -84,7 +84,7 @@ protected[core] case class Collection protected (
         implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = Future.successful {
         // if the resource root namespace is in any of the allowed namespaces
         // then this is an owner of the resource
-        val self = namespaces.contains(resource.namespace.root())
+        val self = namespaces.contains(resource.namespace.root.asString)
 
         resource.entity map {
             _ => self && allowedEntityRights.contains(right)

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -335,7 +335,7 @@ trait ReferencedEntities {
     def referencedEntities(reference: Any): Set[Resource] = {
         reference match {
             case WhiskPackagePut(Some(binding), _, _, _, _) =>
-                Set(Resource(binding.namespace, Collection(Collection.PACKAGES), Some(binding.name())))
+                Set(Resource(binding.namespace.toPath, Collection(Collection.PACKAGES), Some(binding.name())))
             case r: WhiskRulePut =>
                 val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name())) }
                 val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name())) }

--- a/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Entitlement.scala
@@ -217,7 +217,7 @@ protected[core] abstract class EntitlementProvider(config: WhiskConfig, loadBala
     protected def checkPrivilege(user: Identity, right: Privilege, resources: Set[Resource])(
         implicit transid: TransactionId): Future[Boolean] = {
         // check the default namespace first, bypassing additional checks if permitted
-        val defaultNamespaces = Set(user.namespace())
+        val defaultNamespaces = Set(user.namespace.asString)
         implicit val es = this
 
         Future.sequence {
@@ -335,14 +335,14 @@ trait ReferencedEntities {
     def referencedEntities(reference: Any): Set[Resource] = {
         reference match {
             case WhiskPackagePut(Some(binding), _, _, _, _) =>
-                Set(Resource(binding.namespace.toPath, Collection(Collection.PACKAGES), Some(binding.name())))
+                Set(Resource(binding.namespace.toPath, Collection(Collection.PACKAGES), Some(binding.name.asString)))
             case r: WhiskRulePut =>
-                val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name())) }
-                val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name())) }
+                val triggerResource = r.trigger.map { t => Resource(t.path, Collection(Collection.TRIGGERS), Some(t.name.asString)) }
+                val actionResource = r.action map { a => Resource(a.path, Collection(Collection.ACTIONS), Some(a.name.asString)) }
                 Set(triggerResource, actionResource).flatten
             case e: SequenceExec =>
                 e.components.map {
-                    c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name()))
+                    c => Resource(c.path, Collection(Collection.ACTIONS), Some(c.name.asString))
                 }.toSet
             case _ => Set()
         }

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -49,7 +49,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
      * All assets that are not in an explicit package are private because the default package is private.
      */
     protected[core] override def implicitRights(user: Identity, namespaces: Set[String], right: Privilege, resource: Resource)(
-        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId) = {
+        implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = {
         resource.entity map {
             pkgname =>
                 val isOwner = namespaces.contains(resource.namespace.root())

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -52,7 +52,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
         implicit ep: EntitlementProvider, ec: ExecutionContext, transid: TransactionId): Future[Boolean] = {
         resource.entity map {
             pkgname =>
-                val isOwner = namespaces.contains(resource.namespace.root())
+                val isOwner = namespaces.contains(resource.namespace.root.asString)
                 right match {
                     case Privilege.READ =>
                         // must determine if this is a public or owned package
@@ -89,7 +89,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
             case wp =>
                 if (isOwner) {
                     val binding = wp.binding.get
-                    val pkgOwner = namespaces.contains(binding.namespace())
+                    val pkgOwner = namespaces.contains(binding.namespace.asString)
                     val pkgDocid = binding.docid
                     info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
                     checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)

--- a/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/PackageCollection.scala
@@ -89,7 +89,7 @@ class PackageCollection(entityStore: EntityStore) extends Collection(Collection.
             case wp =>
                 if (isOwner) {
                     val binding = wp.binding.get
-                    val pkgOwner = namespaces.contains(binding.namespace.root())
+                    val pkgOwner = namespaces.contains(binding.namespace())
                     val pkgDocid = binding.docid
                     info(this, s"checking subject has privilege '$right' for bound package '$pkgDocid'")
                     checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)

--- a/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/RemoteEntitlement.scala
@@ -58,7 +58,7 @@ protected[core] class RemoteEntitlementService(
         val url = Uri("http://" + apiLocation + "/grant")
 
         val form = FormData(Seq(
-            "subject" -> subject(),
+            "subject" -> subject.asString,
             "right" -> right.toString,
             "resource" -> resource.entity.getOrElse(""),
             "collection" -> resource.collection.toString,
@@ -75,7 +75,7 @@ protected[core] class RemoteEntitlementService(
         val url = Uri("http://" + apiLocation + "/revoke")
 
         val form = FormData(Seq(
-            "subject" -> subject(),
+            "subject" -> subject.asString,
             "right" -> right.toString,
             "resource" -> resource.entity.getOrElse(""),
             "collection" -> resource.collection.toString,
@@ -92,7 +92,7 @@ protected[core] class RemoteEntitlementService(
         info(this, s"checking namespace at ${apiLocation}")
 
         val url = Uri("http://" + apiLocation + "/check").withQuery(
-            "subject" -> subject(),
+            "subject" -> subject.asString,
             "right" -> right.toString,
             "resource" -> resource.entity.getOrElse(""),
             "collection" -> resource.collection.toString,

--- a/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
+++ b/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
@@ -41,7 +41,7 @@ object NamespaceProvider {
     /**
      * The default list of namespaces for a subject.
      */
-    protected[core] def defaultNamespaces(subject: Subject) = Set(subject())
+    protected[core] def defaultNamespaces(subject: Subject): Set[String] = Set(subject.asString)
 }
 
 protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds, forceLocal: Boolean = false)(
@@ -65,7 +65,7 @@ protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDura
             info(this, s"getting namespaces from ${apiLocation}")
 
             val url = Uri("http://" + apiLocation + "/namespaces").withQuery(
-                "subject" -> subject())
+                "subject" -> subject.asString)
 
             val pipeline: HttpRequest => Future[Set[String]] = (
                 addHeader("X-Transaction-Id", transid.toString())

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -120,7 +120,7 @@ class LoadBalancerService(
             val start = transid.started(this, LoggingMarkers.CONTROLLER_KAFKA)
             invokerIndex =>
                 val topic = ActivationMessage.invoker(invokerIndex)
-                val subject = msg.user.subject()
+                val subject = msg.user.subject.asString
                 val entry = setupActivation(msg.activationId, subject, invokerIndex, timeout, transid)
                 info(this, s"posting topic '$topic' with activation id '${msg.activationId}'")
                 (producer.send(topic, msg) map { status =>
@@ -294,7 +294,7 @@ class LoadBalancerService(
      * these are moved to some common place (like a subclass of Message?)
      */
     private def hashAndCountSubjectAction(msg: ActivationMessage): (Int, Int) = {
-        val subject = msg.user.subject()
+        val subject = msg.user.subject.asString
         val path = msg.action.toString
         val hash = subject.hashCode() ^ path.hashCode()
         val key = (subject, path)

--- a/tests/src/whisk/core/admin/WskAdminTests.scala
+++ b/tests/src/whisk/core/admin/WskAdminTests.scala
@@ -41,7 +41,7 @@ class WskAdminTests
     it should "CRD a subject" in {
         val wskadmin = new RunWskAdminCmd {}
         val auth = WhiskAuth(Subject(), AuthKey())
-        val subject = auth.subject()
+        val subject = auth.subject.asString
 
         println(s"CRD subject: $subject")
         val create = wskadmin.cli(Seq("user", "create", subject))

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -56,7 +56,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     behavior of "Actions API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("action_tests")
     setVerbosity(InfoLevel)
@@ -664,7 +664,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val sequence = Vector(stringToFullyQualifiedName(s"$namespace/${entity.name}"))
         val content = WhiskActionPut(Some(Exec.sequence(sequence)))
 
-        Put(s"$collectionPath/${aname()}", content) ~> sealRoute(routes(creds)) ~> check {
+        Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(InternalServerError)
             responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
         }

--- a/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
@@ -49,7 +49,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     behavior of "Activations API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("activations_tests")
 
@@ -59,7 +59,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         // create two sets of activation records, and check that only one set is served back
         val creds1 = WhiskAuth(Subject(), AuthKey())
         (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject()), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
+            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
         } foreach { put(entityStore, _) }
 
         val actionName = aname
@@ -75,7 +75,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
                 val response = responseAs[List[JsObject]]
                 activations.length should be(response.length)
                 activations forall { a => response contains a.summaryAsJson } should be(true)
-                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName() case _ => false } }
+                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName.asString case _ => false } }
             }
         }
 
@@ -87,7 +87,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
                 val response = responseAs[List[JsObject]]
                 activations.length should be(response.length)
                 activations forall { a => response contains a.summaryAsJson } should be(true)
-                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName() case _ => false } }
+                rawResponse forall { a => a.getFields("for") match { case Seq(JsString(n)) => n == actionName.asString case _ => false } }
             }
         }
 
@@ -104,7 +104,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         // create two sets of activation records, and check that only one set is served back
         val creds1 = WhiskAuth(Subject(), AuthKey())
         (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject()), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
+            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
         } foreach { put(entityStore, _) }
 
         val actionName = aname
@@ -130,7 +130,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         // create two sets of activation records, and check that only one set is served back
         val creds1 = WhiskAuth(Subject(), AuthKey())
         (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject()), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
+            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
         } foreach { put(entityStore, _) }
 
         val actionName = aname
@@ -193,7 +193,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
         // create two sets of activation records, and check that only one set is served back
         val creds1 = WhiskAuth(Subject(), AuthKey())
         (1 to 2).map { i =>
-            WhiskActivation(EntityPath(creds1.subject()), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
+            WhiskActivation(EntityPath(creds1.subject.asString), aname, creds1.subject, ActivationId(), start = Instant.now, end = Instant.now)
         } foreach { put(entityStore, _) }
 
         val activations = (1 to 2).map { i =>
@@ -344,7 +344,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
             status should be(InternalServerError)
             val error = responseAs[ErrorResponse].error
             error should include("missing required member")
-            Seq(entity.name(), "annotations", "parameters", "exec", "trigger", "action", "rules", "binding", "response").map {
+            Seq(entity.name.asString, "annotations", "parameters", "exec", "trigger", "action", "rules", "binding", "response").map {
                 error should not include (_)
             }
         }

--- a/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -204,7 +204,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -234,7 +234,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -265,7 +265,7 @@ class EntitlementProviderTests
         // this forces a doc mismatch error
         val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), Exec.js(""))
         put(entityStore, action)
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -296,7 +296,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -330,7 +330,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -342,7 +342,7 @@ class EntitlementProviderTests
 
         // simulate package deletion for which binding was once entitled
         deletePackage(provider.docid)
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -376,7 +376,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -409,7 +409,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
@@ -439,7 +439,7 @@ class EntitlementProviderTests
             (ACTIVATE, guestUser, Right(false)),
             (REJECT, guestUser, Right(false)))
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
@@ -474,7 +474,7 @@ class EntitlementProviderTests
         put(entityStore, provider)
         put(entityStore, action)
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
@@ -507,7 +507,7 @@ class EntitlementProviderTests
         put(entityStore, provider)
         put(entityStore, action)
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
@@ -542,7 +542,7 @@ class EntitlementProviderTests
         put(entityStore, binding)
         put(entityStore, action)
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
@@ -577,7 +577,7 @@ class EntitlementProviderTests
         put(entityStore, binding)
         put(entityStore, action)
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
@@ -608,7 +608,7 @@ class EntitlementProviderTests
         val action = WhiskAction(someUser.namespace.toPath, MakeName.next(), Exec.js(""))
         put(entityStore, action)
 
-        paths.map {
+        paths foreach {
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,

--- a/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -101,7 +101,7 @@ class EntitlementProviderTests
     it should "not authorize a user to CRUD an entity in a collection if authkey has no CRUD rights" in {
         implicit val tid = transid()
         val subject = Subject()
-        val someUser = Identity(subject, EntityName(subject()), AuthKey(), Set(Privilege.ACTIVATE))
+        val someUser = Identity(subject, EntityName(subject.asString), AuthKey(), Set(Privilege.ACTIVATE))
         val collections = Seq(ACTIONS, RULES, TRIGGERS)
         val resources = collections map { Resource(someUser.namespace.toPath, _, Some("xyz")) }
         resources foreach { r =>
@@ -208,7 +208,7 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
                     // any user can list any namespace packages
                     // (because this performs a db view lookup which is later filtered)
@@ -238,7 +238,7 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
                     Resource(someUser.namespace.toPath, PACKAGES, Some("xyz")))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
@@ -269,9 +269,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(someUser.namespace.toPath, PACKAGES, Some(action.name())))
+                    Resource(someUser.namespace.toPath, PACKAGES, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -300,9 +300,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(someUser.namespace.toPath, PACKAGES, Some(provider.name())))
+                    Resource(someUser.namespace.toPath, PACKAGES, Some(provider.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -334,9 +334,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name())))
+                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
 
@@ -346,9 +346,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name())))
+                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -380,9 +380,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name())))
+                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -413,9 +413,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new PackageCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name())))
+                    Resource(guestUser.namespace.toPath, PACKAGES, Some(binding.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -443,7 +443,7 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
                     // any user can list any namespace packages
                     // (because this performs a db view lookup which is later filtered)
@@ -470,7 +470,7 @@ class EntitlementProviderTests
             (REJECT, guestUser, Right(false)))
 
         val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
-        val action = WhiskAction(provider.path, MakeName.next(), Exec.js(""))
+        val action = WhiskAction(provider.fullPath, MakeName.next(), Exec.js(""))
         put(entityStore, provider)
         put(entityStore, action)
 
@@ -478,9 +478,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name())))
+                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -503,7 +503,7 @@ class EntitlementProviderTests
             (REJECT, guestUser, Right(false)))
 
         val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
-        val action = WhiskAction(provider.path, MakeName.next(), Exec.js(""))
+        val action = WhiskAction(provider.fullPath, MakeName.next(), Exec.js(""))
         put(entityStore, provider)
         put(entityStore, action)
 
@@ -511,9 +511,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name())))
+                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -537,7 +537,7 @@ class EntitlementProviderTests
 
         val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = true)
         val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        val action = WhiskAction(binding.path, MakeName.next(), Exec.js(""))
+        val action = WhiskAction(binding.fullPath, MakeName.next(), Exec.js(""))
         put(entityStore, provider)
         put(entityStore, binding)
         put(entityStore, action)
@@ -546,9 +546,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name())))
+                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -572,7 +572,7 @@ class EntitlementProviderTests
 
         val provider = WhiskPackage(someUser.namespace.toPath, MakeName.next(), None, publish = false)
         val binding = WhiskPackage(guestUser.namespace.toPath, MakeName.next(), provider.bind)
-        val action = WhiskAction(binding.path, MakeName.next(), Exec.js(""))
+        val action = WhiskAction(binding.fullPath, MakeName.next(), Exec.js(""))
         put(entityStore, provider)
         put(entityStore, binding)
         put(entityStore, action)
@@ -581,9 +581,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name())))
+                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }
@@ -612,9 +612,9 @@ class EntitlementProviderTests
             case (priv, who, expected) =>
                 val check = new ActionCollection(entityStore).implicitRights(
                     who,
-                    Set(who.namespace()),
+                    Set(who.namespace.asString),
                     priv,
-                    Resource(action.namespace, ACTIONS, Some(action.name())))
+                    Resource(action.namespace, ACTIONS, Some(action.name.asString)))
                 Await.ready(check, requestTimeout).eitherValue.get shouldBe expected
         }
     }

--- a/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -42,9 +42,9 @@ import whisk.core.entity._
  * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
  */
 @RunWith(classOf[JUnitRunner])
-class AuthorizeTests extends ControllerTestCommon with Authenticate {
+class EntitlementProviderTests extends ControllerTestCommon {
 
-    behavior of "Authorize"
+    behavior of "Entitlement Provider"
 
     val requestTimeout = 1 second
     val someUser = Subject().toIdentity(AuthKey())

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -59,14 +59,14 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
     override val apiversion = "v1"
 
     val subject = Subject()
-    override val systemId = subject()
+    override val systemId = subject.asString
     override lazy val systemKey = Future.successful(WhiskAuth(subject, AuthKey()).toIdentity)
 
     /** Meta API tests */
     behavior of "Meta API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     setVerbosity(InfoLevel)
 
     val packages = Seq(
@@ -186,7 +186,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
     }
 
     it should "resolve a meta package into the systemId namespace" in {
-        resolvePackageName(EntityName("foo")).fullPath() shouldBe s"$systemId/foo"
+        resolvePackageName(EntityName("foo")).fullPath.asString shouldBe s"$systemId/foo"
     }
 
     it should "reject unsupported http verbs" in {

--- a/tests/src/whisk/core/controller/test/NamespacesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/NamespacesApiTests.scala
@@ -54,14 +54,14 @@ class NamespacesApiTests extends ControllerTestCommon with WhiskNamespacesApi {
 
     val collectionPath = s"/${collection.path}"
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
 
     it should "list namespaces for subject" in {
         implicit val tid = transid()
         Get(collectionPath) ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val ns = responseAs[List[EntityPath]]
-            ns should be(List(EntityPath(creds.subject())))
+            ns should be(List(EntityPath(creds.subject.asString)))
         }
     }
 
@@ -70,13 +70,13 @@ class NamespacesApiTests extends ControllerTestCommon with WhiskNamespacesApi {
         Get(s"$collectionPath/") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val ns = responseAs[List[EntityPath]]
-            ns should be(List(EntityPath(creds.subject())))
+            ns should be(List(EntityPath(creds.subject.asString)))
         }
     }
 
     it should "get namespace entities for subject" in {
         implicit val tid = transid()
-        Get(s"$collectionPath/${creds.subject()}") ~> sealRoute(routes(creds)) ~> check {
+        Get(s"$collectionPath/${creds.subject}") ~> sealRoute(routes(creds)) ~> check {
             status should be(OK)
             val ns = responseAs[JsObject]
             ns should be(JsObject(Namespaces.emptyNamespace map { kv => (kv._1, JsArray()) }))
@@ -86,28 +86,28 @@ class NamespacesApiTests extends ControllerTestCommon with WhiskNamespacesApi {
     it should "reject get namespace entities for unauthorized subject" in {
         implicit val tid = transid()
         val anothercred = WhiskAuth(Subject(), AuthKey())
-        Get(s"$collectionPath/${anothercred.subject()}") ~> sealRoute(routes(creds)) ~> check {
+        Get(s"$collectionPath/${anothercred.subject}") ~> sealRoute(routes(creds)) ~> check {
             status should be(Forbidden)
         }
     }
 
     it should "reject request with put" in {
         implicit val tid = transid()
-        Put(s"$collectionPath/${creds.subject()}") ~> sealRoute(routes(creds)) ~> check {
+        Put(s"$collectionPath/${creds.subject}") ~> sealRoute(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
         }
     }
 
     it should "reject request with post" in {
         implicit val tid = transid()
-        Post(s"$collectionPath/${creds.subject()}") ~> sealRoute(routes(creds)) ~> check {
+        Post(s"$collectionPath/${creds.subject}") ~> sealRoute(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
         }
     }
 
     it should "reject request with delete" in {
         implicit val tid = transid()
-        Delete(s"$collectionPath/${creds.subject()}") ~> sealRoute(routes(creds)) ~> check {
+        Delete(s"$collectionPath/${creds.subject}") ~> sealRoute(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
         }
     }

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -66,7 +66,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             if (i % 2 == 0) {
                 WhiskPackage(namespace, aname, None)
             } else {
-                val binding = Some(Binding(namespace, aname))
+                val binding = Some(Binding(namespace.root, aname))
                 WhiskPackage(namespace, aname, binding)
             }
         }.toList
@@ -384,7 +384,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "create package reference with implicit namespace" in {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
-        val reference = WhiskPackage(namespace, aname, Some(Binding(EntityPath.DEFAULT, provider.name)))
+        val reference = WhiskPackage(namespace, aname, Some(Binding(EntityPath.DEFAULT.root, provider.name)))
         val content = WhiskPackagePut(reference.binding)
         put(entityStore, provider)
         Put(s"$collectionPath/${reference.name}", content) ~> sealRoute(routes(creds)) ~> check {
@@ -400,7 +400,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
     it should "reject create package reference when referencing non-existent package in same namespace" in {
         implicit val tid = transid()
-        val binding = Some(Binding(namespace, aname))
+        val binding = Some(Binding(namespace.root, aname))
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
@@ -413,7 +413,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
         val privateNamespace = EntityPath(privateCreds.subject())
 
-        val binding = Some(Binding(privateNamespace, aname))
+        val binding = Some(Binding(privateNamespace.root, aname))
         val content = WhiskPackagePut(binding)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
             status should be(Forbidden)
@@ -424,7 +424,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         implicit val tid = transid()
         val provider = WhiskPackage(namespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
-        val content = WhiskPackagePut(Some(Binding(reference.namespace, reference.name)))
+        val content = WhiskPackagePut(Some(Binding(reference.namespace.root, reference.name)))
         put(entityStore, provider)
         put(entityStore, reference)
         Put(s"$collectionPath/$aname", content) ~> sealRoute(routes(creds)) ~> check {
@@ -648,7 +648,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject bind to non-package" in {
         implicit val tid = transid()
         val action = WhiskAction(namespace, aname, Exec.js("??"))
-        val reference = WhiskPackage(namespace, aname, Some(Binding(action.namespace, action.name)))
+        val reference = WhiskPackage(namespace, aname, Some(Binding(action.namespace.root, action.name)))
         val content = WhiskPackagePut(reference.binding)
 
         put(entityStore, action)

--- a/tests/src/whisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackagesApiTests.scala
@@ -48,7 +48,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     behavior of "Packages API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("packages_tests")
     val entityTooBigRejectionMessage = "request entity too large"
@@ -246,7 +246,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "not get package reference for a private package in other namespace" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
 
         val provider = WhiskPackage(privateNamespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
@@ -306,7 +306,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "not get package reference with its actions and feeds from private package" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
         val provider = WhiskPackage(privateNamespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
         val action = WhiskAction(provider.namespace.addPath(provider.name), aname, Exec.js("??"))
@@ -368,7 +368,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "not create package reference from private package in another namespace" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
 
         val provider = WhiskPackage(privateNamespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
@@ -411,7 +411,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject create package reference when referencing non-existent package in another namespace" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
 
         val binding = Some(Binding(privateNamespace.root, aname))
         val content = WhiskPackagePut(binding)
@@ -549,7 +549,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
 
         val provider = WhiskPackage(privateNamespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)
@@ -563,7 +563,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     it should "reject update package reference when new binding refers to private package in another namespace" in {
         implicit val tid = transid()
         val privateCreds = WhiskAuth(Subject(), AuthKey()).toIdentity
-        val privateNamespace = EntityPath(privateCreds.subject())
+        val privateNamespace = EntityPath(privateCreds.subject.asString)
 
         val provider = WhiskPackage(privateNamespace, aname)
         val reference = WhiskPackage(namespace, aname, provider.bind)

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -51,7 +51,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     behavior of "Rules API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     def aname() = MakeName.next("rules_tests")
     def afullname(namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
@@ -291,7 +291,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
         val rule = WhiskRule(namespace, aname(), FullyQualifiedEntityName(namespace, aname()), FullyQualifiedEntityName(namespace, aname()))
         val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name)
         val action = WhiskAction(rule.action.path, rule.action.name, Exec.js("??"))
-        val content = JsObject("trigger" -> JsString(s"/_/${trigger.name()}"), "action" -> JsString(s"/_/${action.name()}"))
+        val content = JsObject("trigger" -> JsString(s"/_/${trigger.name.asString}"), "action" -> JsString(s"/_/${action.name.asString}"))
 
         put(entityStore, trigger, false)
         put(entityStore, action)

--- a/tests/src/whisk/core/controller/test/SequenceApiTests.scala
+++ b/tests/src/whisk/core/controller/test/SequenceApiTests.scala
@@ -47,7 +47,7 @@ class SequenceApiTests
 
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val defaultNamespace = EntityPath.DEFAULT
     def aname() = MakeName.next("sequence_tests")
     val allowedActionDuration = 120 seconds
@@ -63,7 +63,7 @@ class SequenceApiTests
         put(entityStore, component)
         // create exec sequence that will violate max length
         val limit = whiskConfig.actionSequenceLimit.toInt + 1 // one more than allowed
-        val sequence = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid())
+        val sequence = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
         val content = WhiskActionPut(Some(Exec.sequence(sequence.toVector)))
 
         // create an action sequence
@@ -109,7 +109,7 @@ class SequenceApiTests
         put(entityStore, component)
 
         val seqName = s"${aname()}_cyclic"
-        val sSeq = makeSimpleSequence(seqName, namespace, Vector(component.name(), seqName, component.name()), false)
+        val sSeq = makeSimpleSequence(seqName, namespace, Vector(component.name.asString, seqName, component.name.asString), false)
 
         // create an action sequence
         val content = WhiskActionPut(Some(sSeq.exec))
@@ -126,7 +126,7 @@ class SequenceApiTests
         val component = WhiskAction(namespace, aname(), Exec.js("??"))
         put(entityStore, component)
         // create valid exec sequence initially
-        val sequence = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid())
+        val sequence = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
         val content = WhiskActionPut(Some(Exec.sequence(sequence.toVector)))
 
         // create a valid action sequence first
@@ -154,7 +154,7 @@ class SequenceApiTests
         put(entityStore, component)
         // create valid exec sequence
         val limit = whiskConfig.actionSequenceLimit.toInt
-        val sequence = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid())
+        val sequence = for (i <- 1 to limit) yield stringToFullyQualifiedName(component.docid.asString)
         val content = WhiskActionPut(Some(Exec.sequence(sequence.toVector)))
 
         // create an action sequence
@@ -201,7 +201,7 @@ class SequenceApiTests
         // put the action in the entity store so it's found
         val component = WhiskAction(namespace, aname(), Exec.js("??"))
         put(entityStore, component)
-        val sequence = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid())
+        val sequence = for (i <- 1 to 2) yield stringToFullyQualifiedName(component.docid.asString)
 
         // create package
         val pkg = s"${aname()}_pkg"

--- a/tests/src/whisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/whisk/core/controller/test/TriggersApiTests.scala
@@ -53,7 +53,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     behavior of "Triggers API"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("triggers_tests")
     val entityTooBigRejectionMessage = "request entity too large"

--- a/tests/src/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/whisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -57,7 +57,7 @@ class SequenceActionApiMigrationTests extends ControllerTestCommon
     behavior of "Sequence Action API Migration"
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
-    val namespace = EntityPath(creds.subject())
+    val namespace = EntityPath(creds.subject.asString)
     val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
     def aname = MakeName.next("seq_migration_tests")
 

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -47,6 +47,12 @@ import whisk.core.entity.WhiskEntityQueries
 import whisk.core.entity.types.AuthStore
 import whisk.core.entity.types.EntityStore
 
+/**
+ * WARNING: the put/get/del operations in this trait operate directly on the datastore,
+ * and in the presence of a cache, there will be inconsistencies if one mixes these
+ * operations with those that flow through the cache. To mitigate this, use unique asset
+ * names in tests, and defer all cleanup to the end of a test suite.
+ */
 trait DbUtils extends TransactionCounter {
     implicit val dbOpTimeout = 15 seconds
     val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -197,7 +197,7 @@ trait DbUtils extends TransactionCounter {
     def putGetCheck[A, Au >: A](db: ArtifactStore[Au], entity: A, factory: DocumentFactory[A], gc: Boolean = true)(
         implicit transid: TransactionId, timeout: Duration = 10 seconds, ma: Manifest[A]): (DocInfo, A) = {
         val doc = put(db, entity, gc)
-        assert(doc != null && doc.id() != null && doc.rev() != null)
+        assert(doc != null && doc.id.asString != null && doc.rev.asString != null)
         val future = factory.get(db, doc.id, doc.rev)
         val dbEntity = Await.result(future, timeout)
         assert(dbEntity != null)

--- a/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -61,7 +61,7 @@ class DispatcherTests extends FlatSpec with Matchers with WskActorSystem {
         val content = JsObject("payload" -> JsNumber(count))
         val user = WhiskAuth(Subject(), AuthKey()).toIdentity
         val path = FullyQualifiedEntityName(EntityPath("test"), EntityName(s"count-$count"), Some(SemVer()))
-        val msg = Message(TransactionId.testing, path, DocRevision(), user, ActivationId(), EntityPath(user.subject()), Some(content))
+        val msg = Message(TransactionId.testing, path, DocRevision(), user, ActivationId(), EntityPath(user.subject.asString), Some(content))
         connector.send(msg)
     }
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -202,23 +202,15 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
 
     it should "desiarilize legacy format" in {
         val names = Seq(
-            JsObject("path" -> "a".toJson, "name" -> "b".toJson),
-            JsObject("path" -> "a".toJson, "name" -> "b".toJson, "version" -> "0.0.1".toJson),
-            JsString("a/b"),
             JsObject("namespace" -> "a".toJson, "name" -> "b".toJson),
-            JsObject("namespace" -> "a".toJson, "path" -> "a".toJson, "name" -> "b".toJson),
-            JsObject("name" -> "b".toJson),
             JsObject(),
+            JsObject("name" -> "b".toJson),
             JsNull)
 
-        //Binding.optionalBindingDeserializer.read(names(0)) shouldBe Some(Binding(EntityPath("a"), EntityName("b")))
-        //Binding.optionalBindingDeserializer.read(names(1)) shouldBe Some(Binding(EntityPath("a"), EntityName("b"), Some(SemVer())))
-        //Binding.optionalBindingDeserializer.read(names(2)) shouldBe Some(Binding(EntityPath("a"), EntityName("b")))
-        Binding.optionalBindingDeserializer.read(names(3)) shouldBe Some(Binding(EntityPath("a"), EntityName("b")))
-        Binding.optionalBindingDeserializer.read(names(6)) shouldBe None
-        //a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(4))
-        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(5))
-        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(7))
+        Binding.optionalBindingDeserializer.read(names(0)) shouldBe Some(Binding(EntityName("a"), EntityName("b")))
+        Binding.optionalBindingDeserializer.read(names(1)) shouldBe None
+        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(2))
+        a[DeserializationException] should be thrownBy Binding.optionalBindingDeserializer.read(names(3))
     }
 
     it should "serialize optional binding to empty object" in {
@@ -256,7 +248,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
     }
 
     it should "serialize and deserialize package binding" in {
-        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"), Some(Binding(EntityPath("x"), EntityName("y"))))
+        val pkg = WhiskPackage(EntityPath("a"), EntityName("b"), Some(Binding(EntityName("x"), EntityName("y"))))
         val pkgAsJson = JsObject(
             "namespace" -> "a".toJson,
             "name" -> "b".toJson,

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -75,7 +75,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
     it should "accept well formed doc info" in {
         Seq("a", " a", "a ").foreach { i =>
             val d = DocInfo(i)
-            assert(d.id() == i.trim)
+            assert(d.id.asString == i.trim)
         }
     }
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -33,6 +33,7 @@ import org.scalatest.junit.JUnitRunner
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+import whisk.core.entitlement.Privilege
 import whisk.core.entity._
 import whisk.core.entity.size.SizeInt
 
@@ -57,12 +58,20 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
         }
     }
 
+    behavior of "Privilege"
+
+    it should "serdes a right" in {
+        Privilege.serdes.read("READ".toJson) shouldBe Privilege.READ
+        Privilege.serdes.read("read".toJson) shouldBe Privilege.READ
+        a[DeserializationException] should be thrownBy Privilege.serdes.read("???".toJson)
+    }
+
     behavior of "Identity"
 
     it should "serdes an identity" in {
         val i = WhiskAuth(Subject(), AuthKey()).toIdentity
         val expected = JsObject(
-            "subject" -> i.subject().toJson,
+            "subject" -> i.subject.asString.toJson,
             "namespace" -> i.namespace.toJson,
             "authkey" -> i.authkey.compact.toJson,
             "rights" -> Array("READ", "PUT", "DELETE", "ACTIVATE").toJson)

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -75,10 +75,10 @@ class ViewTests extends FlatSpec
     }
 
     val creds1 = WhiskAuth(Subject("s12345"), AuthKey())
-    val namespace1 = EntityPath(creds1.subject())
+    val namespace1 = EntityPath(creds1.subject.asString)
 
     val creds2 = WhiskAuth(Subject("t12345"), AuthKey())
-    val namespace2 = EntityPath(creds2.subject())
+    val namespace2 = EntityPath(creds2.subject.asString)
 
     val config = new WhiskConfig(WhiskEntityStore.requiredProperties)
     val datastore = WhiskEntityStore.datastore(config)

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -196,8 +196,8 @@ class ViewTests extends FlatSpec
             WhiskRule(namespace1, aname, trigger = afullname(namespace1), action = afullname(namespace1)),
             WhiskPackage(namespace1, aname),
             WhiskPackage(namespace1, aname),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
+            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
+            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
             WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace1, aname, Subject(), ActivationId(), start = now, end = now),
 
@@ -213,8 +213,8 @@ class ViewTests extends FlatSpec
             WhiskRule(namespace2, aname, trigger = afullname(namespace2), action = afullname(namespace2)),
             WhiskPackage(namespace2, aname),
             WhiskPackage(namespace2, aname),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))),
+            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))),
+            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))),
             WhiskActivation(namespace2, aname, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now),
             WhiskActivation(namespace2, actionName, Subject(), ActivationId(), start = now, end = now))
@@ -297,13 +297,13 @@ class ViewTests extends FlatSpec
         implicit val entities = Seq(
             WhiskPackage(namespace1, aname, publish = true),
             WhiskPackage(namespace1, aname, publish = false),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname)), publish = true),
-            WhiskPackage(namespace1, aname, Some(Binding(namespace2, aname))),
+            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname)), publish = true),
+            WhiskPackage(namespace1, aname, Some(Binding(namespace2.root, aname))),
 
             WhiskPackage(namespace2, aname, publish = true),
             WhiskPackage(namespace2, aname, publish = false),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname)), publish = true),
-            WhiskPackage(namespace2, aname, Some(Binding(namespace1, aname))))
+            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname)), publish = true),
+            WhiskPackage(namespace2, aname, Some(Binding(namespace1.root, aname))))
 
         entities foreach { put(datastore, _) }
         waitOnView(datastore, namespace1, entities.length / 2)


### PR DESCRIPTION
Adding some missing tests for package and action entitlement as well as tests which cover the action/package implicit right inference.

Remove `apply()` idiom which converted some of our types to `String` in favor of an explicit `asString` method (not using `toString` since that may format types for printing instead of type conversion).

This is further dusting ahead of some changes to the object access model.

@nwspeete-ibm FYI.