### PR TITLE
Preparation for HA of the controller

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -23,6 +23,7 @@ defaultLimits:
 # port means outer port
 controller:
   port: 10001
+  instances: "{{ groups['controllers'] | length }}"
   blackboxFraction: 0.10
 
 consul:
@@ -51,6 +52,7 @@ invoker:
   coreshare: 2
   serializeDockerOp: true
   serializeDockerPull: true
+  instances: "{{ groups['invokers'] | length }}"
 
 nginx:
   version: 1.11

--- a/ansible/roles/controller/tasks/clean.yml
+++ b/ansible/roles/controller/tasks/clean.yml
@@ -3,13 +3,13 @@
 
 - name: remove controller
   docker_container:
-    name: controller
+    name: controller{{play_hosts.index(inventory_hostname)}}
     image: "{{ docker_registry }}{{ docker_image_prefix }}/controller:{{ docker_image_tag }}"
     state: absent
   ignore_errors: True
 
 - name: remove controller log directory
   file:
-    path: "{{ whisk_logs_dir }}/controller"
+    path: "{{ whisk_logs_dir }}/controller{{play_hosts.index(inventory_hostname)}}"
     state: absent
   become: true

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -7,21 +7,21 @@
 
 - name: ensure controller log directory is created with permissions
   file:
-    path: "{{ whisk_logs_dir }}/controller"
+    path: "{{ whisk_logs_dir }}/controller{{play_hosts.index(inventory_hostname)}}"
     state: directory
     mode: 0777
   become: true
 
 - name: (re)start controller
   docker_container:
-    name: controller
+    name: controller{{play_hosts.index(inventory_hostname)}}
     image: "{{ docker_registry }}{{ docker_image_prefix }}/controller:{{ docker_image_tag }}"
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"
-    hostname: controller
+    hostname: controller{{play_hosts.index(inventory_hostname)}}
     env:
-      "COMPONENT_NAME": "controller"
+      "COMPONENT_NAME": "controller{{play_hosts.index(inventory_hostname)}}"
       "CONSULSERVER_HOST": "{{ groups['consul_servers'] | first }}"
       "CONSUL_HOST_PORT4": "{{ consul.port.http }}"
       "PORT": 8080
@@ -33,13 +33,13 @@
       "SERVICE_CHECK_TIMEOUT": "2s"
       "SERVICE_CHECK_INTERVAL": "15s"
     volumes:
-      - "{{ whisk_logs_dir }}/controller:/logs"
+      - "{{ whisk_logs_dir }}/controller{{play_hosts.index(inventory_hostname)}}:/logs"
     ports:
-      - "{{ controller.port }}:8080"
+      - "{{ controller.port + play_hosts.index(inventory_hostname)}}:8080"
 
 - name: wait until the Controller in this host is up and running
   uri:
-    url: "http://{{ inventory_hostname }}:{{ controller.port }}/ping"
+    url: "http://{{ inventory_hostname }}:{{ controller.port + play_hosts.index(inventory_hostname)}}/ping"
   register: result
   until: result.status == 200
   retries: 12

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -36,6 +36,7 @@
       - "{{ whisk_logs_dir }}/controller{{play_hosts.index(inventory_hostname)}}:/logs"
     ports:
       - "{{ controller.port + play_hosts.index(inventory_hostname)}}:8080"
+    command: /bin/sh -c "/controller/bin/controller {{play_hosts.index(inventory_hostname)}} >> /logs/controller{{play_hosts.index(inventory_hostname)}}_logs.log 2>&1"
 
 - name: wait until the Controller in this host is up and running
   uri:

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -32,6 +32,7 @@
       "SERVICE_CHECK_HTTP": "/ping"
       "SERVICE_CHECK_TIMEOUT": "2s"
       "SERVICE_CHECK_INTERVAL": "15s"
