### PR TITLE
Add Binary Field to Action Exec

### DIFF
--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -49,6 +49,7 @@ type Exec struct {
     Jar         string      `json:"jar,omitempty"`
     Main        string      `json:"main,omitempty"`
     Components  []string    `json:"components,omitempty"`    // List of fully qualified actions
+    Binary      bool        `json:"binary,omitempty"`
 }
 
 type ActionListOptions struct {


### PR DESCRIPTION
- A binary field is displayed for Docker and Zip actions

Closes https://github.com/openwhisk/openwhisk/issues/1610