### PR TITLE
allow parameters on actions to be treated as final

### DIFF
--- a/ansible/roles/routemgmt/files/installRouteMgmt.sh
+++ b/ansible/roles/routemgmt/files/installRouteMgmt.sh
@@ -60,23 +60,29 @@ $WSK_CLI -i --apihost "$APIHOST" package update --auth "$AUTH"  --shared no "$NA
 
 echo Installing routemgmt actions
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/createRoute" "$OPENWHISK_HOME/core/routemgmt/createRoute.js" \
--a description 'Create an API route'
+-a description 'Create an API route' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/createApi" "$OPENWHISK_HOME/core/routemgmt/createApi.js" \
--a description 'Create an API configuration'
+-a description 'Create an API configuration' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/deleteApi" "$OPENWHISK_HOME/core/routemgmt/deleteApi.js" \
--a description 'Delete the specified API configuration'
+-a description 'Delete the specified API configuration' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/getApi" "$OPENWHISK_HOME/core/routemgmt/getApi.js" \
--a description 'Retrieve the specified API configuration (in JSON format)'
+-a description 'Retrieve the specified API configuration (in JSON format)' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/activateApi" "$OPENWHISK_HOME/core/routemgmt/activateApi.js" \
--a description 'Activate the specified API'
+-a description 'Activate the specified API' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/deactivateApi" "$OPENWHISK_HOME/core/routemgmt/deactivateApi.js" \
--a description 'Deactivate the specified API'
+-a description 'Deactivate the specified API' \
+-a final true
 
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" "$NAMESPACE/routemgmt/syncApi" "$OPENWHISK_HOME/core/routemgmt/syncApi.js" \
--a description 'Synchronize the API configuration with the API gateway'
-
+-a description 'Synchronize the API configuration with the API gateway' \
+-a final true

--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -53,11 +53,11 @@ protected[core] class Parameters protected[entity] (
             name.size + value.size
     }.foldLeft(0 B)(_ + _)
 