+      "CONTROLLER_INSTANCES": "{{ controller.instances }}"
     volumes:
       - "{{ whisk_logs_dir }}/controller{{play_hosts.index(inventory_hostname)}}:/logs"
     ports:

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -39,6 +39,8 @@
         -e SERVICE_CHECK_HTTP=/ping
         -e SERVICE_CHECK_TIMEOUT=2s
         -e SERVICE_CHECK_INTERVAL=15s
+        -e CONTROLLER_INSTANCES={{ controller.instances }}
+        -e INVOKER_INSTANCES={{ invoker.instances }}
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs
         -v {{dockerInfo["json"]["DockerRootDir"]}}/containers/:/containers
         -p {{invoker.port + play_hosts.index(inventory_hostname)}}:8080

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -2,7 +2,7 @@
 
 events {
 {# default: 1024 #}
-    worker_connections  4096;  
+    worker_connections  4096;
 }
 
 http {
@@ -15,6 +15,13 @@ http {
         '$request $status $body_bytes_sent '
         '$http_referer $http_user_agent $upstream_addr';
     access_log /logs/nginx_access.log combined-upstream;
+
+    upstream controllers {
+      least_conn;
+{% for ip in groups['controllers'] %}
+        server {{ ip }}:{{ controller.port + groups['controllers'].index(ip)}};
+{% endfor %}
+    }
 
     server {
         listen 443 default ssl;
@@ -30,13 +37,13 @@ http {
         proxy_ssl_session_reuse off;
 
         location /docs {
-            proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+            proxy_pass http://controllers;
         }
         location /api-docs {
-            proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+            proxy_pass http://controllers;
         }
         location /api/v1 {
-            proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+            proxy_pass http://controllers;
             proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
         }
         location /blackbox-0.1.0.tar.gz {

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -128,13 +128,13 @@ protected case class TransactionMetadata(val id: Long, val start: Instant)
 
 object TransactionId {
     val unknown = TransactionId(0)
-    val testing = TransactionId(-1)         // Common id for for unit testing
-    val invoker = TransactionId(-100)       // Invoker startup/shutdown or GC activity
+    val testing = TransactionId(-1) // Common id for for unit testing
+    val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
     val invokerWarmup = TransactionId(-101) // Invoker warmup thread that makes stem-cell containers
-    val invokerNanny = TransactionId(-102)  // Invoker nanny thread
-    val dispatcher = TransactionId(-110)    // Kafka message dispatcher
-    val loadbalancer = TransactionId(-120)  // Loadbalancer thread
-    val controller = TransactionId(-130)    // Controller startup
+    val invokerNanny = TransactionId(-102) // Invoker nanny thread
+    val dispatcher = TransactionId(-110) // Kafka message dispatcher
+    val loadbalancer = TransactionId(-120) // Loadbalancer thread
+    val controller = TransactionId(-130) // Controller startup
 
     def apply(tid: BigDecimal): TransactionId = {
         Try {
@@ -159,9 +159,12 @@ object TransactionId {
  * A thread-safe transaction counter.
  */
 trait TransactionCounter {
+    val numberOfInstances: Int
+    val instance: Int
+
     def transid(): TransactionId = {
-        TransactionId(cnt.incrementAndGet())
+        TransactionId(cnt.addAndGet(numberOfInstances))
     }
 
-    private val cnt = new AtomicInteger(1)
+    private val cnt = new AtomicInteger(instance + numberOfInstances)
 }

--- a/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 import whisk.common.Logging
-import whisk.common.TransactionCounter
 import whisk.core.connector.MessageConsumer
 import org.apache.kafka.clients.consumer.CommitFailedException
 
@@ -44,8 +43,7 @@ class KafkaConsumerConnector(
     sessionTimeout: FiniteDuration = 30 seconds,
     autoCommitInterval: FiniteDuration = 10 seconds)
     extends MessageConsumer
-    with Logging
-    with TransactionCounter {
+    with Logging {
 
     /**
      * Long poll for messages. Method returns once message are available but no later than given

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -75,10 +75,12 @@ class WhiskConfig(
     val invokerCoreShare = this(WhiskConfig.invokerCoreShare)
     val invokerSerializeDockerOp = this(WhiskConfig.invokerSerializeDockerOp)
     val invokerSerializeDockerPull = this(WhiskConfig.invokerSerializeDockerPull)
+    val invokerInstances = this(WhiskConfig.invokerInstances)
 
     val wskApiHost = this(WhiskConfig.wskApiHost)
     val controllerHost = this(WhiskConfig.controllerHostName) + ":" + this(WhiskConfig.controllerHostPort)
     val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
+    val controllerInstances = this(WhiskConfig.controllerInstances)
 
     val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
     val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
@@ -230,6 +232,7 @@ object WhiskConfig extends Logging {
     val invokerCoreShare = "invoker.coreshare"
     val invokerSerializeDockerOp = "invoker.serializeDockerOp"
     val invokerSerializeDockerPull = "invoker.serializeDockerPull"
+    val invokerInstances = "invoker.instances"
 
     val wskApiHost = "whisk.api.host"
 
@@ -240,6 +243,7 @@ object WhiskConfig extends Logging {
     private val controllerHostName = "controller.host"
     private val controllerHostPort = "controller.host.port"
     private val controllerBlackboxFraction = "controller.blackboxFraction"
+    val controllerInstances = "controller.instances"
 
     val kafkaHostName = "kafka.host"
     val loadbalancerHostName = "loadbalancer.host"

--- a/common/scala/src/main/scala/whisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicRasService.scala
@@ -49,22 +49,22 @@ trait BasicRasService extends BasicHttpService {
  */
 object BasicRasService {
 
-    def startService(system: ActorSystem, name: String, interface: String, port: Integer) = {
-        BasicHttpService.startService(system, name, interface, port, new ServiceBuilder)
+    def startService(system: ActorSystem, name: String, interface: String, port: Integer, instance: Int, numberOfInstances: Int) = {
+        BasicHttpService.startService(system, name, interface, port, new ServiceBuilder(instance, numberOfInstances))
     }
 
     /**
      * In spray, we send messages to an Akka Actor. A RasService represents an Actor
      * which extends the BasicRasService trait.
      */
-    private class RasService extends BasicRasService with Actor {
+    private class RasService(override val instance: Int, override val numberOfInstances: Int) extends BasicRasService with Actor {
         override def actorRefFactory = context
     }
 
     /**
      * Akka-style factory for RasService.
      */
-    private class ServiceBuilder extends Creator[RasService] {
-        def create = new RasService
+    private class ServiceBuilder(instance: Int, numberOfInstances: Int) extends Creator[RasService] {
+        def create = new RasService(instance, numberOfInstances)
     }
 }

--- a/core/controller/Dockerfile
+++ b/core/controller/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install swagger-ui
 RUN wget --no-verbose https://github.com/swagger-api/swagger-ui/archive/v2.1.4.tar.gz && \
     mkdir swagger-ui && \
-    tar zxf v2.1.4.tar.gz -C /swagger-ui --strip-components=2 swagger-ui-2.1.4/dist && \ 
+    tar zxf v2.1.4.tar.gz -C /swagger-ui --strip-components=2 swagger-ui-2.1.4/dist && \
     rm v2.1.4.tar.gz && \
     perl -pi -w -e  's{http://petstore.swagger.io/v2/swagger.json}{/api/v1/api-docs}g;' /swagger-ui/index.html
 
@@ -13,6 +13,5 @@ RUN wget --no-verbose https://github.com/swagger-api/swagger-ui/archive/v2.1.4.t
 # Copy app jars
 COPY build/distributions/controller.tar ./
 RUN tar xf controller.tar
-CMD controller/bin/controller >> /logs/${COMPONENT_NAME}_logs.log 2>&1
 
 EXPOSE 8080

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -61,7 +61,7 @@ object WhiskServices {
      * @param config the configuration with loadbalancerHost defined
      * @return a load balancer component
      */
-    def makeLoadBalancerComponent(config: WhiskConfig)(implicit as: ActorSystem) = new LoadBalancerService(config, InfoLevel)
+    def makeLoadBalancerComponent(config: WhiskConfig, instance: Int)(implicit as: ActorSystem) = new LoadBalancerService(config, InfoLevel, instance)
 
 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -107,7 +107,7 @@ object Controller {
 
         // if deploying multiple instances (scale out), must pass the instance number as the
         // second argument.  (TODO .. seems fragile)
-        val instance = if (args.length > 0) args(1).toInt else 0
+        val instance = if (args.length > 0) args(0).toInt else 0
 
         if (config.isValid) {
             val port = config.servicePort.toInt

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -48,10 +48,12 @@ import whisk.core.entitlement.EntitlementProvider
  */
 class Controller(
     config: WhiskConfig,
-    instance: Int,
+    override val instance: Int,
     loglevel: LogLevel)
     extends BasicRasService
     with Actor {
+
+    override val numberOfInstances = config.controllerInstances.toInt
 
     // each akka Actor has an implicit context
     override def actorRefFactory: ActorContext = context
@@ -72,7 +74,7 @@ class Controller(
     }
 
     setVerbosity(loglevel)
-    info(this, s"starting controller instance ${instance}")
+    info(this, s"starting controller instance ${instance} of ${config.controllerInstances}")
 
     /** The REST APIs. */
     private val apiv1 = new RestAPIVersion_v1(config, loglevel, instance, context.system)
@@ -88,6 +90,7 @@ object Controller {
     // a value, and whose values are default values.   A null value in the Map means there is
     // no default value specified, so it must appear in the properties file
     def requiredProperties = Map(WhiskConfig.servicePort -> 8080.toString) ++
+        Map(WhiskConfig.controllerInstances -> 1.toString) ++
         RestAPIVersion_v1.requiredProperties ++
         LoadBalancerService.requiredProperties ++
         EntitlementProvider.requiredProperties

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -75,7 +75,7 @@ class Controller(
     info(this, s"starting controller instance ${instance}")
 
     /** The REST APIs. */
-    private val apiv1 = new RestAPIVersion_v1(config, loglevel, context.system)
+    private val apiv1 = new RestAPIVersion_v1(config, loglevel, instance, context.system)
 
 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -111,6 +111,7 @@ protected[controller] trait RespondWithHeaders extends Directives {
 protected[controller] class RestAPIVersion_v1(
     config: WhiskConfig,
     verbosity: LogLevel,
+    instance: Int,
     implicit val actorSystem: ActorSystem)
     extends RestAPIVersion("v1", config(whiskVersionDate), config(whiskVersionBuildno))
     with Authenticate
@@ -160,7 +161,7 @@ protected[controller] class RestAPIVersion_v1(
 
     // initialize backend services
     protected implicit val consulServer = WhiskServices.consulServer(config)
-    protected implicit val loadBalancer = WhiskServices.makeLoadBalancerComponent(config)
+    protected implicit val loadBalancer = WhiskServices.makeLoadBalancerComponent(config, instance)
     protected implicit val iamProvider = WhiskServices.iamProvider(config)
     protected implicit val entitlementService = WhiskServices.entitlementService(config, loadBalancer, iamProvider)
     protected implicit val activationId = new ActivationIdGenerator {}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -74,7 +74,8 @@ trait LoadBalancer {
 
 class LoadBalancerService(
     config: WhiskConfig,
-    verbosity: LogLevel)(
+    verbosity: LogLevel,
+    instance: Int)(
         implicit val actorSystem: ActorSystem)
     extends LoadBalancer with Logging {
 
@@ -167,7 +168,7 @@ class LoadBalancerService(
                 LoadBalancerKeys.activationCountKey -> producer.sentCount().toJson)
         })
 
-    private val consumer = new KafkaConsumerConnector(config.kafkaHost, "completions", "completed")
+    private val consumer = new KafkaConsumerConnector(config.kafkaHost, "completions", s"completed$instance")
     consumer.setVerbosity(verbosity)
     consumer.onMessage((topic, partition, offset, bytes) => {
         val raw = new String(bytes, "utf-8")

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -226,7 +226,7 @@ class Invoker(
             val boundParams = action.parameters.toJsObject
             val params = JsObject(boundParams.fields ++ payload.fields)
             val timeout = action.limits.timeout.duration
-            con.run(msg, params,  timeout)
+            con.run(msg, params, timeout)
         }
 
         initResultOpt match {
@@ -259,7 +259,7 @@ class Invoker(
         val activationResult = makeWhiskActivation(msg, EntityPath(action.fullyQualifiedName(false).toString), action.version, activationResponse, activationInterval, Some(action.limits))
         val completeMsg = CompletionMessage(transid, activationResult)
 
-        producer.send("completed", completeMsg) map { status =>
+        producer.send("completed0", completeMsg) map { status =>
             info(this, s"posted completion of activation ${msg.activationId}")
         }
 

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -55,6 +55,9 @@ protected trait ControllerTestCommon
     with HttpService
     with Logging {
 
+    override val instance = 0
+    override val numberOfInstances = 1
+
     override val actorRefFactory = null
     implicit val routeTestTimeout = RouteTestTimeout(90 seconds)
 
@@ -192,8 +195,7 @@ class DegenerateLoadBalancerService(config: WhiskConfig, verbosity: LogLevel)
 
     override def getActiveUserActivationCounts: Map[String, Long] = Map()
 
-    override def publish(action: WhiskAction, msg: ActivationMessage, timeout: FiniteDuration)
-                        (implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
+    override def publish(action: WhiskAction, msg: ActivationMessage, timeout: FiniteDuration)(implicit transid: TransactionId): (Future[Unit], Future[WhiskActivation]) =
         (Future.successful {},
             whiskActivationStub map {
                 activation => Future.successful(activation)

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -54,6 +54,9 @@ import whisk.core.entity.types.EntityStore
  * names in tests, and defer all cleanup to the end of a test suite.
  */
 trait DbUtils extends TransactionCounter {
+    override val numberOfInstances = 1
+    override val instance = 0
+
     implicit val dbOpTimeout = 15 seconds
     val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()
     case class RetryOp() extends Throwable

--- a/tests/src/whisk/core/entity/test/ConformanceTests.scala
+++ b/tests/src/whisk/core/entity/test/ConformanceTests.scala
@@ -46,6 +46,9 @@ class ConformanceTests extends FlatSpec
     with TransactionCounter
     with WskActorSystem {
 
+    override val numberOfInstances = 1
+    override val instance = 0
+
     implicit val defaultPatience =
         PatienceConfig(timeout = Span(1, Minutes), interval = Span(1, Seconds))
 

--- a/tools/build/checkLogs.py
+++ b/tools/build/checkLogs.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         ("db-rules.log", [ partial(database_has_at_most_x_entries, 0) ]),
         ("db-triggers.log", [ partial(database_has_at_most_x_entries, 0) ]),
         # Assert that stdout of the container is correctly piped and empty
-        ("controller.log", [ partial(file_has_at_most_x_bytes, 0) ]),
+        ("controller0.log", [ partial(file_has_at_most_x_bytes, 0) ]),
         ("invoker0.log", [ partial(file_has_at_most_x_bytes, 0) ])
     ]
 


### PR DESCRIPTION
This PR is to prepare HA for the controller. The goal is not to make the controller able to be HA.

This PR treats only:
- controller-container has an index
- the port for each controller is unique
- active ack will be sent to the right controller
- Tids, generated by controller will be unique (All tids of controllerX are `tid % numberOfInvokers = x`
- Edit nginx.conf to loadbalance between controllers (if more than one controller is deployed)