### PR TITLE
Properly Format Strings Containing Precent Characters

### DIFF
--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -60,9 +60,7 @@ var actionCreateCmd = &cobra.Command{
     action, err := parseAction(cmd, args)
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseAction(%s, %s) error: %s\n", cmd, args, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to parse action command arguments: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to parse action command arguments: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return whiskErr
@@ -71,9 +69,7 @@ var actionCreateCmd = &cobra.Command{
     _, _, err = client.Actions.Insert(action, false)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.Insert(%#v, false) error: %s\n", action, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to create action: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to create action: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -102,9 +98,7 @@ var actionUpdateCmd = &cobra.Command{
     action, err := parseAction(cmd, args)
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseAction(%s, %s) error: %s\n", cmd, args, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to parse action command arguments: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to parse action command arguments: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return whiskErr
@@ -113,9 +107,7 @@ var actionUpdateCmd = &cobra.Command{
     _, _, err = client.Actions.Insert(action, true)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.Insert(%#v, %t, false) error: %s\n", action, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to update action: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to update action: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -145,9 +137,8 @@ var actionInvokeCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+        map[string]interface{}{"name": args[0], "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -160,9 +151,8 @@ var actionInvokeCmd = &cobra.Command{
       parameters, err = getJSONFromStrings(flags.common.param, false)
       if err != nil {
         whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, false) failed: %s\n", flags.common.param, err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-            map[string]interface{}{"param": fmt.Sprintf("%#v", flags.common.param), "err": err}))
+        errMsg := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+            map[string]interface{}{"param": fmt.Sprintf("%#v", flags.common.param), "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr
@@ -179,9 +169,8 @@ var actionInvokeCmd = &cobra.Command{
       if (isWhiskErr && whiskErr.ApplicationError != true) || !isWhiskErr {
         whisk.Debug(whisk.DbgError, "client.Actions.Invoke(%s, %s, %t) error: %s\n", qName.entityName, parameters,
           flags.common.blocking, err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("Unable to invoke action '{{.name}}': {{.err}}",
-            map[string]interface{}{"name": qName.entityName, "err": err}))
+        errMsg := wski18n.T("Unable to invoke action '{{.name}}': {{.err}}",
+          map[string]interface{}{"name": qName.entityName, "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
@@ -235,8 +224,7 @@ var actionGetCmd = &cobra.Command{
       field = args[1]
 
       if !fieldExists(&whisk.Action{}, field) {
-        errMsg := fmt.Sprintf(
-          wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field}))
+        errMsg := wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field})
         whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
@@ -246,9 +234,8 @@ var actionGetCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+        map[string]interface{}{"name": args[0], "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -258,9 +245,7 @@ var actionGetCmd = &cobra.Command{
     action, _, err := client.Actions.Get(qName.entityName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", qName.entityName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to get action: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to get action: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -302,9 +287,8 @@ var actionDeleteCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+        map[string]interface{}{"name": args[0], "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return whiskErr
@@ -314,9 +298,7 @@ var actionDeleteCmd = &cobra.Command{
     _, err = client.Actions.Delete(qName.entityName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.Delete(%s) error: %s\n", qName.entityName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to delete action: {{.err}}",
-          map[string]interface{}{"err": err}))
+      errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return whiskErr
@@ -343,9 +325,8 @@ var actionListCmd = &cobra.Command{
       qName, err = parseQualifiedName(args[0])
       if err != nil {
         whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-            map[string]interface{}{"name": args[0], "err": err}))
+        errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": args[0], "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
@@ -353,8 +334,7 @@ var actionListCmd = &cobra.Command{
 
       if len(qName.namespace) == 0 {
         whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-        errMsg := fmt.Sprintf(
-          wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
+        errMsg := wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
@@ -393,9 +373,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
   qName, err = parseQualifiedName(args[0])
   if err != nil {
     whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-    errMsg := fmt.Sprintf(
-      wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-        map[string]interface{}{"name": args[0], "err": err}))
+    errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+      map[string]interface{}{"name": args[0], "err": err})
     whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
       whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     return nil, whiskErr
@@ -410,9 +389,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
   parameters, err := getJSONFromStrings(flags.common.param, true)
   if err != nil {
     whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-    errMsg := fmt.Sprintf(
-      wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-        map[string]interface{}{"param": fmt.Sprintf("%#v", flags.common.param), "err": err}))
+    errMsg := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+        map[string]interface{}{"param": fmt.Sprintf("%#v", flags.common.param), "err": err})
     whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
       whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     return nil, whiskErr
@@ -422,9 +400,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
   annotations, err := getJSONFromStrings(flags.common.annotation, true)
   if err != nil {
     whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-    errMsg := fmt.Sprintf(
-      wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-        map[string]interface{}{"annotation": fmt.Sprintf("%#v", flags.common.annotation), "err": err}))
+    errMsg := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+        map[string]interface{}{"annotation": fmt.Sprintf("%#v", flags.common.annotation), "err": err})
     whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
       whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     return nil, whiskErr
@@ -437,9 +414,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
     qNameCopy, err = parseQualifiedName(args[1])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[1], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[1], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+        map[string]interface{}{"name": args[1], "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return nil, whiskErr
@@ -449,9 +425,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
     existingAction, _, err := client.Actions.Get(qNameCopy.entityName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", qName.entityName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("Unable to obtain action '{{.name}}' to copy: {{.err}}",
-          map[string]interface{}{"name": qName.entityName, "err": err}))
+      errMsg := wski18n.T("Unable to obtain action '{{.name}}' to copy: {{.err}}",
+          map[string]interface{}{"name": qName.entityName, "err": err})
       whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return nil, whiskErr
@@ -498,9 +473,8 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
       }
     } else if len(flags.action.kind) > 0 {
       whisk.Debug(whisk.DbgError, "--kind argument '%s' is not supported\n", flags.action.kind)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a supported action runtime",
-          map[string]interface{}{"name": flags.action.kind}))
+      errMsg := wski18n.T("'{{.name}}' is not a supported action runtime",
+        map[string]interface{}{"name": flags.action.kind})
       whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
         whisk.DISPLAY_USAGE)
       return nil, whiskErr
@@ -522,9 +496,7 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
         errMsg = wski18n.T("creating an action from a .zip artifact requires specifying the action kind explicitly")
       } else {
         whisk.Debug(whisk.DbgError, "Action runtime extension '%s' is not supported\n", ext)
-        errMsg = fmt.Sprintf(
-          wski18n.T("'{{.name}}' is not a supported action runtime",
-            map[string]interface{}{"name": ext}))
+        errMsg = wski18n.T("'{{.name}}' is not a supported action runtime", map[string]interface{}{"name": ext})
       }
       whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
         whisk.DISPLAY_USAGE)

--- a/tools/cli/go-whisk-cli/commands/activation.go
+++ b/tools/cli/go-whisk-cli/commands/activation.go
@@ -58,18 +58,15 @@ var activationListCmd = &cobra.Command{
             qName, err = parseQualifiedName(args[0])
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                        map[string]interface{}{"name": args[0], "err": err}))
+                errStr := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                        map[string]interface{}{"name": args[0], "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
                 whisk.Debug(whisk.DbgError, "Namespace '%s' is invalid\n", ns)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Namespace '{{.name}}' is invalid",
-                        map[string]interface{}{"name": ns}))
+                errStr := wski18n.T("Namespace '{{.name}}' is invalid", map[string]interface{}{"name": ns})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
@@ -127,8 +124,7 @@ var activationGetCmd = &cobra.Command{
             field = args[1]
 
             if !fieldExists(&whisk.Activation{}, field) {
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field}))
+                errMsg := wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field})
                 whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -139,9 +135,8 @@ var activationGetCmd = &cobra.Command{
         activation, _, err := client.Activations.Get(id)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Activations.Get(%s) failed: %s\n", id, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain activation record for '{{.id}}': {{.err}}",
-                    map[string]interface{}{"id": id, "err": err}))
+            errStr := wski18n.T("Unable to obtain activation record for '{{.id}}': {{.err}}",
+                    map[string]interface{}{"id": id, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -191,9 +186,8 @@ var activationLogsCmd = &cobra.Command{
         activation, _, err := client.Activations.Logs(id)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Activations.Logs(%s) failed: %s\n", id, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain logs for activation '{{.id}}': {{.err}}",
-                    map[string]interface{}{"id": id, "err": err}))
+            errStr := wski18n.T("Unable to obtain logs for activation '{{.id}}': {{.err}}",
+                map[string]interface{}{"id": id, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -220,9 +214,8 @@ var activationResultCmd = &cobra.Command{
         result, _, err := client.Activations.Result(id)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Activations.result(%s) failed: %s\n", id, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain result information for activation '{{.id}}': {{.err}}",
-                    map[string]interface{}{"id": id, "err": err}))
+            errStr := wski18n.T("Unable to obtain result information for activation '{{.id}}': {{.err}}",
+                    map[string]interface{}{"id": id, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -60,9 +60,7 @@ var apiCreateCmd = &cobra.Command{
             api, err = parseSwaggerApi()
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseSwaggerApi() error: %s\n", err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Unable to parse swagger file: {{.err}}",
-                        map[string]interface{}{"err": err}))
+                errMsg := wski18n.T("Unable to parse swagger file: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
@@ -75,9 +73,8 @@ var apiCreateCmd = &cobra.Command{
             api, err = parseApi(cmd, args)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Unable to parse api command arguments: {{.err}}",
-                        map[string]interface{}{"err": err}))
+                errMsg := wski18n.T("Unable to parse api command arguments: {{.err}}",
+                    map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
@@ -90,9 +87,7 @@ var apiCreateCmd = &cobra.Command{
         retApi, _, err := client.Apis.Insert(sendApi, false)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, false) error: %s\n", api, err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("Unable to create API: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errMsg := wski18n.T("Unable to create API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -151,9 +146,7 @@ var apiUpdateCmd = &cobra.Command{
         api, err := parseApi(cmd, args)
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("Unable to parse API command arguments: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errMsg := wski18n.T("Unable to parse API command arguments: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return whiskErr
@@ -164,9 +157,7 @@ var apiUpdateCmd = &cobra.Command{
         retApi, _, err := client.Apis.Insert(sendApi, true)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, %t, false) error: %s\n", api, err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("Unable to update API: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errMsg := wski18n.T("Unable to update API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -208,9 +199,7 @@ var apiGetCmd = &cobra.Command{
         retApi, _, err := client.Apis.Get(api, options)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Get(%s) error: %s\n", api.Id, err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("Unable to get API: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -237,13 +226,11 @@ var apiGetCmd = &cobra.Command{
         if (displayResult == nil) {
             var errMsg string
             if (isBasePathArg) {
-                errMsg = fmt.Sprintf(
-                    wski18n.T("API does not exist for basepath {{.basepath}}",
-                    map[string]interface{}{"basepath": args[0]}))
+                errMsg = wski18n.T("API does not exist for basepath {{.basepath}}",
+                    map[string]interface{}{"basepath": args[0]})
             } else {
-                errMsg = fmt.Sprintf(
-                wski18n.T("API does not exist for API name {{.apiname}}",
-                    map[string]interface{}{"apiname": args[0]}))
+                errMsg = wski18n.T("API does not exist for API name {{.apiname}}",
+                    map[string]interface{}{"apiname": args[0]})
             }
 
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
@@ -299,9 +286,7 @@ var apiDeleteCmd = &cobra.Command{
         _, err := client.Apis.Delete(api, options)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Delete(%s) error: %s\n", api.Id, err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("Unable to delete action: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -364,9 +349,7 @@ var apiListCmd = &cobra.Command{
             retApiArray, _, err = client.Apis.List(options)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "client.Apis.List(%s) error: %s\n", options, err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Unable to get api: {{.err}}",
-                        map[string]interface{}{"err": err}))
+                errMsg := wski18n.T("Unable to get api: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -393,9 +376,7 @@ var apiListCmd = &cobra.Command{
             retApiArray, _, err = client.Apis.Get(api, options)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "client.Apis.Get(%s) error: %s\n", api.Id, err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Unable to obtain the API list: {{.err}}",
-                        map[string]interface{}{"err": err}))
+                errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -502,18 +483,15 @@ func parseApi(cmd *cobra.Command, args []string) (*whisk.Api, error) {
         qName, err = parseQualifiedName(args[2])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[2], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid action name: {{.err}}",
-                    map[string]interface{}{"name": args[2], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid action name: {{.err}}",
+                map[string]interface{}{"name": args[2], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return nil, whiskErr
         }
         if (qName.entityName == "") {
             whisk.Debug(whisk.DbgError, "Action name '%s' is invalid\n", args[2])
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid action name.",
-                    map[string]interface{}{"name": args[2]}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid action name.", map[string]interface{}{"name": args[2]})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return nil, whiskErr
@@ -551,8 +529,7 @@ func parseSwaggerApi() (*whisk.Api, error) {
     // Test is for completeness, but this situation should only arise due to an internal error
     if ( len(flags.api.configfile) == 0 ) {
         whisk.Debug(whisk.DbgError, "No swagger file is specified\n")
-        errMsg := fmt.Sprintf(
-            wski18n.T("A configuration file was not specified."))
+        errMsg := wski18n.T("A configuration file was not specified.")
         whiskErr := whisk.MakeWskError(errors.New(errMsg),whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return nil, whiskErr
@@ -561,9 +538,8 @@ func parseSwaggerApi() (*whisk.Api, error) {
     swagger, err:= readFile(flags.api.configfile)
     if ( err != nil ) {
         whisk.Debug(whisk.DbgError, "readFile(%s) error: %s\n", flags.api.configfile, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("Error reading swagger file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": flags.api.configfile, "err": err}))
+        errMsg := wski18n.T("Error reading swagger file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": flags.api.configfile, "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return nil, whiskErr
@@ -574,9 +550,8 @@ func parseSwaggerApi() (*whisk.Api, error) {
     err = json.Unmarshal([]byte(swagger), swaggerObj)
     if ( err != nil ) {
         whisk.Debug(whisk.DbgError, "JSON parse of `%s' error: %s\n", flags.api.configfile, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("Error parsing swagger file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": flags.api.configfile, "err": err}))
+        errMsg := wski18n.T("Error parsing swagger file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": flags.api.configfile, "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return nil, whiskErr
@@ -607,11 +582,10 @@ func IsValidApiVerb(verb string) (error, bool) {
     // Is the API verb valid?
     if _, ok := whisk.ApiVerbs[strings.ToUpper(verb)]; !ok {
         whisk.Debug(whisk.DbgError, "Invalid API verb: %s\n", verb)
-        errMsg := fmt.Sprintf(
-            wski18n.T("'{{.verb}}' is not a valid API verb.  Valid values are: {{.verbs}}",
+        errMsg := wski18n.T("'{{.verb}}' is not a valid API verb.  Valid values are: {{.verbs}}",
                 map[string]interface{}{
                     "verb": verb,
-                    "verbs": reflect.ValueOf(whisk.ApiVerbs).MapKeys()}))
+                    "verbs": reflect.ValueOf(whisk.ApiVerbs).MapKeys()})
         whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr, false
@@ -622,11 +596,10 @@ func IsValidApiVerb(verb string) (error, bool) {
 func hasPathPrefix(path string) (error, bool) {
     if (! strings.HasPrefix(path, "/")) {
         whisk.Debug(whisk.DbgError, "path does not begin with '/': %s\n", path)
-        errMsg := fmt.Sprintf(
-            wski18n.T("'{{.path}}' must begin with '/'.",
+        errMsg := wski18n.T("'{{.path}}' must begin with '/'.",
                 map[string]interface{}{
                     "path": path,
-                }))
+                })
         whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr, false

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -63,8 +63,7 @@ func setupClientConfig(cmd *cobra.Command, args []string) (error){
 
     if err != nil {
         whisk.Debug(whisk.DbgError, "whisk.NewClient(%#v, %#v) error: %s\n", http.DefaultClient, clientConfig, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("Unable to initialize server connection: {{.err}}", map[string]interface{}{"err": err}))
+        errMsg := wski18n.T("Unable to initialize server connection: {{.err}}", map[string]interface{}{"err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr
@@ -204,8 +203,7 @@ func Execute() error {
 
     if err != nil {
         whisk.Debug(whisk.DbgError, "parseParams(%s) failed: %s\n", os.Args, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("Failed to parse arguments: {{.err}}", map[string]interface{}{"err":err}))
+        errMsg := wski18n.T("Failed to parse arguments: {{.err}}", map[string]interface{}{"err":err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return whiskErr

--- a/tools/cli/go-whisk-cli/commands/namespace.go
+++ b/tools/cli/go-whisk-cli/commands/namespace.go
@@ -49,9 +49,8 @@ var namespaceListCmd = &cobra.Command{
         namespaces, _, err := client.Namespaces.List()
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Namespaces.List() error: %s\n", err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to obtain the list of available namespaces: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errStr := wski18n.T("Unable to obtain the list of available namespaces: {{.err}}",
+                map[string]interface{}{"err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -80,9 +79,8 @@ var namespaceGetCmd = &cobra.Command{
             qName, err = parseQualifiedName(args[0])
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                        map[string]interface{}{"name": args[0], "err": err}))
+                errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                        map[string]interface{}{"name": args[0], "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr

--- a/tools/cli/go-whisk-cli/commands/package.go
+++ b/tools/cli/go-whisk-cli/commands/package.go
@@ -51,9 +51,8 @@ var packageBindCmd = &cobra.Command{
     pkgQName, err := parseQualifiedName(packageName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", packageName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": packageName, "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": packageName, "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -63,9 +62,8 @@ var packageBindCmd = &cobra.Command{
     bindQName, err := parseQualifiedName(bindingName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", bindingName, err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": bindingName, "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": bindingName, "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -82,9 +80,8 @@ var packageBindCmd = &cobra.Command{
 
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+      errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -97,9 +94,8 @@ var packageBindCmd = &cobra.Command{
 
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
+      errStr := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -119,8 +115,7 @@ var packageBindCmd = &cobra.Command{
     _, _, err = client.Packages.Insert(p, false)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, false) failed: %s\n", p, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Binding creation failed: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Binding creation failed: {{.err}}", map[string]interface{}{"err":err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -148,9 +143,8 @@ var packageCreateCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": args[0], "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -167,9 +161,8 @@ var packageCreateCmd = &cobra.Command{
 
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+      errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -179,9 +172,8 @@ var packageCreateCmd = &cobra.Command{
 
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
+      errStr := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -200,8 +192,7 @@ var packageCreateCmd = &cobra.Command{
     p, _, err = client.Packages.Insert(p, false)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, false) failed: %s\n", p, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package creation failed: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Package creation failed: {{.err}}", map[string]interface{}{"err":err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -229,9 +220,8 @@ var packageUpdateCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": args[0], "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -248,9 +238,8 @@ var packageUpdateCmd = &cobra.Command{
 
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+      errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+          map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -259,9 +248,8 @@ var packageUpdateCmd = &cobra.Command{
     annotations, err := getJSONFromStrings(flags.common.annotation, true)
     if err != nil {
       whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
+      errStr := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+          map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
       return werr
     }
@@ -280,8 +268,7 @@ var packageUpdateCmd = &cobra.Command{
     p, _, err = client.Packages.Insert(p, true)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Insert(%#v, true) failed: %s\n", p, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package update failed: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Package update failed: {{.err}}", map[string]interface{}{"err":err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -310,8 +297,7 @@ var packageGetCmd = &cobra.Command{
       field = args[1]
 
       if !fieldExists(&whisk.Package{}, field) {
-        errMsg := fmt.Sprintf(
-          wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field}))
+        errMsg := wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field})
         whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return whiskErr
@@ -321,9 +307,8 @@ var packageGetCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": args[0], "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -333,8 +318,7 @@ var packageGetCmd = &cobra.Command{
     xPackage, _, err := client.Packages.Get(qName.entityName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Get(%s) failed: %s\n", qName.entityName, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package get failed: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Package get failed: {{.err}}", map[string]interface{}{"err":err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -375,9 +359,8 @@ var packageDeleteCmd = &cobra.Command{
     qName, err := parseQualifiedName(args[0])
     if err != nil {
       whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-      errMsg := fmt.Sprintf(
-        wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-          map[string]interface{}{"name": args[0], "err": err}))
+      errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+          map[string]interface{}{"name": args[0], "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
         whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
@@ -387,8 +370,7 @@ var packageDeleteCmd = &cobra.Command{
     _, err = client.Packages.Delete(qName.entityName)
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Delete(%s) failed: %s\n", qName.entityName, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package delete failed: {{.err}}", map[string]interface{}{"err":err}))
+      errStr := wski18n.T("Package delete failed: {{.err}}", map[string]interface{}{"err":err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -415,9 +397,8 @@ var packageListCmd = &cobra.Command{
       qName, err = parseQualifiedName(args[0])
       if err != nil {
         whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-        errMsg := fmt.Sprintf(
-          wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-            map[string]interface{}{"name": args[0], "err": err}))
+        errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+            map[string]interface{}{"name": args[0], "err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
           whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
@@ -425,8 +406,7 @@ var packageListCmd = &cobra.Command{
       ns := qName.namespace
       if len(ns) == 0 {
         whisk.Debug(whisk.DbgError, "An empty namespace in the package name '%s' is invalid \n", args[0])
-        errStr := fmt.Sprintf(
-          wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
+        errStr := wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return werr
       }
@@ -484,9 +464,8 @@ var packageRefreshCmd = &cobra.Command{
 
         if err != nil {
           whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-          errMsg := fmt.Sprintf(
-            wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-              map[string]interface{}{"name": args[0], "err": err}))
+          errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+              map[string]interface{}{"name": args[0], "err": err})
           werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
           return werr
@@ -504,9 +483,8 @@ var packageRefreshCmd = &cobra.Command{
     updates, resp, err := client.Packages.Refresh()
     if err != nil {
       whisk.Debug(whisk.DbgError, "client.Packages.Refresh() of namespace '%s' failed: %s\n", client.Config.Namespace, err)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package refresh for namespace '{{.name}}' failed: {{.err}}",
-          map[string]interface{}{"name": client.Config.Namespace, "err": err}))
+      errStr := wski18n.T("Package refresh for namespace '{{.name}}' failed: {{.err}}",
+          map[string]interface{}{"name": client.Config.Namespace, "err": err})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }
@@ -537,14 +515,13 @@ var packageRefreshCmd = &cobra.Command{
 
     case http.StatusNotImplemented:
       whisk.Debug(whisk.DbgError, "client.Packages.Refresh() for namespace '%s' returned 'Not Implemented' HTTP status code: %d\n", client.Config.Namespace, resp.StatusCode)
-      errStr := fmt.Sprintf(wski18n.T("The package refresh feature is not implemented in the target deployment"))
+      errStr := wski18n.T("The package refresh feature is not implemented in the target deployment")
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     default:
       whisk.Debug(whisk.DbgError, "client.Packages.Refresh() for namespace '%s' returned an unexpected HTTP status code: %d\n", client.Config.Namespace, resp.StatusCode)
-      errStr := fmt.Sprintf(
-        wski18n.T("Package refresh for namespace '{{.name}}' failed due to unexpected HTTP status code: {{.code}}",
-          map[string]interface{}{"name": client.Config.Namespace, "code": resp.StatusCode}))
+      errStr := wski18n.T("Package refresh for namespace '{{.name}}' failed due to unexpected HTTP status code: {{.code}}",
+          map[string]interface{}{"name": client.Config.Namespace, "code": resp.StatusCode})
       werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
       return werr
     }

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -72,9 +72,7 @@ var propertySetCmd = &cobra.Command{
         props, err := readProps(Properties.PropsFile)
         if err != nil {
             whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to set the property value: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errStr := wski18n.T("Unable to set the property value: {{.err}}", map[string]interface{}{"err": err})
             werr = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -412,9 +410,8 @@ func loadProperties() error {
     props, err := readProps(Properties.PropsFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "readProps(%s) failed: %s\n", Properties.PropsFile, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to read the properties file '{{.filename}}': {{.err}}",
-                map[string]interface{}{"filename": Properties.PropsFile, "err": err}))
+        errStr := wski18n.T("Unable to read the properties file '{{.filename}}': {{.err}}",
+                map[string]interface{}{"filename": Properties.PropsFile, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -486,9 +483,8 @@ func parseConfigFlags(cmd *cobra.Command, args []string) error {
 
             if err != nil {
                 whisk.Debug(whisk.DbgError, "getURLBase(%s) failed: %s\n", apiHost, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Invalid host address '{{.host}}': {{.err}}",
-                        map[string]interface{}{"host": Properties.APIHost, "err": err}))
+                errStr := wski18n.T("Invalid host address '{{.host}}': {{.err}}",
+                        map[string]interface{}{"host": Properties.APIHost, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -543,9 +539,7 @@ func writeProps(path string, props map[string]string) error {
     file, err := os.Create(path)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", path, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Whisk properties file write failure: {{.err}}",
-                map[string]interface{}{"err": err}))
+        errStr := wski18n.T("Whisk properties file write failure: {{.err}}", map[string]interface{}{"err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -558,9 +552,7 @@ func writeProps(path string, props map[string]string) error {
         _, err = fmt.Fprintln(writer, line)
         if err != nil {
             whisk.Debug(whisk.DbgError, "fmt.Fprintln() write to '%s' failed: %s\n", path, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Whisk properties file write failure: {{.err}}",
-                    map[string]interface{}{"err": err}))
+            errStr := wski18n.T("Whisk properties file write failure: {{.err}}", map[string]interface{}{"err": err})
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }

--- a/tools/cli/go-whisk-cli/commands/rule.go
+++ b/tools/cli/go-whisk-cli/commands/rule.go
@@ -49,9 +49,8 @@ var ruleEnableCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -63,9 +62,8 @@ var ruleEnableCmd = &cobra.Command{
         _, _, err = client.Rules.SetState(ruleName, "active")
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, active) failed: %s\n", ruleName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to enable rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to enable rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -93,9 +91,8 @@ var ruleDisableCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -107,9 +104,8 @@ var ruleDisableCmd = &cobra.Command{
         _, _, err = client.Rules.SetState(ruleName, "inactive")
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to disable rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to disable rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -137,9 +133,8 @@ var ruleStatusCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -151,9 +146,8 @@ var ruleStatusCmd = &cobra.Command{
         rule, _, err := client.Rules.Get(ruleName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to retrieve rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to retrieve rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -182,9 +176,8 @@ var ruleCreateCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -206,9 +199,8 @@ var ruleCreateCmd = &cobra.Command{
         retRule, _, err = client.Rules.Insert(rule, false)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Insert(%#v) failed: %s\n", rule, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to create rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to create rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -238,9 +230,8 @@ var ruleUpdateCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -260,9 +251,8 @@ var ruleUpdateCmd = &cobra.Command{
         _, _, err = client.Rules.Insert(rule, true)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Insert(%#v) failed: %s\n", rule, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to update rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": rule.Name, "err": err}))
+            errStr := wski18n.T("Unable to update rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": rule.Name, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -292,8 +282,7 @@ var ruleGetCmd = &cobra.Command{
             field = args[1]
 
             if !fieldExists(&whisk.Rule{}, field){
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field}))
+                errMsg := wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field})
                 whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -303,9 +292,8 @@ var ruleGetCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -317,9 +305,8 @@ var ruleGetCmd = &cobra.Command{
         rule, _, err := client.Rules.Get(ruleName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Get(%s) failed: %s\n", ruleName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to retrieve rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to retrieve rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -359,9 +346,8 @@ var ruleDeleteCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -374,9 +360,8 @@ var ruleDeleteCmd = &cobra.Command{
             _, _, err := client.Rules.SetState(ruleName, "inactive")
             if err != nil {
                 whisk.Debug(whisk.DbgError, "client.Rules.SetState(%s, inactive) failed: %s\n", ruleName, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to disable rule '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": ruleName, "err": err}))
+                errStr := wski18n.T("Unable to disable rule '{{.name}}': {{.err}}",
+                        map[string]interface{}{"name": ruleName, "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -385,9 +370,8 @@ var ruleDeleteCmd = &cobra.Command{
         _, err = client.Rules.Delete(ruleName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Rules.Delete(%s) error: %s\n", ruleName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to delete rule '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": ruleName, "err": err}))
+            errStr := wski18n.T("Unable to delete rule '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": ruleName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -413,17 +397,15 @@ var ruleListCmd = &cobra.Command{
             qName, err = parseQualifiedName(args[0])
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Namespace '{{.name}}' is invalid: {{.err}}\n",
-                        map[string]interface{}{"name": args[0], "err": err}))
+                errStr := wski18n.T("Namespace '{{.name}}' is invalid: {{.err}}\n",
+                        map[string]interface{}{"name": args[0], "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
                 whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-                errStr := fmt.Sprintf(
-                    wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
+                errStr := wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }

--- a/tools/cli/go-whisk-cli/commands/sdk.go
+++ b/tools/cli/go-whisk-cli/commands/sdk.go
@@ -62,8 +62,7 @@ var sdkInstallCmd = &cobra.Command{
         var err error
         if len(args) != 1 {
             whisk.Debug(whisk.DbgError, "Invalid number of arguments: %d\n", len(args))
-            errStr := fmt.Sprintf(
-                wski18n.T("The SDK component argument is missing. One component (docker, ios, or bashauto) must be specified"))
+            errStr := wski18n.T("The SDK component argument is missing. One component (docker, ios, or bashauto) must be specified")
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -77,9 +76,8 @@ var sdkInstallCmd = &cobra.Command{
             err = WskCmd.GenBashCompletionFile(BASH_AUTOCOMPLETE_FILENAME)
             if (err != nil) {
                 whisk.Debug(whisk.DbgError, "GenBashCompletionFile('%s`) error: \n", BASH_AUTOCOMPLETE_FILENAME, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to generate '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME, "err": err}))
+                errStr := wski18n.T("Unable to generate '{{.name}}': {{.err}}",
+                        map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -88,9 +86,8 @@ var sdkInstallCmd = &cobra.Command{
                     map[string]interface{}{"name": BASH_AUTOCOMPLETE_FILENAME}))
         default:
             whisk.Debug(whisk.DbgError, "Invalid component argument '%s'\n", component)
-            errStr := fmt.Sprintf(
-                wski18n.T("The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
-                    map[string]interface{}{"component": component}))
+            errStr := wski18n.T("The SDK component argument '{{.component}}' is invalid. Valid components are docker, ios and bashauto",
+                    map[string]interface{}{"component": component})
             err = whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         }
 
@@ -107,18 +104,16 @@ func dockerInstall() error {
     targetFile := sdkMap[SDK_DOCKER_COMPONENT_NAME].FileName
     if _, err = os.Stat(targetFile); err == nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' exists\n", targetFile)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
-                map[string]interface{}{"name": targetFile}))
+        errStr := wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
+            map[string]interface{}{"name": targetFile})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
 
     if err = sdkInstall(SDK_DOCKER_COMPONENT_NAME); err != nil {
         whisk.Debug(whisk.DbgError, "sdkInstall(%s) failed: %s\n", SDK_DOCKER_COMPONENT_NAME, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("The {{.component}} SDK installation failed: {{.err}}",
-                map[string]interface{}{"component": SDK_DOCKER_COMPONENT_NAME, "err": err}))
+        errStr := wski18n.T("The {{.component}} SDK installation failed: {{.err}}",
+                map[string]interface{}{"component": SDK_DOCKER_COMPONENT_NAME, "err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -132,9 +127,8 @@ func iOSInstall() error {
 
     if err = sdkInstall(SDK_IOS_COMPONENT_NAME); err != nil {
         whisk.Debug(whisk.DbgError, "sdkInstall(%s) failed: %s\n", SDK_IOS_COMPONENT_NAME, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("The {{.component}} SDK installation failed: {{.err}}",
-                map[string]interface{}{"component": SDK_IOS_COMPONENT_NAME, "err": err}))
+        errStr := wski18n.T("The {{.component}} SDK installation failed: {{.err}}",
+                map[string]interface{}{"component": SDK_IOS_COMPONENT_NAME, "err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -149,9 +143,8 @@ func sdkInstall(componentName string) error {
     targetFile := sdkMap[componentName].FileName
     if _, err := os.Stat(targetFile); err == nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' exists\n", targetFile)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
-                map[string]interface{}{"name": targetFile}))
+        errStr := wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
+                map[string]interface{}{"name": targetFile})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -159,18 +152,16 @@ func sdkInstall(componentName string) error {
     resp, err := client.Sdks.Install(sdkMap[componentName].UrlPath)
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Sdks.Install(%s) failed: %s\n", sdkMap[componentName].UrlPath, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to retrieve '{{.urlpath}}' SDK: {{.err}}",
-                map[string]interface{}{"urlpath": sdkMap[componentName].UrlPath, "err": err}))
+        errStr := wski18n.T("Unable to retrieve '{{.urlpath}}' SDK: {{.err}}",
+                map[string]interface{}{"urlpath": sdkMap[componentName].UrlPath, "err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
 
     if resp.Body == nil {
         whisk.Debug(whisk.DbgError, "SDK Install HTTP response has no body\n")
-        errStr := fmt.Sprintf(
-            wski18n.T("Server failed to send the '{{.component}}' SDK: {{.err}}",
-                map[string]interface{}{"name": componentName, "err": err}))
+        errStr := wski18n.T("Server failed to send the '{{.component}}' SDK: {{.err}}",
+                map[string]interface{}{"name": componentName, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_NETWORK, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -179,9 +170,8 @@ func sdkInstall(componentName string) error {
     sdkfile, err := os.Create(targetFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Create(%s) failure: %s\n", targetFile, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Error creating SDK file {{.name}}: {{.err}}",
-                map[string]interface{}{"name": targetFile, "err": err}))
+        errStr := wski18n.T("Error creating SDK file {{.name}}: {{.err}}",
+                map[string]interface{}{"name": targetFile, "err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -191,9 +181,8 @@ func sdkInstall(componentName string) error {
     _, err = io.Copy(sdkfile, resp.Body)
     if err != nil {
         whisk.Debug(whisk.DbgError, "io.Copy() of resp.Body into sdkfile failure: %s\n", err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Error copying server response into file: {{.err}}",
-                map[string]interface{}{"err": err}))
+        errStr := wski18n.T("Error copying server response into file: {{.err}}",
+                map[string]interface{}{"err": err})
         werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         sdkfile.Close()
         return werr
@@ -209,9 +198,8 @@ func sdkInstall(componentName string) error {
         targetdir := sdkMap[componentName].UnpackDir
         if _, err = os.Stat(targetdir); err == nil {
             whisk.Debug(whisk.DbgError, "os.Stat reports that directory '%s' exists\n", targetdir)
-            errStr := fmt.Sprintf(
-                wski18n.T("The directory {{.name}} already exists.  Delete it and retry.",
-                    map[string]interface{}{"name": targetdir}))
+            errStr := wski18n.T("The directory {{.name}} already exists.  Delete it and retry.",
+                    map[string]interface{}{"name": targetdir})
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -224,9 +212,8 @@ func sdkInstall(componentName string) error {
             err := unpackGzip(targetFile, "temp.tar")
             if err != nil {
                 whisk.Debug(whisk.DbgError, "unpackGzip(%s,temp.tar) failure: %s\n", targetFile, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Error unGzipping file {{.name}}: {{.err}}",
-                        map[string]interface{}{"name": targetFile, "err": err}))
+                errStr := wski18n.T("Error unGzipping file {{.name}}: {{.err}}",
+                    map[string]interface{}{"name": targetFile, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -236,9 +223,8 @@ func sdkInstall(componentName string) error {
             err = unpackTar("temp.tar")
             if err != nil {
                 whisk.Debug(whisk.DbgError, "unpackTar(temp.tar) failure: %s\n", err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Error untarring file {{.name}}: {{.err}}",
-                        map[string]interface{}{"name": "temp.tar", "err": err}))
+                errStr := wski18n.T("Error untarring file {{.name}}: {{.err}}",
+                        map[string]interface{}{"name": "temp.tar", "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }

--- a/tools/cli/go-whisk-cli/commands/trigger.go
+++ b/tools/cli/go-whisk-cli/commands/trigger.go
@@ -51,9 +51,8 @@ var triggerFireCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
@@ -72,9 +71,8 @@ var triggerFireCmd = &cobra.Command{
             parameters, err = getJSONFromStrings(flags.common.param, false)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, false) failed: %s\n", flags.common.param, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-                        map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+                errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+                        map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
@@ -84,9 +82,8 @@ var triggerFireCmd = &cobra.Command{
         trigResp, _, err := client.Triggers.Fire(qName.entityName, parameters)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Triggers.Fire(%s, %#v) failed: %s\n", qName.entityName, parameters, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to fire trigger '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": qName.entityName, "err": err}))
+            errStr := wski18n.T("Unable to fire trigger '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": qName.entityName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
@@ -122,9 +119,8 @@ var triggerCreateCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -139,17 +135,15 @@ var triggerCreateCmd = &cobra.Command{
             feedqName, err := parseQualifiedName(flags.common.feed)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", flags.common.feed, err)
-                errMsg := fmt.Sprintf(
-                    wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                        map[string]interface{}{"name": flags.common.feed, "err": err}))
+                errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                        map[string]interface{}{"name": flags.common.feed, "err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
             }
             if len(feedqName.namespace) == 0 {
                 whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", flags.common.feed)
-                errStr := fmt.Sprintf(
-                    wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
+                errStr := wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
@@ -170,9 +164,8 @@ var triggerCreateCmd = &cobra.Command{
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-                    map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+            errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+                    map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -187,9 +180,8 @@ var triggerCreateCmd = &cobra.Command{
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-                    map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
+            errStr := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+                    map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -206,9 +198,8 @@ var triggerCreateCmd = &cobra.Command{
         _, _, err = client.Triggers.Insert(trigger, false)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Triggers.Insert(%+v,false) failed: %s\n", trigger, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to create trigger '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": trigger.Name, "err": err}))
+            errStr := wski18n.T("Unable to create trigger '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": trigger.Name, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -219,9 +210,8 @@ var triggerCreateCmd = &cobra.Command{
             if err != nil {
                 whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", trigger.Name, flags.common.feed,
                     err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to create trigger '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": trigger.Name, "err": err}))
+                errStr := wski18n.T("Unable to create trigger '{{.name}}': {{.err}}",
+                        map[string]interface{}{"name": trigger.Name, "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
                 // Delete trigger that was created for this feed
@@ -257,9 +247,8 @@ var triggerUpdateCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
@@ -277,9 +266,8 @@ var triggerUpdateCmd = &cobra.Command{
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.param, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
-                    map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err}))
+            errStr := wski18n.T("Invalid parameter argument '{{.param}}': {{.err}}",
+                    map[string]interface{}{"param": fmt.Sprintf("%#v",flags.common.param), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -289,9 +277,8 @@ var triggerUpdateCmd = &cobra.Command{
 
         if err != nil {
             whisk.Debug(whisk.DbgError, "getJSONFromStrings(%#v, true) failed: %s\n", flags.common.annotation, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
-                    map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err}))
+            errStr := wski18n.T("Invalid annotation argument '{{.annotation}}': {{.err}}",
+                    map[string]interface{}{"annotation": fmt.Sprintf("%#v",flags.common.annotation), "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
             return werr
         }
@@ -305,9 +292,8 @@ var triggerUpdateCmd = &cobra.Command{
         retTrigger, _, err := client.Triggers.Insert(trigger, true)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Triggers.Insert(%+v,true) failed: %s\n", trigger, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to update trigger '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": trigger.Name, "err": err}))
+            errStr := wski18n.T("Unable to update trigger '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": trigger.Name, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -338,8 +324,7 @@ var triggerGetCmd = &cobra.Command{
             field = args[1]
 
             if !fieldExists(&whisk.Trigger{}, field) {
-                errMsg := fmt.Sprintf(
-                    wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field}))
+                errMsg := wski18n.T("Invalid field filter '{{.arg}}'.", map[string]interface{}{"arg": field})
                 whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -349,9 +334,8 @@ var triggerGetCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
@@ -363,9 +347,8 @@ var triggerGetCmd = &cobra.Command{
         retTrigger, _, err := client.Triggers.Get(qName.entityName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Triggers.Get(%s) failed: %s\n", qName.entityName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to get trigger '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": qName.entityName, "err": err}))
+            errStr := wski18n.T("Unable to get trigger '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": qName.entityName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -408,9 +391,8 @@ var triggerDeleteCmd = &cobra.Command{
         qName, err := parseQualifiedName(args[0])
         if err != nil {
             whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-            errMsg := fmt.Sprintf(
-                wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                    map[string]interface{}{"name": args[0], "err": err}))
+            errMsg := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                    map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
@@ -422,9 +404,8 @@ var triggerDeleteCmd = &cobra.Command{
         retTrigger, _, err = client.Triggers.Delete(qName.entityName)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Triggers.Delete(%s) failed: %s\n", qName.entityName, err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": qName.entityName, "err": err}))
+            errStr := wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": qName.entityName, "err": err})
             werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -443,9 +424,8 @@ var triggerDeleteCmd = &cobra.Command{
                 if err != nil {
                     whisk.Debug(whisk.DbgError, "configureFeed(%s, %s) failed: %s\n", qName.entityName, flags.common.feed,
                         err)
-                    errStr := fmt.Sprintf(
-                        wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
-                            map[string]interface{}{"name": qName.entityName, "err": err}))
+                    errStr := wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
+                            map[string]interface{}{"name": qName.entityName, "err": err})
                     werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
 
                     return werr
@@ -473,17 +453,15 @@ var triggerListCmd = &cobra.Command{
             qName, err = parseQualifiedName(args[0])
             if err != nil {
                 whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[0], err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
-                        map[string]interface{}{"name": args[0], "err": err}))
+                errStr := wski18n.T("'{{.name}}' is not a valid qualified name: {{.err}}",
+                        map[string]interface{}{"name": args[0], "err": err})
                 werr := whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
             ns := qName.namespace
             if len(ns) == 0 {
                 whisk.Debug(whisk.DbgError, "Namespace is missing from '%s'\n", args[0])
-                errStr := fmt.Sprintf(
-                    wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\""))
+                errStr := wski18n.T("No valid namespace detected. Run 'wsk property set --namespace' or ensure the name argument is preceded by a \"/\"")
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return werr
             }
@@ -518,9 +496,8 @@ func configureFeed(triggerName string, FullFeedName string) error {
     err := actionInvokeCmd.RunE(nil, feedArgs)
     if err != nil {
         whisk.Debug(whisk.DbgError, "Invoke of action '%s' failed: %s\n", FullFeedName, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to invoke trigger '{{.trigname}}' feed action '{{.feedname}}'; feed is not configured: {{.err}}",
-                map[string]interface{}{"trigname": triggerName, "feedname": FullFeedName, "err": err}))
+        errStr := wski18n.T("Unable to invoke trigger '{{.trigname}}' feed action '{{.feedname}}'; feed is not configured: {{.err}}",
+                map[string]interface{}{"trigname": triggerName, "feedname": FullFeedName, "err": err})
         err = whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     } else {
         whisk.Debug(whisk.DbgInfo, "Successfully configured trigger feed via feed action '%s'\n", FullFeedName)
@@ -534,9 +511,8 @@ func deleteTrigger(triggerName string) error {
     err := triggerDeleteCmd.RunE(nil, args)
     if err != nil {
         whisk.Debug(whisk.DbgError, "Trigger '%s' delete failed: %s\n", triggerName, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": triggerName, "err": err}))
+        errStr := wski18n.T("Unable to delete trigger '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": triggerName, "err": err})
         err = whisk.MakeWskErrorFromWskError(errors.New(errStr), err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
     }
 

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -82,7 +82,7 @@ func parseQualifiedName(name string) (QualifiedName, error) {
 
         if len(parts) < 2 || len(parts) > 4 {
             whisk.Debug(whisk.DbgError, "A valid qualified name was not detected\n")
-            errStr := fmt.Sprintf(wski18n.T("A valid qualified name must be specified."))
+            errStr := wski18n.T("A valid qualified name must be specified.")
             err := whisk.MakeWskError(errors.New(errStr), whisk.NOT_ALLOWED, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return qualifiedName, err
         }
@@ -90,7 +90,7 @@ func parseQualifiedName(name string) (QualifiedName, error) {
         for i := 1; i < len(parts); i++ {
             if len(parts[i]) == 0 || parts[i] == "." {
                 whisk.Debug(whisk.DbgError, "A valid qualified name was not detected\n")
-                errStr := fmt.Sprintf(wski18n.T("A valid qualified name must be specified."))
+                errStr := wski18n.T("A valid qualified name must be specified.")
                 err := whisk.MakeWskError(errors.New(errStr), whisk.NOT_ALLOWED, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return qualifiedName, err
             }
@@ -100,7 +100,7 @@ func parseQualifiedName(name string) (QualifiedName, error) {
     } else {
         if len(name) == 0 || name == "." {
             whisk.Debug(whisk.DbgError, "A valid qualified name was not detected\n")
-            errStr := fmt.Sprintf(wski18n.T("A valid qualified name must be specified."))
+            errStr := wski18n.T("A valid qualified name must be specified.")
             err := whisk.MakeWskError(errors.New(errStr), whisk.NOT_ALLOWED, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return qualifiedName, err
         }
@@ -572,9 +572,8 @@ func unpackGzip(inpath string, outpath string) error {
     // Make sure the target file does not exist
     if _, err := os.Stat(outpath); err == nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' exists\n", outpath)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
-                map[string]interface{}{"name": outpath}))
+        errStr := wski18n.T("The file {{.name}} already exists.  Delete it and retry.",
+            map[string]interface{}{"name": outpath})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -582,9 +581,7 @@ func unpackGzip(inpath string, outpath string) error {
     // Make sure the input file exists
     if _, err := os.Stat(inpath); err != nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' does not exist\n", inpath)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file '{{.name}}' does not exist.",
-                map[string]interface{}{"name": inpath}))
+        errStr := wski18n.T("The file '{{.name}}' does not exist.", map[string]interface{}{"name": inpath})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -592,9 +589,8 @@ func unpackGzip(inpath string, outpath string) error {
     unGzFile, err := os.Create(outpath)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", outpath, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Error creating unGzip file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": outpath, "err": err}))
+        errStr := wski18n.T("Error creating unGzip file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": outpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -603,9 +599,8 @@ func unpackGzip(inpath string, outpath string) error {
     gzFile, err := os.Open(inpath)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Open(%s) failed: %s\n", inpath, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Error opening Gzip file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": inpath, "err": err}))
+        errStr := wski18n.T("Error opening Gzip file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": inpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -614,9 +609,8 @@ func unpackGzip(inpath string, outpath string) error {
     gzReader, err := gzip.NewReader(gzFile)
     if err != nil {
         whisk.Debug(whisk.DbgError, "gzip.NewReader() failed: %s\n", err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": inpath, "err": err}))
+        errStr := wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": inpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -624,9 +618,8 @@ func unpackGzip(inpath string, outpath string) error {
     _, err = io.Copy(unGzFile, gzReader)
     if err != nil {
         whisk.Debug(whisk.DbgError, "io.Copy() failed: %s\n", err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": inpath, "err": err}))
+        errStr := wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": inpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -638,9 +631,7 @@ func unpackZip(inpath string) error {
     // Make sure the input file exists
     if _, err := os.Stat(inpath); err != nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' does not exist\n", inpath)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file '{{.name}}' does not exist.",
-                map[string]interface{}{"name": inpath}))
+        errStr := wski18n.T("The file '{{.name}}' does not exist.", map[string]interface{}{"name": inpath})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -648,9 +639,8 @@ func unpackZip(inpath string) error {
     zipFileReader, err := zip.OpenReader(inpath)
     if err != nil {
         whisk.Debug(whisk.DbgError, "zip.OpenReader(%s) failed: %s\n", inpath, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Unable to opens '{{.name}}' for unzipping: {{.err}}",
-                map[string]interface{}{"name": inpath, "err": err}))
+        errStr := wski18n.T("Unable to opens '{{.name}}' for unzipping: {{.err}}",
+            map[string]interface{}{"name": inpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -666,9 +656,8 @@ func unpackZip(inpath string) error {
         if itemType.IsDir() {
             if err := os.MkdirAll(item.Name, item.Mode()); err != nil {
                 whisk.Debug(whisk.DbgError, "os.MkdirAll(%s, %d) failed: %s\n", item.Name, item.Mode(), err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to create directory '{{.dir}}' while unzipping '{{.name}}': {{.err}}",
-                        map[string]interface{}{"dir": item.Name, "name": inpath, "err": err}))
+                errStr := wski18n.T("Unable to create directory '{{.dir}}' while unzipping '{{.name}}': {{.err}}",
+                        map[string]interface{}{"dir": item.Name, "name": inpath, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -679,26 +668,23 @@ func unpackZip(inpath string) error {
             defer unzipFile.Close()
             if err != nil {
                 whisk.Debug(whisk.DbgError, "'%s' Open() failed: %s\n", item.Name, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to open zipped file '{{.file}}' while unzipping '{{.name}}': {{.err}}",
-                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err}))
+                errStr := wski18n.T("Unable to open zipped file '{{.file}}' while unzipping '{{.name}}': {{.err}}",
+                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             targetFile, err := os.Create(itemName)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", itemName, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to create file '{{.file}}' while unzipping '{{.name}}': {{.err}}",
-                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err}))
+                errStr := wski18n.T("Unable to create file '{{.file}}' while unzipping '{{.name}}': {{.err}}",
+                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             if _, err := io.Copy(targetFile, unzipFile); err != nil {
                 whisk.Debug(whisk.DbgError, "io.Copy() of '%s' failed: %s\n", itemName, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": itemName, "err": err}))
+                errStr := wski18n.T("Unable to unzip file '{{.name}}': {{.err}}",
+                        map[string]interface{}{"name": itemName, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -713,9 +699,7 @@ func unpackTar(inpath string) error {
     // Make sure the input file exists
     if _, err := os.Stat(inpath); err != nil {
         whisk.Debug(whisk.DbgError, "os.Stat reports file '%s' does not exist\n", inpath)
-        errStr := fmt.Sprintf(
-            wski18n.T("The file '{{.name}}' does not exist.",
-                map[string]interface{}{"name": inpath}))
+        errStr := wski18n.T("The file '{{.name}}' does not exist.", map[string]interface{}{"name": inpath})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -723,9 +707,8 @@ func unpackTar(inpath string) error {
     tarFileReader, err := os.Open(inpath)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Open(%s) failed: %s\n", inpath, err)
-        errStr := fmt.Sprintf(
-            wski18n.T("Error opening tar file '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": inpath, "err": err}))
+        errStr := wski18n.T("Error opening tar file '{{.name}}': {{.err}}",
+            map[string]interface{}{"name": inpath, "err": err})
         werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
         return werr
     }
@@ -741,9 +724,8 @@ func unpackTar(inpath string) error {
         }
         if err != nil {
             whisk.Debug(whisk.DbgError, "tReader.Next() failed: %s\n", err)
-            errStr := fmt.Sprintf(
-                wski18n.T("Error reading tar file '{{.name}}': {{.err}}",
-                    map[string]interface{}{"name": inpath, "err": err}))
+            errStr := wski18n.T("Error reading tar file '{{.name}}': {{.err}}",
+                    map[string]interface{}{"name": inpath, "err": err})
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -753,9 +735,8 @@ func unpackTar(inpath string) error {
         case tar.TypeDir:
             if err := os.MkdirAll(item.Name, os.FileMode(item.Mode)); err != nil {
                 whisk.Debug(whisk.DbgError, "os.MkdirAll(%s, %d) failed: %s\n", item.Name, item.Mode, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to create directory '{{.dir}}' while untarring '{{.name}}': {{.err}}",
-                        map[string]interface{}{"dir": item.Name, "name": inpath, "err": err}))
+                errStr := wski18n.T("Unable to create directory '{{.dir}}' while untarring '{{.name}}': {{.err}}",
+                        map[string]interface{}{"dir": item.Name, "name": inpath, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
@@ -764,25 +745,22 @@ func unpackTar(inpath string) error {
             defer untarFile.Close()
             if err != nil {
                 whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", item.Name, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to create file '{{.file}}' while untarring '{{.name}}': {{.err}}",
-                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err}))
+                errStr := wski18n.T("Unable to create file '{{.file}}' while untarring '{{.name}}': {{.err}}",
+                        map[string]interface{}{"file": item.Name, "name": inpath, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
             if _, err := io.Copy(untarFile, tReader); err != nil {
                 whisk.Debug(whisk.DbgError, "io.Copy() of '%s' failed: %s\n", item.Name, err)
-                errStr := fmt.Sprintf(
-                    wski18n.T("Unable to untar file '{{.name}}': {{.err}}",
-                        map[string]interface{}{"name": item.Name, "err": err}))
+                errStr := wski18n.T("Unable to untar file '{{.name}}': {{.err}}",
+                        map[string]interface{}{"name": item.Name, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return werr
             }
         default:
             whisk.Debug(whisk.DbgError, "Unexpected tar file type of %q\n", item.Typeflag)
-            errStr := fmt.Sprintf(
-                wski18n.T("Unable to untar '{{.name}}' due to unexpected tar file type\n",
-                    map[string]interface{}{"name": item.Name}))
+            errStr := wski18n.T("Unable to untar '{{.name}}' due to unexpected tar file type\n",
+                    map[string]interface{}{"name": item.Name})
             werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return werr
         }
@@ -855,9 +833,8 @@ func readFile(filename string) (string, error) {
     _, err := os.Stat(filename)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.Stat(%s) error: %s\n", filename, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("File '{{.name}}' is not a valid file or it does not exist: {{.err}}",
-                map[string]interface{}{"name": filename, "err": err}))
+        errMsg := wski18n.T("File '{{.name}}' is not a valid file or it does not exist: {{.err}}",
+                map[string]interface{}{"name": filename, "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_USAGE,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
 
@@ -867,9 +844,8 @@ func readFile(filename string) (string, error) {
     file, err := ioutil.ReadFile(filename)
     if err != nil {
         whisk.Debug(whisk.DbgError, "os.ioutil.ReadFile(%s) error: %s\n", filename, err)
-        errMsg := fmt.Sprintf(
-            wski18n.T("Unable to read '{{.name}}': {{.err}}",
-                map[string]interface{}{"name": filename, "err": err}))
+        errMsg := wski18n.T("Unable to read '{{.name}}': {{.err}}",
+                map[string]interface{}{"name": filename, "err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
         return "", whiskErr
@@ -914,8 +890,7 @@ func parseShared(shared string) (bool, bool, error) {
         isSet = false
     } else {
         whisk.Debug(whisk.DbgError, "Cannot use value '%s' for shared.\n", shared)
-        errMsg := fmt.Sprintf(wski18n.T("Cannot use value '{{.arg}}' for shared.",
-                map[string]interface{}{"arg": shared}))
+        errMsg := wski18n.T("Cannot use value '{{.arg}}' for shared.", map[string]interface{}{"arg": shared})
         whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG,
             whisk.DISPLAY_USAGE)
         return false, false, whiskErr

--- a/tools/cli/go-whisk/whisk/wskerror.go
+++ b/tools/cli/go-whisk/whisk/wskerror.go
@@ -16,10 +16,6 @@
 
 package whisk
 
-import (
-)
-import "fmt"
-
 const EXITCODE_ERR_GENERAL      int = 1
 const EXITCODE_ERR_USAGE        int = 2
 const EXITCODE_ERR_NETWORK      int = 3
@@ -50,7 +46,7 @@ Parameters:
     err     - WskError object used to display an error message from
  */
 func (whiskError WskError) Error() string {
-    return fmt.Sprintf(whiskError.RootErr.Error())
+    return whiskError.RootErr.Error()
 }
 
 /*


### PR DESCRIPTION
- Remove unnecessary sprintf() calls that cause strings containing '%' characters to be malformed

Closes: https://github.com/openwhisk/openwhisk/issues/1396