-    protected[entity] def ++(p: (ParameterName, ParameterValue)) = {
+    protected[entity] def +(p: (ParameterName, ParameterValue)) = {
         Option(p) map { p => new Parameters(params + (p._1 -> p._2)) } getOrElse this
     }
 
-    protected[entity] def ++(p: ParameterName, v: ParameterValue) = {
+    protected[entity] def +(p: ParameterName, v: ParameterValue) = {
         new Parameters(params + (p -> v))
     }
 
@@ -65,14 +65,18 @@ protected[core] class Parameters protected[entity] (
     protected[core] def ++(p: Parameters) = new Parameters(params ++ p.params)
 
     /** Remove parameter by name. */
-    protected[core] def --(p: String) = {
-        Try { new ParameterName(p) } map {
-            param => new Parameters(params - param)
-        } getOrElse this
+    protected[core] def -(p: String) = {
+        // wrap with try since parameter name may throw an exception for illegal p
+        Try(new Parameters(params - new ParameterName(p))) getOrElse this
     }
 
-    protected[core] def toJsArray = JsArray(params map { p => JsObject("key" -> p._1().toJson, "value" -> p._2().toJson) } toSeq: _*)
-    protected[core] def toJsObject = JsObject(params map { p => (p._1() -> p._2().toJson) })
+    /** Gets list of immutable parameters (those with a value defined). */
+    protected[core] def immutableParameters: Set[String] = {
+        params.keySet filter (params(_).isDefined) map (_.name)
+    }
+
+    protected[core] def toJsArray = JsArray(params map { p => JsObject("key" -> p._1.name.toJson, "value" -> p._2.value.toJson) } toSeq: _*)
+    protected[core] def toJsObject = JsObject(params map { p => (p._1.name -> p._2.value.toJson) })
     override def toString = toJsArray.compactPrint
 
     /**
@@ -87,7 +91,7 @@ protected[core] class Parameters protected[entity] (
     /**
      * Retrieves parameter by name if it exists.
      */
-    protected[core] def apply(p: String) = Try { params(new ParameterName(p)) } map { _() } toOption
+    protected[core] def apply(p: String) = Try(params(new ParameterName(p)).value) toOption
 }
 
 /**
@@ -101,8 +105,6 @@ protected[core] class Parameters protected[entity] (
  * @param name the name of the parameter (its key)
  */
 protected[entity] class ParameterName protected[entity] (val name: String) extends AnyVal {
-    protected[entity] def apply() = name
-
     /**
      * The size of the ParameterName entity as ByteSize.
      */
@@ -121,8 +123,12 @@ protected[entity] class ParameterName protected[entity] (val name: String) exten
  *
  * @param value the value of the parameter, may be null
  */
-protected[entity] class ParameterValue protected[entity] (private val value: JsValue) extends AnyVal {
-    protected[core] def apply() = Option(value) getOrElse JsNull
+protected[entity] class ParameterValue protected[entity] (private val v: JsValue) extends AnyVal {
+    /** @return JsValue if defined else JsNull. */
+    protected[entity] def value = Option(v) getOrElse JsNull
+
+    /** @return true iff value is not JsNull. */
+    protected[entity] def isDefined = value != JsNull
 
     /**
      * The size of the ParameterValue entity as ByteSize.
@@ -150,10 +156,9 @@ protected[core] object Parameters extends ArgNormalizer[Parameters] {
     @throws[IllegalArgumentException]
     protected[core] def apply(p: String, v: String): Parameters = {
         require(p != null && p.trim.nonEmpty, "key undefined")
-        Parameters() ++ {
-            (new ParameterName(ArgNormalizer.trim(p)),
-                new ParameterValue(Option(v) map { _.trim.toJson } getOrElse JsNull))
-        }
+        Parameters() + (
+            new ParameterName(ArgNormalizer.trim(p)),
+            new ParameterValue(Option(v) map { _.trim.toJson } getOrElse JsNull))
     }
 
     /**
@@ -167,10 +172,9 @@ protected[core] object Parameters extends ArgNormalizer[Parameters] {
     @throws[IllegalArgumentException]
     protected[core] def apply(p: String, v: JsValue): Parameters = {
         require(p != null && p.trim.nonEmpty, "key undefined")
-        Parameters() ++ {
-            (new ParameterName(ArgNormalizer.trim(p)),
-                new ParameterValue(Option(v) getOrElse JsNull))
-        }
+        Parameters() + (
+            new ParameterName(ArgNormalizer.trim(p)),
+            new ParameterValue(Option(v) getOrElse JsNull))
     }
 
     override protected[core] implicit val serdes = new RootJsonFormat[Parameters] {

--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -91,7 +91,7 @@ protected[core] class Parameters protected[entity] (
     /**
      * Retrieves parameter by name if it exists.
      */
-    protected[core] def apply(p: String) = Try(params(new ParameterName(p)).value) toOption
+    protected[core] def get(p: String) = params.get(new ParameterName(p)).map(_.value)
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -109,7 +109,7 @@ case class WhiskAction(
     require(exec != null, "exec undefined")
     require(limits != null, "limits undefined")
 
-    /** @return true iIf action has appropriate annotation. */
+    /** @return true iff action has appropriate annotation. */
     def hasFinalParamsAnnotation = {
         annotations(WhiskAction.finalParamsAnnotationName) map {
             case JsBoolean(b) => b
@@ -187,6 +187,7 @@ case class WhiskAction(
             case _ => this
         }
     }
+
     def toJson = WhiskAction.serdes.write(this).asJsObject
 }
 
@@ -338,7 +339,6 @@ object WhiskAction
             }
         }
     }
-
 }
 
 object ActionLimitsOption extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -111,7 +111,7 @@ case class WhiskAction(
 
     /** @return true iff action has appropriate annotation. */
     def hasFinalParamsAnnotation = {
-        annotations(WhiskAction.finalParamsAnnotationName) map {
+        annotations.get(WhiskAction.finalParamsAnnotationName) map {
             case JsBoolean(b) => b
             case _            => false
         } getOrElse false

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -109,6 +109,14 @@ case class WhiskAction(
     require(exec != null, "exec undefined")
     require(limits != null, "limits undefined")
 
+    /** @return true iIf action has appropriate annotation. */
+    def hasFinalParamsAnnotation = {
+        annotations(WhiskAction.finalParamsAnnotationName) map {
+            case JsBoolean(b) => b
+            case _            => false
+        } getOrElse false
+    }
+
     /**
      * Merges parameters (usually from package) with existing action parameters.
      * Existing parameters supersede those in p.
@@ -188,7 +196,10 @@ object WhiskAction
     with DefaultJsonProtocol {
 
     val execFieldName = "exec"
+    val finalParamsAnnotationName = "final"
+
     override val collectionName = "actions"
+
     override implicit val serdes = jsonFormat8(WhiskAction.apply)
 
     def containerImageName(exec: Exec, registry: String, prefix: String, tag: String): String = {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -130,7 +130,7 @@ case class WhiskPackage(
     def withPackageActions(actions: List[WhiskPackageAction] = List()): WhiskPackageWithActions = {
         val actionGroups = actions map { a =>
             //  group into "actions" and "feeds"
-            val feed = a.annotations(Parameters.Feed) map { _ => true } getOrElse false
+            val feed = a.annotations.get(Parameters.Feed) map { _ => true } getOrElse false
             (feed, a)
         } groupBy { _._1 } mapValues { _.map(_._2) }
         WhiskPackageWithActions(this, actionGroups.getOrElse(false, List()), actionGroups.getOrElse(true, List()))

--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -221,12 +221,12 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
             }
 
             if (pkg.binding.isEmpty) {
-                pkg.annotations("meta") filter {
+                pkg.annotations.get("meta") filter {
                     // does package have annotation: meta == true
                     _ match { case JsBoolean(b) => b case _ => false }
                 } flatMap {
                     // if so, find action name for http verb
-                    _ => pkg.annotations(method.name.toLowerCase)
+                    _ => pkg.annotations.get(method.name.toLowerCase)
                 } match {
                     // if action name is defined as a string, accept it, else fail request
                     case Some(JsString(actionName)) =>

--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -68,6 +68,44 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
         }
     }
 
+    /**
+     * Adds route to handle /experimental/package-name to allow a proxy activation of actions
+     * contained in package. A meta package must exist in a predefined system namespace.
+     * Such packages are self-encoding as "meta" API handlers via an annotation on the package
+     * (i.e., annotation "meta" -> true) and an explicit mapping from HTTP verbs to action names
+     * to invoke in response to incoming requests. Package bindings are not allowed.
+     *
+     * The subject making the activation request is subject to entitlement checks for activations
+     * (this is tantamount to limiting API requests from a single user) invoking actions directly.
+     *
+     * A sample meta-package looks like this:
+     * WhiskPackage(
+     *      EntityPath(systemId),
+     *      EntityName("meta-example"),
+     *      annotations =
+     *          Parameters("meta", JsBoolean(true)) ++
+     *          Parameters("get", JsString("action to run on get")) ++
+     *          Parameters("post", JsString("action to run on post")) ++
+     *          Parameters("delete", JsString("action to run on delete")))
+     *
+     * In addition, it is a good idea to mark actions in a meta package as final to prevent
+     * invoke-time parameters from overriding parameters.
+     *
+     * A sample final action looks like this:
+     * WhiskAction(
+     *      EntityPath("systemId/meta-example"),
+     *      EntityName("action to run on get"),
+     *      annotations =
+     *          Parameters("final", JsBoolean(true)))
+     *
+     * The meta API requests are handled by matching the first segment to a package name in the system
+     * namespace. If it exists and it is a valid meta package, the HTTP verb from the request is mapped
+     * to a corresponding action and that action is invoked. The action receives as arguments additional
+     * context meta data (the verb, the remaining unmatched URI path, and the namespace of the subject
+     * making the request). Query parameters and body parameters are passed to the action with the order
+     * of precedence being:
+     * package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path).
+     */
     def routes(user: Identity)(implicit transid: TransactionId) = {
         (routePrefix & pathPrefix(EntityName.REGEX.r) & allowedOperations) { s =>
             val metaPackage = resolvePackageName(EntityName(s))
@@ -105,15 +143,23 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
             }
         }
 
-        def activate(action: WhiskAction) = {
+        def activate(action: WhiskAction): Future[(ActivationId, Option[WhiskActivation])] = {
             // precedence order for parameters:
             // package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path)
-            systemKey flatMap {
-                val content = requestParams ++ Map(
-                    "__ow_meta_verb" -> method.value.toLowerCase.toJson,
-                    "__ow_meta_path" -> restofPath.toJson,
-                    "__ow_meta_namespace" -> user.namespace.toJson)
-                invokeAction(_, action, Some(JsObject(content)), blocking = true, waitOverride = true)
+            systemKey flatMap { identity =>
+                val invokeParams = if (action.hasFinalParamsAnnotation) {
+                    requestParams -- action.parameters.immutableParameters
+                } else requestParams // in the absence of immutable annotations, return the request untouched
+
+                if (invokeParams.size == requestParams.size) {
+                    val content = invokeParams ++ Map(
+                        "__ow_meta_verb" -> method.value.toLowerCase.toJson,
+                        "__ow_meta_path" -> restofPath.toJson,
+                        "__ow_meta_namespace" -> user.namespace.toJson)
+                    invokeAction(identity, action, Some(JsObject(content)), blocking = true, waitOverride = true)
+                } else {
+                    Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
+                }
             }
         }
 
@@ -151,7 +197,7 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
     }
 
     /**
-     * Meta API handlers must be in packages and have a "meta -> true" annotation
+     * Meta API handlers must be in packages (not bindings) and have a "meta -> true" annotation
      * in addition to a mapping from http verbs to action names; fetch package to
      * ensure it exists, if it doesn't reject the request as not allowed.
      * if package exists, check that it satisfies invariants on annotations.
@@ -170,22 +216,29 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
                 Future.failed(RejectRequest(MethodNotAllowed))
         } flatMap { pkg =>
             // expecting the meta handlers to be private; should it be an error? warn for now
-            if (pkg.publish) warn(this, s"'${pkg.fullyQualifiedName(true)}' is public")
+            if (pkg.publish) {
+                warn(this, s"'${pkg.fullyQualifiedName(true)}' is public")
+            }
 
-            pkg.annotations("meta") filter {
-                // does package have annotatation: meta == true
-                _ match { case JsBoolean(b) => b case _ => false }
-            } flatMap {
-                // if so, find action name for http verb
-                _ => pkg.annotations(method.name.toLowerCase)
-            } match {
-                // if action name is defined as a string, accept it, else fail request
-                case Some(JsString(actionName)) =>
-                    info(this, s"'${pkg.name}' maps '${method.name}' to action '${actionName}'")
-                    Future.successful(EntityName(actionName), pkg.parameters)
-                case _ =>
-                    info(this, s"'${pkg.name}' is missing 'meta' annotation or action name for '${method.name.toLowerCase}'")
-                    Future.failed(RejectRequest(MethodNotAllowed))
+            if (pkg.binding.isEmpty) {
+                pkg.annotations("meta") filter {
+                    // does package have annotation: meta == true
+                    _ match { case JsBoolean(b) => b case _ => false }
+                } flatMap {
+                    // if so, find action name for http verb
+                    _ => pkg.annotations(method.name.toLowerCase)
+                } match {
+                    // if action name is defined as a string, accept it, else fail request
+                    case Some(JsString(actionName)) =>
+                        info(this, s"'${pkg.name}' maps '${method.name}' to action '${actionName}'")
+                        Future.successful(EntityName(actionName), pkg.parameters)
+                    case _ =>
+                        info(this, s"'${pkg.name}' is missing 'meta' annotation or action name for '${method.name.toLowerCase}'")
+                        Future.failed(RejectRequest(MethodNotAllowed))
+                }
+            } else {
+                warn(this, s"'${pkg.fullyQualifiedName(true)}' is a binding")
+                Future.failed(RejectRequest(MethodNotAllowed))
             }
         }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -220,7 +220,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
                 content.publish getOrElse false,
                 // remove any binding annotation from PUT (always set by the controller)
                 (content.annotations getOrElse Parameters())
-                    -- WhiskPackage.bindingFieldName
+                    - WhiskPackage.bindingFieldName
                     ++ bindingAnnotation(content.binding))
         }
     }
@@ -247,7 +247,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
                 content.publish getOrElse wp.publish,
                 // override any binding annotation from PUT (always set by the controller)
                 (content.annotations getOrElse wp.annotations)
-                    -- WhiskPackage.bindingFieldName
+                    - WhiskPackage.bindingFieldName
                     ++ bindingAnnotation(content.binding orElse wp.binding)).
                 revision[WhiskPackage](wp.docinfo.rev)
         }

--- a/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Triggers.scala
@@ -290,7 +290,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
             revision[WhiskTrigger](trigger.docinfo.rev)
 
         // feed must be specified in create, and cannot be added as a trigger update
-        content.annotations flatMap { _(Parameters.Feed) } map { _ =>
+        content.annotations flatMap { _.get(Parameters.Feed) } map { _ =>
             Future failed {
                 RejectRequest(BadRequest, "A trigger feed is only permitted when the trigger is created")
             }
@@ -313,7 +313,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
      * or updated.
      */
     private def validateTriggerFeed(trigger: WhiskTrigger)(implicit transid: TransactionId) = {
-        trigger.annotations(Parameters.Feed) map {
+        trigger.annotations.get(Parameters.Feed) map {
             case JsString(f) if (EntityPath.validate(f)) =>
                 Future successful trigger
             case _ => Future failed {

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -219,7 +219,7 @@ protected[actions] trait SequenceActions extends Logging {
         // compute max memory
         val maxMemory = Try {
             val memoryLimits = wskActivations map { activation =>
-                val limits = ActionLimits.serdes.read(activation.annotations("limits").get)
+                val limits = ActionLimits.serdes.read(activation.annotations.get("limits").get)
                 limits.memory.megabytes
             }
             memoryLimits.max.MB

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -23,6 +23,7 @@ import java.time.Instant
 import scala.concurrent.Future
 
 import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
 
 import akka.event.Logging.InfoLevel
@@ -34,9 +35,8 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
 import whisk.core.controller.WhiskMetaApi
-import whisk.core.entity._
 import whisk.core.database.NoDocumentException
-import org.scalatest.BeforeAndAfterEach
+import whisk.core.entity._
 import whisk.http.ErrorResponse
 import whisk.http.Messages
 
@@ -101,11 +101,15 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
             EntityName("publicmeta"),
             publish = true,
             annotations = Parameters("meta", JsBoolean(true)) ++
-                Parameters("get", JsString("getApi"))))
+                Parameters("get", JsString("getApi"))),
+        WhiskPackage(
+            EntityPath(systemId),
+            EntityName("bindingmeta"),
+            Some(Binding(EntityName(systemId), EntityName("heavymeta"))),
+            annotations = Parameters("meta", JsBoolean(true))))
 
     override protected[controller] def invokeAction(user: Identity, action: WhiskAction, payload: Option[JsObject], blocking: Boolean, waitOverride: Boolean = false)(
         implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
-
         if (failActivation == 0) {
             // construct a result stub that includes:
             // 1. the package name for the action (to confirm that this resolved to systemId)
@@ -127,7 +131,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
 
             // check that action parameters were merged with package
             // all actions have default parameters (see actionLookup stub)
-            pkgLookup(resolvePackageName(action.namespace.last)) map { pkg =>
+            pkgLookup(resolvePackageName(action.namespace.last)) foreach { pkg =>
                 action.parameters shouldBe (pkg.parameters ++ defaultActionParameters)
                 action.parameters("z") shouldBe defaultActionParameters("z")
             }
@@ -151,13 +155,16 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         }
     }
 
-    val defaultActionParameters = Parameters("y", JsString("Y")) ++ Parameters("z", JsString("Z"))
+    val defaultActionParameters = {
+        Parameters("y", JsString("Y")) ++ Parameters("z", JsString("Z"))
+    }
 
     override protected def actionLookup(pkgName: FullyQualifiedEntityName, actionName: EntityName)(
         implicit transid: TransactionId) = {
         if (!failActionLookup) {
             Future.successful {
-                WhiskAction(pkgName.fullPath, actionName, Exec.js("??"), defaultActionParameters)
+                val annotations = Parameters(WhiskAction.finalParamsAnnotationName, JsBoolean(true))
+                WhiskAction(pkgName.fullPath, actionName, Exec.js("??"), defaultActionParameters, annotations = annotations)
             }
         } else {
             Future.failed(NoDocumentException("doesn't exist"))
@@ -193,7 +200,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         implicit val tid = transid()
 
         val methods = Seq((Put, MethodNotAllowed))
-        methods.map {
+        methods.foreach {
             case (m, code) =>
                 m("/experimental/partialmeta") ~> sealRoute(routes(creds)) ~> check {
                     status should be(code)
@@ -205,15 +212,20 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         implicit val tid = transid()
         val methods = Seq(Get, Post, Delete)
 
-        methods.map { m =>
+        methods.foreach { m =>
             m("/experimental") ~> sealRoute(routes(creds)) ~> check {
                 status shouldBe NotFound
             }
         }
 
-        val paths = Seq("/experimental/doesntexist", "/experimental/notmeta", "/experimental/badmeta")
-        paths.map { p =>
-            methods.map { m =>
+        val paths = Seq(
+            "/experimental/doesntexist",
+            "/experimental/notmeta",
+            "/experimental/badmeta",
+            "/experimental/bindingmeta")
+
+        paths.foreach { p =>
+            methods.foreach { m =>
                 m(p) ~> sealRoute(routes(creds)) ~> check {
                     withClue(p) {
                         status shouldBe MethodNotAllowed
@@ -232,7 +244,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         implicit val tid = transid()
 
         val methods = Seq((Get, "getApi"), (Post, "createRoute"), (Delete, "deleteApi"))
-        methods.map {
+        methods.foreach {
             case (m, name) =>
                 m("/experimental/heavymeta?a=b&c=d&namespace=xyz") ~> sealRoute(routes(creds)) ~> check {
                     status should be(OK)
@@ -249,7 +261,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         implicit val tid = transid()
 
         val methods = Seq((Get, OK), (Post, MethodNotAllowed), (Delete, MethodNotAllowed))
-        methods.map {
+        methods.foreach {
             case (m, code) =>
                 m("/experimental/partialmeta?a=b&c=d") ~> sealRoute(routes(creds)) ~> check {
                     status should be(code)
@@ -268,7 +280,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         implicit val tid = transid()
 
         val paths = Seq("", "/", "/foo", "/foo/bar", "/foo/bar/", "/foo%20bar")
-        paths.map { p =>
+        paths.foreach { p =>
             withClue(s"failed on path: '$p'") {
                 Get(s"/experimental/partialmeta$p?a=b&c=d") ~> sealRoute(routes(creds)) ~> check {
                     status should be(OK)
@@ -334,8 +346,8 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
 
         val methods = Seq(Get, Post, Delete)
 
-        methods.map { m =>
-            reservedProperties.map { p =>
+        methods.foreach { m =>
+            reservedProperties.foreach { p =>
                 m(s"/experimental/packagemeta/?$p=YYY") ~> sealRoute(routes(creds)) ~> check {
                     status should be(BadRequest)
                     responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
@@ -360,6 +372,32 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
                 "pkg" -> s"$systemId/heavymeta".toJson,
                 "action" -> "createRoute".toJson,
                 "content" -> metaPayload("post", Map("a" -> "b", "c" -> "d"), creds.namespace.name, body = Some(content)))
+        }
+    }
+
+    it should "invoke action and ignore invoke parameters that are immutable" in {
+        implicit val tid = transid()
+        val contentX = JsObject("x" -> "overriden".toJson)
+        val contentZ = JsObject("z" -> "overriden".toJson)
+
+        Get(s"/experimental/packagemeta?x=overriden") ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        Get(s"/experimental/packagemeta?y=overriden") ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        Get(s"/experimental/packagemeta", contentX) ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
+        }
+
+        Get(s"/experimental/packagemeta?y=overriden", contentZ) ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.parametersNotAllowed
         }
     }
 

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -133,7 +133,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
             // all actions have default parameters (see actionLookup stub)
             pkgLookup(resolvePackageName(action.namespace.last)) foreach { pkg =>
                 action.parameters shouldBe (pkg.parameters ++ defaultActionParameters)
-                action.parameters("z") shouldBe defaultActionParameters("z")
+                action.parameters.get("z") shouldBe defaultActionParameters.get("z")
             }
 
             Future.successful(activation.activationId, Some(activation))

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -402,6 +402,11 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
         assert(params(3).toString == json(3).compactPrint) // drops unknown prop "foo"
     }
 
+    it should "filter immutable parameters" in {
+        val params = Parameters("k", "v") ++ Parameters("ns", null: String) ++ Parameters("njs", JsNull)
+        params.immutableParameters shouldBe Set("k")
+    }
+
     it should "reject malformed JSON" in {
         val params = Seq[JsValue](
             null,


### PR DESCRIPTION
This pull request allows actions to declare their parameters "final" and may not be overridden by invoke-time parameters.