### PR TITLE
Preserve File Permissions from Tar Files

### DIFF
--- a/tests/src/system/basic/WskSdkTests.scala
+++ b/tests/src/system/basic/WskSdkTests.scala
@@ -60,6 +60,9 @@ class WskSdkTests
             // confirm that the image is correct
             lines.get(1) shouldBe "FROM openwhisk/dockerskeleton"
 
+            val buildAndPushFile = new File(sdk, "buildAndPush.sh")
+            buildAndPushFile.canExecute() should be(true)
+
             // confirm there is no other divergence from the base dockerfile
             val originalDockerfile = WhiskProperties.getFileRelativeToWhiskHome("sdk/docker/Dockerfile")
             val originalLines = FileUtils.readLines(originalDockerfile)

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -741,7 +741,7 @@ func unpackTar(inpath string) error {
                 return werr
             }
         case tar.TypeReg:
-            untarFile, err := os.Create(item.Name)
+            untarFile, err:= os.OpenFile(item.Name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(item.Mode))
             defer untarFile.Close()
             if err != nil {
                 whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", item.Name, err)


### PR DESCRIPTION
- Ensure that file permissions are kept when untarring Docker SDK

Closes: https://github.com/openwhisk/openwhisk/issues/1129