### PR TITLE
Allow actions to be accessible from a web browser

### DIFF
--- a/ansible/files/auth_index.json
+++ b/ansible/files/auth_index.json
@@ -2,7 +2,7 @@
   "_id":"_design/subjects",
   "views": {
     "identities": {
-      "map": "function (doc) {\n  if(doc.uuid && doc.key) {\n    emit([doc.uuid, doc.key], {namespace: doc.subject, uuid: doc.uuid, key: doc.key});\n  }\n  if(doc.namespaces) {\n    doc.namespaces.forEach(function(namespace) {\n      emit([namespace.uuid, namespace.key], {namespace: namespace.name, uuid: namespace.uuid, key: namespace.key});\n    });\n  }\n}"
+      "map": "function (doc) {\n  if(doc.uuid && doc.key) {\n    var v = {namespace: doc.subject, uuid: doc.uuid, key: doc.key};\n    emit([doc.subject], v);\n    emit([doc.uuid, doc.key], v);\n  }\n  if(doc.namespaces) {\n    doc.namespaces.forEach(function(namespace) {\n      var v = {namespace: namespace.name, uuid: namespace.uuid, key: namespace.key};\n      emit([namespace.name], v);\n      emit([namespace.uuid, namespace.key], v);\n    });\n  }\n}"
     }
   },
   "language":"javascript",

--- a/ansible/logs.yml
+++ b/ansible/logs.yml
@@ -9,7 +9,7 @@
       file: path="{{ openwhisk_home }}/logs" state=absent
     - name: create "logs" folder
       file: path="{{ openwhisk_home }}/logs" state=directory
-    - name: dump databases
+    - name: dump entity views
       local_action: shell "{{ openwhisk_home }}/bin/wskadmin" db get whisks --docs --view whisks/{{ item }} | tail -n +2 > "{{ openwhisk_home }}/logs/db-{{ item }}.log"
       with_items:
         - activations
@@ -17,6 +17,9 @@
         - triggers
         - rules
         - packages
+      when: "'db' not in exclude_logs_from"
+    - name: dump subjects database
+      local_action: shell "{{ openwhisk_home }}/bin/wskadmin" db get subjects --docs | tail -n +2 > "{{ openwhisk_home }}/logs/db-subjects.log"
       when: "'db' not in exclude_logs_from"
 
 - hosts: shared,core,invokers

--- a/ansible/tasks/initdb.yml
+++ b/ansible/tasks/initdb.yml
@@ -10,7 +10,7 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  register: result
+  register: dbexists
 
 # create only the missing db_auth
 - name: create immortal {{ db_auth }} db with {{ db_provider }}
@@ -21,21 +21,51 @@
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: result.status == 404
+  when: dbexists is defined and dbexists.status == 404
 
-- name: recreate the "full" index on the "auth" database
+# fetches the revision of previous view (to update it) if it exists
+- name: check for previous view in "auth" database
+  vars:
+    auth_index: "{{ lookup('file', '{{ openwhisk_home }}/ansible/files/auth_index.json') }}"
+  uri:
+    url: "{{ db_protocol }}://{{ db_host }}:{{ db_port }}/{{ db_auth }}/{{ auth_index['_id'] }}"
+    return_content: yes
+    method: GET
+    status_code: 200, 404
+    user: "{{ db_username }}"
+    password: "{{ db_password }}"
+    force_basic_auth: yes
+  register: previousView
+  when: dbexists is defined and dbexists.status != 404 #and mode=="updateview"
+
+- name: extract revision from previous view
+  vars:
+    previousContent: "{{ previousView['content']|from_json }}"
+    revision: "{{ previousContent['_rev'] }}"
+    auth_index: "{{ lookup('file', '{{ openwhisk_home }}/ansible/files/auth_index.json') }}"
+  set_fact:
+    previousContent: "{{ previousContent }}"
+    updateWithRevision: "{{ auth_index | combine({'_rev': revision}) }}"
+  when: previousView is defined and previousView.status != 404
+
+- name: check if a view update is required
+  set_fact:
+    updateView: "{{ updateWithRevision }}"
+  when: previousContent is defined and previousContent != updateWithRevision
+
+- name: recreate or update the index on the "auth" database
   vars:
     auth_index: "{{ lookup('file', '{{ openwhisk_home }}/ansible/files/auth_index.json') }}"
   uri:
     url: "{{ db_protocol }}://{{ db_host }}:{{ db_port }}/{{ db_auth }}"
     method: POST
-    status_code: 200,201
+    status_code: 200, 201
     body_format: json
-    body: "{{ auth_index }}"
+    body: "{{ updateView | default(auth_index) }}"
     user: "{{ db_username }}"
     password: "{{ db_password }}"
     force_basic_auth: yes
-  when: result.status == 404
+  when: (dbexists is defined and dbexists.status == 404) or (updateView is defined)
 
 - name: recreate necessary "auth" keys
   vars:
@@ -61,4 +91,4 @@
     password: "{{ db_password }}"
     force_basic_auth: yes
   with_items: "{{ db.authkeys }}"
-  when: result.status == 404
+  when: dbexists is defined and dbexists.status == 404

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -170,6 +170,7 @@ protected[core] class EntityName private (val name: String) extends AnyVal {
     def toJson = JsString(name)
     def toPath: EntityPath = EntityPath(name)
     def addPath(e: EntityName): EntityPath = toPath.addPath(e)
+    def addPath(e: Option[EntityName]): EntityPath = e map { toPath.addPath(_) } getOrElse toPath
     override def toString = name
 }
 

--- a/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Parameter.scala
@@ -17,17 +17,8 @@
 package whisk.core.entity
 
 import scala.util.Try
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.JsArray
-import spray.json.JsNull
-import spray.json.JsObject
-import spray.json.JsString
-import spray.json.JsValue
-import spray.json.DefaultJsonProtocol.JsValueFormat
-import spray.json.DefaultJsonProtocol.mapFormat
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.pimpAny
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 import scala.language.postfixOps
 import whisk.core.entity.size.SizeInt
 import whisk.core.entity.size.SizeString
@@ -70,8 +61,8 @@ protected[core] class Parameters protected[entity] (
         Try(new Parameters(params - new ParameterName(p))) getOrElse this
     }
 
-    /** Gets list of immutable parameters (those with a value defined). */
-    protected[core] def immutableParameters: Set[String] = {
+    /** Gets list all defined parameters. */
+    protected[core] def definedParameters: Set[String] = {
         params.keySet filter (params(_).isDefined) map (_.name)
     }
 
@@ -92,6 +83,28 @@ protected[core] class Parameters protected[entity] (
      * Retrieves parameter by name if it exists.
      */
     protected[core] def get(p: String) = params.get(new ParameterName(p)).map(_.value)
+
+    /**
+     * Retrieves parameter by name if it exist. If value of parameter
+     * is a boolean, return its value else false.
+     */
+    protected[core] def asBool(p: String): Option[Boolean] = {
+        get(p) flatMap {
+            case JsBoolean(b) => Some(b)
+            case _            => None
+        }
+    }
+
+    /**
+     * Retrieves parameter by name if it exist. If value of parameter
+     * is a string, return its value else none.
+     */
+    protected[core] def asString(p: String): Option[String] = {
+        get(p) flatMap {
+            case JsString(s) => Some(s)
+            case _           => None
+        }
+    }
 }
 
 /**

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -111,11 +111,13 @@ case class WhiskAction(
 
     /** @return true iff action has appropriate annotation. */
     def hasFinalParamsAnnotation = {
-        annotations.get(WhiskAction.finalParamsAnnotationName) map {
-            case JsBoolean(b) => b
-            case _            => false
-        } getOrElse false
+        annotations.asBool(WhiskAction.finalParamsAnnotationName) getOrElse false
     }
+
+    /** @return a Set of immutable parameternames */
+    def immutableParameters = if (hasFinalParamsAnnotation) {
+        parameters.definedParameters
+    } else Set.empty[String]
 
     /**
      * Merges parameters (usually from package) with existing action parameters.

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -16,10 +16,11 @@
 
 package whisk.http
 
-import scala.util.Try
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
 
+import spray.http.MediaType
 import spray.http.StatusCode
 import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
@@ -83,6 +84,12 @@ object Messages {
     /** Error messages for activations. */
     val abnormalInitialization = "The action did not initialize and exited unexpectedly."
     val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
+
+    /** Error for meta api. */
+    val propertyNotFound = "Response does not include requested property."
+    def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
+    val contentTypeNotSupported = "Content type not supported."
+    val contentTypeRequired = "Content type is missing."
 
     def invalidInitResponse(actualResponse: String) = {
         "The action failed during initialization" + {

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -17,7 +17,6 @@
 package whisk.core.controller
 
 import scala.concurrent.Future
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Failure
@@ -39,6 +38,7 @@ import whisk.common.LoggingMarkers
 import whisk.common.PrintStreamEmitter
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
+import whisk.core.controller.actions.BlockingInvokeTimeout
 import whisk.core.controller.actions.PostActionActivation
 import whisk.core.database.NoDocumentException
 import whisk.core.entitlement._
@@ -630,6 +630,5 @@ trait WhiskActionsApi
     }
 }
 
-private case class BlockingInvokeTimeout(activationId: ActivationId) extends TimeoutException
 private case class TooManyActionsInSequence() extends RuntimeException
 private case class SequenceWithCycle() extends RuntimeException

--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -19,14 +19,19 @@ package whisk.core.controller
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
 
 import spray.http._
+import spray.http.HttpHeaders.RawHeader
+import spray.http.MediaTypes._
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import spray.routing.Directives
+import spray.routing.RequestContext
 import whisk.common.TransactionId
+import whisk.core.controller.actions.BlockingInvokeTimeout
 import whisk.core.controller.actions.PostActionActivation
 import whisk.core.database._
 import whisk.core.entity._
@@ -34,13 +39,109 @@ import whisk.core.entity.types._
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 import whisk.core.WhiskConfig
+import whisk.utils.JsHelpers._
 
-/**
- * A singleton object which defines the properties that must be present in a configuration
- * in order to implement the Meta API.
- */
-object WhiskMetaApi {
+private case class Context(
+    method: HttpMethod,
+    headers: List[HttpHeader],
+    path: String,
+    query: Map[String, String],
+    body: Option[JsObject] = None) {
+    val requestParams = query.toJson.asJsObject.fields ++ { body.map(_.fields) getOrElse Map() }
+    val overrides = WhiskMetaApi.reservedProperties.intersect(requestParams.keySet)
+    def withBody(b: Option[JsObject]) = Context(method, headers, path, query, b)
+    def metadata(user: Option[Identity]): Map[String, JsValue] = {
+        Map("__ow_meta_verb" -> method.value.toLowerCase.toJson,
+            "__ow_meta_headers" -> headers.map(h => h.lowercaseName -> h.value).toMap.toJson,
+            "__ow_meta_path" -> path.toJson) ++
+            user.map(u => "__ow_meta_namespace" -> u.namespace.asString.toJson)
+    }
+}
+
+protected[core] object WhiskMetaApi extends Directives {
+    /**
+     * Defines the properties that must be present in a configuration
+     * in order to implement the Meta API.
+     */
     def requiredProperties = Map(WhiskConfig.systemKey -> null)
+
+    /** Reserved parameters that requests may no defined. */
+    val reservedProperties = Set(
+        "__ow_meta_verb",
+        "__ow_meta_headers",
+        "__ow_meta_path",
+        "__ow_meta_namespace")
+
+    /** Supported media types for action response. */
+    val mediaTranscoders = Map(
+        "html" -> resultAsHtml _,
+        "text" -> resultAsText _,
+        "json" -> resultAsJson _,
+        "http" -> resultAsHttp _)
+
+    /** Default media extensions for action projection. */
+    val defaultMediaProjection: Map[String, Option[List[String]]] = Map(
+        "html" -> Some(List("html")),
+        "text" -> Some(List("text")),
+        "json" -> None,
+        "http" -> None)
+
+    val supportedMediaTypes = mediaTranscoders.keySet
+
+    protected def resultAsHtml(result: JsValue): RequestContext => Unit = result match {
+        case JsString(html) => respondWithMediaType(`text/html`) { complete(OK, html) }
+        case _              => complete(BadRequest, Messages.invalidMedia(`text/html`))
+    }
+
+    protected def resultAsText(result: JsValue): RequestContext => Unit = {
+        result match {
+            case r: JsObject  => complete(OK, r.prettyPrint)
+            case r: JsArray   => complete(OK, r.prettyPrint)
+            case JsString(s)  => complete(OK, s)
+            case JsBoolean(b) => complete(OK, b.toString)
+            case JsNumber(n)  => complete(OK, n.toString)
+            case JsNull       => complete(OK)
+        }
+    }
+
+    protected def resultAsJson(result: JsValue): RequestContext => Unit = {
+        result match {
+            case r: JsObject => complete(OK, r)
+            case r: JsArray  => complete(OK, r)
+            case _           => complete(BadRequest, Messages.invalidMedia(`application/json`))
+        }
+    }
+
+    protected def resultAsHttp(result: JsValue): RequestContext => Unit = {
+        result match {
+            case JsObject(fields) => Try {
+                val headers = fields.get("headers").map {
+                    case JsObject(hs) => hs.map {
+                        case (k, JsString(v))  => RawHeader(k, v)
+                        case (k, JsBoolean(v)) => RawHeader(k, v.toString)
+                        case (k, JsNumber(v))  => RawHeader(k, v.toString)
+                        case _                 => throw new Throwable("Invalid header")
+                    }.toList
+
+                    case _ => throw new Throwable("Invalid header")
+                } getOrElse List()
+
+                val code = fields.get("code").map {
+                    case JsNumber(c) =>
+                        // the following throws an exception if the code is
+                        // not a whole number or a valid code
+                        StatusCode.int2StatusCode(c.toIntExact)
+                    case _ => throw new Throwable("Illegal code")
+                } getOrElse (OK)
+
+                respondWithHeaders(headers) {
+                    complete(code, JsObject())
+                }
+            } getOrElse complete(BadRequest, Messages.invalidMedia(`message/http`))
+
+            case _ => complete(BadRequest, Messages.invalidMedia(`message/http`))
+        }
+    }
 }
 
 trait WhiskMetaApi extends Directives with PostActionActivation {
@@ -53,26 +154,34 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
     /** Store for identities. */
     protected val authStore: AuthStore
 
-    /** The route prefix e.g., /experimental/package-name. */
-    protected val routePrefix = pathPrefix("experimental")
+    /** The route prefix e.g., /experimental. */
+    protected val routePath = "experimental"
+
+    /** The prefix for anonymous invokes e.g., /experimental/web. */
+    protected val anonymousInvokePath = "web"
 
     /** The name and apikey of the system namespace. */
     protected lazy val systemKey = AuthKey(whiskConfig.systemKey)
     protected lazy val systemIdentity = Identity.get(authStore, systemKey)(TransactionId.controller)
 
-    /** Reserved parameters that requests may no defined. */
-    protected lazy val reservedProperties = Set("__ow_meta_verb", "__ow_meta_path", "__ow_meta_namespace")
+    private val routePrefix = pathPrefix(routePath)
+    private val anonymousInvokePrefix = pathPrefix(anonymousInvokePath)
 
     /** Allowed verbs. */
     private lazy val allowedOperations = get | delete | post
 
-    /** Extracts the HTTP method, query params and unmatched (remaining) path. */
+    private lazy val validNameSegment = pathPrefix(EntityName.REGEX.r)
+    private lazy val packagePrefix = pathPrefix("default".r | EntityName.REGEX.r)
+    private lazy val extensionSplitter = EntityName.REGEX.dropRight(2).concat("""\.([a-zA-Z0-9.+-]+)\z""").r
+
+    /** Extracts the HTTP method, headers, query params and unmatched (remaining) path. */
     private val requestMethodParamsAndPath = {
         extract { ctx =>
             val method = ctx.request.method
             val params = ctx.request.message.uri.query.toMap
             val path = ctx.unmatchedPath.toString
-            (method, params, path)
+            val headers = ctx.request.headers
+            Context(method, headers, path, params)
         }
     }
 
@@ -115,69 +224,225 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
      * package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path).
      */
     def routes(user: Identity)(implicit transid: TransactionId) = {
-        (routePrefix & pathPrefix(EntityName.REGEX.r) & allowedOperations) { s =>
-            entity(as[Option[JsObject]]) { body =>
-                requestMethodParamsAndPath {
-                    case (method, params, restofPath) =>
-                        val requestParams = params.toJson.asJsObject.fields ++ { body.map(_.fields) getOrElse Map() }
-
-                        if (reservedProperties.intersect(requestParams.keySet).isEmpty) {
-                            onSuccess(resolvePackageName(EntityName(s))) { metaPackage =>
-                                process(user, metaPackage, requestParams, restofPath, method)
+        routePrefix {
+            allowedOperations {
+                validNameSegment { pkgname =>
+                    entity(as[Option[JsObject]]) { body =>
+                        requestMethodParamsAndPath { r =>
+                            val context = r.withBody(body)
+                            if (context.overrides.isEmpty) {
+                                val metaPackage = resolvePackageName(EntityName(pkgname))
+                                processMetaRequest(user, metaPackage, context)
+                            } else {
+                                terminate(BadRequest, Messages.parametersNotAllowed)
                             }
-                        } else {
-                            terminate(BadRequest, Messages.parametersNotAllowed)
                         }
+                    }
                 }
             }
         }
     }
 
-    private def process(
-        user: Identity,
-        metaPackage: FullyQualifiedEntityName,
-        requestParams: Map[String, JsValue],
-        restofPath: String,
-        method: HttpMethod)(
-            implicit transid: TransactionId) = {
-        // before checking if package exists, first check that subject has right
-        // to post an activation explicitly (i.e., there is no check on the package/action
-        // resource since the package is expected to be private)
-        def precheck = entitlementProvider.checkThrottles(user) flatMap {
-            _ => confirmMetaPackage(pkgLookup(metaPackage), method)
-        } flatMap {
-            case (actionName, pkgParams) => actionLookup(metaPackage, actionName) map {
-                _.inherit(pkgParams)
-            }
-        }
-
-        def activate(action: WhiskAction): Future[(ActivationId, Option[WhiskActivation])] = {
-            // precedence order for parameters:
-            // package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path)
-            systemIdentity flatMap { identity =>
-                val invokeParams = if (action.hasFinalParamsAnnotation) {
-                    requestParams -- action.parameters.immutableParameters
-                } else requestParams // in the absence of immutable annotations, return the request untouched
-
-                if (invokeParams.size == requestParams.size) {
-                    val content = invokeParams ++ Map(
-                        "__ow_meta_verb" -> method.value.toLowerCase.toJson,
-                        "__ow_meta_path" -> restofPath.toJson,
-                        "__ow_meta_namespace" -> user.namespace.toJson)
-                    invokeAction(identity, action, Some(JsObject(content)), blocking = true, waitOverride = Some(WhiskActionsApi.maxWaitForBlockingActivation))
-                } else {
-                    Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
+    /**
+     * Adds route to web based activations. Actions invoked this way are anonymous in that the
+     * caller is not authenticated. The intended action must be named in the path as a fully qualified
+     * name as in /experimental/web/some-namespace/some-package/some-action. The package is optional
+     * in that the action may be in the default package, in which case, the string "default" must be used.
+     * If the action doesn't exist (or the namespace is not valid) NotFound is generated. Following the
+     * action name, an "extension" is required to specify the desired content type for the response. This
+     * extension is one of supported media types. An example is ".json" for a JSON response or ".html" for
+     * an text/html response.
+     *
+     * Optionally, the result form the action may be projected based on a named property. As in
+     * /experimental/web/some-namespace/some-package/some-action/some-property. If the property
+     * does not exist in the result then a NotFound error is generated. A path of properties may
+     * be supplied to project nested properties.
+     *
+     * Actions may be exposed to this web proxy by adding an annotation ("export" -> true).
+     */
+    def routes()(implicit transid: TransactionId) = {
+        (routePrefix & anonymousInvokePrefix) {
+            validNameSegment { namespace =>
+                packagePrefix { pkg =>
+                    pathPrefix(Segment) {
+                        _ match {
+                            case extensionSplitter(action, extension) =>
+                                if (WhiskMetaApi.supportedMediaTypes.contains(extension)) {
+                                    val pkgName = if (pkg == "default") None else Some(EntityName(pkg))
+                                    handleAnonymousMatch(EntityName(namespace), pkgName, EntityName(action), extension)
+                                } else {
+                                    complete(NotAcceptable, Messages.contentTypeNotSupported)
+                                }
+                            case _ => complete(NotAcceptable, Messages.contentTypeRequired)
+                        }
+                    }
                 }
             }
         }
+    }
 
-        onComplete(precheck flatMap (activate(_))) {
+    /**
+     * Resolves the package into using the systemId namespace.
+     */
+    protected final def resolvePackageName(pkgName: EntityName): Future[FullyQualifiedEntityName] = {
+        systemIdentity map (_.namespace.addPath(pkgName).toFullyQualifiedEntityName)
+    }
+
+    /**
+     * Gets package from datastore.
+     * This method is factored out to allow mock testing.
+     */
+    protected def getPackage(pkgName: FullyQualifiedEntityName)(
+        implicit transid: TransactionId): Future[WhiskPackage] = {
+        WhiskPackage.get(entityStore, pkgName.toDocId)
+    }
+
+    /**
+     * Gets action from datastore.
+     * This method is factored out to allow mock testing.
+     */
+    protected def getAction(actionName: FullyQualifiedEntityName)(
+        implicit transid: TransactionId): Future[WhiskAction] = {
+        WhiskAction.get(entityStore, actionName.toDocId)
+    }
+
+    /**
+     * Gets identity from datastore.
+     * This method is factored out to allow mock testing.
+     */
+    protected def getIdentity(namespace: EntityName)(
+        implicit transid: TransactionId): Future[Identity] = {
+        Identity.get(authStore, namespace)
+    }
+
+    private def processMetaRequest(
+        user: Identity,
+        pkgpath: Future[FullyQualifiedEntityName],
+        context: Context)(
+            implicit transid: TransactionId) = {
+        // checks that subject has right to post an activation explicitly (note there is
+        // no privilege check on the package/action resource since it is expected to be private),
+        // and the package plus action and merge their parameters.
+        def precheck: Future[(Identity, WhiskAction)] = for {
+            // need the system identity
+            identity <- systemIdentity
+
+            // the fully resolved path to the system package namespace
+            metaPackage <- pkgpath
+
+            // these are sequential, could be done in parallel; in bursts all of the lookups
+            // should be cached
+            action <- entitlementProvider.checkThrottles(user) flatMap {
+                _ => confirmMetaPackage(pkgLookup(metaPackage), context.method)
+            } flatMap {
+                case (actionName, pkgParams) =>
+                    actionLookup(metaPackage.add(actionName), failureCode = InternalServerError) map {
+                        _.inherit(pkgParams)
+                    }
+            }
+        } yield (identity, action)
+
+        completeRequest {
+            precheck flatMap {
+                case (identity, action) => activate(identity, action, context, Some(user))
+            }
+        }
+    }
+
+    private def handleAnonymousMatch(namespace: EntityName, pkg: Option[EntityName], action: EntityName, extension: String)(
+        implicit transid: TransactionId) = {
+        entity(as[Option[JsObject]]) { body =>
+            requestMethodParamsAndPath { r =>
+                val context = r.withBody(body)
+                val fullname = namespace.addPath(pkg).addPath(action).toFullyQualifiedEntityName
+                processAnonymousRequest(fullname, context, extension)
+            }
+        }
+    }
+
+    private def processAnonymousRequest(actionName: FullyQualifiedEntityName, context: Context, responseType: String)(
+        implicit transid: TransactionId) = {
+        // checks that subject has right to post an activation and fetch the action
+        // followed by the package and merge parameters. The action is fetched first since
+        // it will not succeed for references relative to a binding, and the export bit is
+        // confirmed before fetching the package and merging parameters.
+        def precheck: Future[(Identity, WhiskAction)] = for {
+            // lookup the identity for the action namespace
+            identity <- identityLookup(actionName.path.root) flatMap {
+                i => entitlementProvider.checkThrottles(i) map (_ => i)
+            }
+
+            // lookup the action - since actions are stored relative to package name
+            // the lookup will fail if the package name for the action refers to a binding instead
+            action <- confirmExportedAction(actionLookup(actionName, failureCode = NotFound)) flatMap { a =>
+                if (a.namespace.defaultPackage) {
+                    Future.successful(a)
+                } else {
+                    pkgLookup(a.namespace.toFullyQualifiedEntityName) map {
+                        pkg => (a.inherit(pkg.parameters))
+                    }
+                }
+            }
+        } yield (identity, action)
+
+        val projectResultField = {
+            Option(context.path)
+                .filter(_.nonEmpty)
+                .map(_.split("/").filter(_.nonEmpty).toList)
+        } orElse WhiskMetaApi.defaultMediaProjection(responseType)
+
+        completeRequest(
+            queuedActivation = precheck flatMap {
+                case (identity, action) => activate(identity, action, context)
+            },
+            projectResultField,
+            responseType = responseType)
+    }
+
+    private def activate(identity: Identity, action: WhiskAction, context: Context, behalfOf: Option[Identity] = None)(
+        implicit transid: TransactionId): Future[(ActivationId, Option[WhiskActivation])] = {
+        // precedence order for parameters:
+        // package.params -> action.params -> query.params -> request.entity (body) -> augment arguments (namespace, path)
+        val noOverrides = (context.requestParams.keySet intersect action.immutableParameters).isEmpty
+        if (noOverrides) {
+            val content = context.requestParams ++ context.metadata(behalfOf)
+            invokeAction(identity, action, Some(JsObject(content)), blocking = true, waitOverride = Some(WhiskActionsApi.maxWaitForBlockingActivation))
+        } else {
+            Future.failed(RejectRequest(BadRequest, Messages.parametersNotAllowed))
+        }
+    }
+
+    private def completeRequest(
+        queuedActivation: Future[(ActivationId, Option[WhiskActivation])],
+        projectResultField: Option[List[String]] = None,
+        responseType: String = "json")(
+            implicit transid: TransactionId) = {
+        onComplete(queuedActivation) {
             case Success((activationId, Some(activation))) =>
-                val code = if (activation.response.isSuccess) OK else BadRequest
-                // if activation error'ed, treat it as a bad request regardless of failure reason
-                complete(code, activation.resultAsJson)
+                val result = activation.resultAsJson
+
+                if (activation.response.isSuccess) {
+                    val resultPath = projectResultField getOrElse List()
+                    val result = getFieldPath(activation.resultAsJson, resultPath)
+                    result match {
+                        case Some(projection) =>
+                            val marshaler = Future(WhiskMetaApi.mediaTranscoders(responseType)(projection))
+                            onComplete(marshaler) {
+                                case Success(done) => done // all transcoders terminate the connection
+                                case Failure(t)    => terminate(InternalServerError)
+                            }
+                        case _ => complete(NotFound, Messages.propertyNotFound)
+                    }
+                } else {
+                    complete(BadRequest, result)
+                }
+
             case Success((activationId, None)) =>
                 // blocking invoke which got queued instead
+                complete(Accepted, JsObject("code" -> transid.id.toJson))
+
+            case Failure(t: BlockingInvokeTimeout) =>
+                info(this, s"activation waiting period expired")
                 complete(Accepted, JsObject("code" -> transid.id.toJson))
 
             case Failure(t: RejectRequest) =>
@@ -190,77 +455,105 @@ trait WhiskMetaApi extends Directives with PostActionActivation {
     }
 
     /**
-     * Resolves the package into using the systemId namespace.
+     * Gets package from datastore and confirms it is not a binding.
      */
-    protected final def resolvePackageName(pkgName: EntityName) = {
-        systemIdentity.map { identity =>
-            FullyQualifiedEntityName(identity.namespace.toPath, pkgName)
+    private def pkgLookup(pkg: FullyQualifiedEntityName)(
+        implicit transid: TransactionId): Future[WhiskPackage] = {
+        getPackage(pkg).filter {
+            _.binding.isEmpty
+        } recoverWith {
+            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+                // if the package lookup fails or the package doesn't conform to expected invariants,
+                // fail the request with BadRequest so as not to leak information about the existence
+                // of packages that are otherwise private
+                info(this, s"meta api request for package which does not exist")
+                Future.failed(RejectRequest(NotFound))
+            case _: NoSuchElementException =>
+                warn(this, s"'$pkg' is a binding")
+                Future.failed(RejectRequest(NotFound))
         }
     }
 
     /**
-     * Gets package from datastore. This method is factored out to allow mock testing.
+     * Gets the action if it exists and fail future with RejectRequest if it does not.
+     * Caller should specify desired failure code for failed future.
+     * For a meta action, should be InternalServerError since the meta package might be
+     * badly configured. And for export errors NotFound is appropriate.
      */
-    protected def pkgLookup(pkg: FullyQualifiedEntityName)(
-        implicit transid: TransactionId): Future[WhiskPackage] = {
-        WhiskPackage.get(entityStore, pkg.toDocId)
+    private def actionLookup(actionName: FullyQualifiedEntityName, failureCode: StatusCode)(
+        implicit transid: TransactionId): Future[WhiskAction] = {
+        getAction(actionName) recoverWith {
+            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+                Future.failed(RejectRequest(failureCode))
+        }
     }
 
     /**
-     * Meta API handlers must be in packages (not bindings) and have a "meta -> true" annotation
-     * in addition to a mapping from http verbs to action names; fetch package to
-     * ensure it exists, if it doesn't reject the request as not allowed.
-     * if package exists, check that it satisfies invariants on annotations.
+     * Gets the identity for the namespace.
+     */
+    private def identityLookup(namespace: EntityName)(
+        implicit transid: TransactionId): Future[Identity] = {
+        getIdentity(namespace) recoverWith {
+            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
+                Future.failed(RejectRequest(NotFound))
+            case t =>
+                // leak nothing no matter what, failure is already logged so skip here
+                Future.failed(RejectRequest(NotFound))
+        }
+    }
+
+    /**
+     * Meta API handlers must be in packages (not bindings) and have a ("meta" -> true)
+     * annotation in addition to a mapping from HTTP verbs to action names; fetch package to
+     * ensure it exists and reject request if it does not. If package exists, check that
+     * it satisfies invariants on annotations.
      *
-     * @param pkg the whisk package
-     * @param method the http verb to look up corresponding action in package annotations
+     * @param pkgLookup future that resolves to whisk package
+     * @param method the HTTP verb to look up corresponding action in package annotations
      * @return future that resolves the tuple (action to invoke, package parameters to pass on to action)
      */
-    private def confirmMetaPackage(pkgLookup: Future[WhiskPackage], method: HttpMethod)(implicit transid: TransactionId) = {
-        pkgLookup recoverWith {
-            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
-                // if the package lookup fails or the package doesn't conform to expected invariants,
-                // fail the request with MethodNotAllowed so as not to leak information about the existence
-                // of packages that are otherwise private
-                info(this, s"meta api request references package which is missing")
-                Future.failed(RejectRequest(MethodNotAllowed))
-        } flatMap { pkg =>
+    private def confirmMetaPackage(pkgLookup: Future[WhiskPackage], method: HttpMethod)(
+        implicit transid: TransactionId): Future[(EntityName, Parameters)] = {
+        pkgLookup flatMap { pkg =>
             // expecting the meta handlers to be private; should it be an error? warn for now
             if (pkg.publish) {
                 warn(this, s"'${pkg.fullyQualifiedName(true)}' is public")
             }
 
-            if (pkg.binding.isEmpty) {
-                pkg.annotations.get("meta") filter {
-                    // does package have annotation: meta == true
-                    _ match { case JsBoolean(b) => b case _ => false }
-                } flatMap {
-                    // if so, find action name for http verb
-                    _ => pkg.annotations.get(method.name.toLowerCase)
-                } match {
+            // does package have annotation: meta == true and a
+            // mapping from HTTP verb to action name?
+            val isMetaPackage = pkg.annotations.asBool("meta").exists(identity)
+
+            if (isMetaPackage) {
+                pkg.annotations.asString(method.name.toLowerCase).map { actionName =>
                     // if action name is defined as a string, accept it, else fail request
-                    case Some(JsString(actionName)) =>
-                        info(this, s"'${pkg.name}' maps '${method.name}' to action '${actionName}'")
-                        Future.successful(EntityName(actionName), pkg.parameters)
-                    case _ =>
-                        info(this, s"'${pkg.name}' is missing 'meta' annotation or action name for '${method.name.toLowerCase}'")
-                        Future.failed(RejectRequest(MethodNotAllowed))
+                    info(this, s"'${pkg.name}' maps '${method.name}' to action '${actionName}'")
+                    Future.successful(EntityName(actionName), pkg.parameters)
+                } getOrElse {
+                    info(this, s"'${pkg.name}' is missing action name for '${method.name.toLowerCase}'")
+                    Future.failed(RejectRequest(MethodNotAllowed))
                 }
             } else {
-                warn(this, s"'${pkg.fullyQualifiedName(true)}' is a binding")
-                Future.failed(RejectRequest(MethodNotAllowed))
+                info(this, s"'${pkg.name}' is missing 'meta' annotation")
+                Future.failed(RejectRequest(NotFound))
             }
         }
     }
 
-    protected def actionLookup(pkgName: FullyQualifiedEntityName, actionName: EntityName)(
+    /**
+     * Checks if an action is exported (i.e., carries the required annotation).
+     */
+    private def confirmExportedAction(actionLookup: Future[WhiskAction])(
         implicit transid: TransactionId): Future[WhiskAction] = {
-        val docid = pkgName.add(actionName).toDocId
-        WhiskAction.get(entityStore, docid) recoverWith {
-            case _: ArtifactStoreException | DeserializationException(_, _, _) =>
-                // the action doesn't exist or is corrupted but the package stated otherwise
-                // so treat this as an internal error
-                Future.failed(RejectRequest(InternalServerError))
+        actionLookup flatMap { action =>
+            if (action.annotations.asBool("web-export").exists(identity)) {
+                info(this, s"${action.fullyQualifiedName(true)} is exported")
+                Future.successful(action)
+            } else {
+                info(this, s"${action.fullyQualifiedName(true)} not exported")
+                Future.failed(RejectRequest(NotFound))
+            }
         }
     }
+
 }

--- a/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/RestAPIs.scala
@@ -141,6 +141,8 @@ protected[controller] class RestAPIVersion_v1(
                                     activations.routes(user) ~
                                     packages.routes(user)
                             } ~ meta.routes(user)
+                } ~ {
+                    meta.routes()
                 } ~ pathPrefix(swaggeruipath) {
                     getFromDirectory("/swagger-ui/")
                 } ~ path(swaggeruipath) {

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PostActionActivation.scala
@@ -18,6 +18,7 @@ package whisk.core.controller.actions
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.TimeoutException
 
 import spray.json._
 import whisk.common.TransactionId
@@ -54,3 +55,5 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
         }
     }
 }
+
+protected[controller] case class BlockingInvokeTimeout(activationId: ActivationId) extends TimeoutException

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -34,7 +34,6 @@ import whisk.common.PrintStreamEmitter
 import whisk.common.StartMarker
 import whisk.common.TransactionId
 import whisk.core.connector.ActivationMessage
-import whisk.core.controller.BlockingInvokeTimeout
 import whisk.core.controller.WhiskServices
 import whisk.core.database.NoDocumentException
 import whisk.core.entity._

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -34,7 +34,6 @@ import spray.json._
 import whisk.common.Logging
 import whisk.common.PrintStreamEmitter
 import whisk.common.TransactionId
-import whisk.core.controller.BlockingInvokeTimeout
 import whisk.core.controller.WhiskActionsApi._
 import whisk.core.controller.WhiskServices
 import whisk.core.entity._

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -945,7 +945,7 @@ object WskAdmin {
     }
 
     /**
-     * returns user given the auth key
+     * returns (subject, namespace) pair given the auth key
      */
     def getUser(authKey: String): (String, String) = {
         val wskadmin = new RunWskAdminCmd {}

--- a/tests/src/system/rest/RestUtil.scala
+++ b/tests/src/system/rest/RestUtil.scala
@@ -35,7 +35,10 @@ trait RestUtil {
     private val trustStorePassword = WhiskProperties.getSslCertificateChallenge
 
     // force RestAssured to allow all hosts in SSL certificates
-    protected val sslconfig = new RestAssuredConfig().sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames());
+    protected val sslconfig = {
+        new RestAssuredConfig().
+            sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames());
+    }
 
     /**
      * @return the URL and port for the whisk service

--- a/tests/src/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/whisk/core/cli/test/WskWebActionsTests.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.cli.test
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import com.jayway.restassured.RestAssured
+
+import common.TestHelpers
+import common.TestUtils
+import common.Wsk
+import common.WskAdmin
+import common.WskProps
+import common.WskTestHelpers
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import system.rest.RestUtil
+
+/**
+ * Tests for basic CLI usage. Some of these tests require a deployed backend.
+ */
+@RunWith(classOf[JUnitRunner])
+class WskWebActionsTests
+    extends TestHelpers
+    with WskTestHelpers
+    with RestUtil {
+
+    implicit val wskprops = WskProps()
+    val wsk = new Wsk
+    val namespace = WskAdmin.getUser(wskprops.authKey)._2
+
+    behavior of "Wsk Web Actions"
+
+    it should "create a web action accessible via HTTPS" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val response = RestAssured.given().config(sslconfig).
+                get(getServiceURL() + s"/api/v1/experimental/web/$namespace/default/webaction.text/a?a=A")
+
+            response.statusCode() should be(200)
+            response.body().asString() shouldBe "A"
+    }
+
+}

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -128,7 +128,7 @@ trait DbUtils extends TransactionCounter {
     def waitOnView(db: AuthStore, authkey: AuthKey, count: Int)(
         implicit context: ExecutionContext, transid: TransactionId, timeout: Duration) = {
         val success = retry(() => {
-            Identity.list(db, authkey) map { l =>
+            Identity.list(db, List(authkey.uuid.asString, authkey.key.asString)) map { l =>
                 if (l.length != count) {
                     throw RetryOp()
                 } else true

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -160,7 +160,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
 
     it should "accept well formed names" in {
         val paths = Seq("a", "a b", "a@b.c", "_a", "_", "_ _", "a0", "a 0", "a.0", "a@@", "0", "0.0", "0.0.0", "0a", "0.a")
-        val spaces = paths.foreach { n =>
+        paths.foreach { n =>
             assert(EntityName(n).toString == n)
         }
     }
@@ -405,7 +405,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
 
     it should "filter immutable parameters" in {
         val params = Parameters("k", "v") ++ Parameters("ns", null: String) ++ Parameters("njs", JsNull)
-        params.immutableParameters shouldBe Set("k")
+        params.definedParameters shouldBe Set("k")
     }
 
     it should "reject malformed JSON" in {

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -87,16 +87,23 @@ def parseArgs():
     subcmd = subparser.add_parser('create', help='create a user and show authorization key')
     subcmd.add_argument('subject', help='the subject to create')
     subcmd.add_argument('-u', '--auth', help='the uuid:key to initialize the subject authorization key with')
+    subcmd.add_argument('-ns', '--namespace', help='create key for given namespace instead (defaults to subject id')
 
     subcmd = subparser.add_parser('delete', help='delete a user')
     subcmd.add_argument('subject', help='the subject to delete')
+    subcmd.add_argument('-ns', '--namespace', help='delete key for given namespace only')
 
     subcmd = subparser.add_parser('get', help='get authorization key for user')
     subcmd.add_argument('subject', help='the subject to get key for')
-    subcmd.add_argument('--namespace', help='the namespace to get the key for, defaults to "default namespace"')
+    subcmd.add_argument('-ns', '--namespace', help='the namespace to get the key for, defaults to subject id')
 
     subcmd = subparser.add_parser('whois', help='identify user from an authorization key')
     subcmd.add_argument('authkey', help='the credentials to look up')
+
+    subcmd = subparser.add_parser('list', help='list authorization keys associated with a namespace')
+    subcmd.add_argument('namespace', help='the namespace to lookup')
+    subcmd.add_argument('-p', '--pick', metavar='N', help='show no more than N identities', type=int, default=1)
+    subcmd.add_argument('-k', '--key', help='show only the keys', action='store_true')
 
     propmenu = subparsers.add_parser('db', help='work with dbs')
     subparser = propmenu.add_subparsers(title='available commands', dest='subcmd')
@@ -126,6 +133,8 @@ def userCmd(args, props):
         return getUserCmd(args, props)
     elif args.subcmd == 'whois':
         return whoisUserCmd(args, props)
+    elif args.subcmd == 'list':
+        return listUserCmd(args, props)
     else:
         print 'unknown command'
         return 2
@@ -157,6 +166,12 @@ def createUserCmd(args, props):
         print 'Subject name must be at least 5 characters'
         return 2
 
+    if args.namespace and args.namespace.strip() == '':
+        print 'Namespace must not be empty'
+        return 2
+    else:
+        desiredNamespace = subject if not args.namespace else args.namespace.strip()
+
     if args.auth:
         try:
             parts = args.auth.split(':')
@@ -177,30 +192,32 @@ def createUserCmd(args, props):
         uid = str(uuid.uuid4())
         key = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(64))
 
-    doc = {
-        '_id': subject,
-        'subject': subject,
-        'namespaces': [
-            {
-                'name': subject,
+    (doc, res) = getSubjectFromDb(args, props)
+    if doc is None:
+        doc = {
+            '_id': subject,
+            'subject': subject,
+            'namespaces': [
+                {
+                    'name': desiredNamespace,
+                    'uuid': uid,
+                    'key': key
+                }
+            ]
+        }
+    else:
+        namespaces = filter(lambda ns: ns['name'] == desiredNamespace, doc['namespaces'])
+        if len(namespaces) == 0:
+            doc['namespaces'].append({
+                'name': desiredNamespace,
                 'uuid': uid,
                 'key': key
-            }
-        ]
-    }
+            })
+        else:
+            print 'Namespace already exists'
+            return 1
 
-    url = '%(protocol)s://%(host)s:%(port)s/%(database)s' % {
-        'protocol': protocol,
-        'host'    : host,
-        'port'    : port,
-        'database': database
-    }
-    body = json.dumps(doc)
-    headers = {
-        'Content-Type': 'application/json',
-    }
-
-    res = request('POST', url, body, headers, auth='%s:%s' % (username, password), verbose=args.verbose)
+    res = insertIntoDatabase(props, doc, args.verbose)
     if res.status in [201, 202]:
         print '%s:%s' % (uid, key)
     else:
@@ -219,10 +236,29 @@ def getUserCmd(args, props):
             print '%s:%s' % (ns['uuid'], ns['key'])
             return 0
         else:
-            print 'namespace "%s" not found for %s' % (namespaceName, args.subject)
+            print 'namespace "%s" not found for "%s"' % (namespaceName, args.subject)
             return 1
     else:
         print 'Failed to get subject (%s)' % res.read().strip()
+        return 1
+
+def listUserCmd(args, props):
+    (nslist, res) = getIdentitiesFromNamespace(args, props)
+
+    if args.pick < 1:
+        print 'pick at least 1 identity to show'
+        return 2
+
+    if nslist is not None:
+        nslist = nslist[:args.pick]
+        if len(nslist) > 0:
+            for p in nslist:
+                print '%s:%s%s' % (p['uuid'], p['key'], "\t%s" % p['subject'] if not args.key else "")
+            return 0
+        else:
+            print 'no identities found for namespace "%s"' % args.namespace
+    else:
+        print 'Failed to get namespace key (%s)' % res.read().strip()
         return 1
 
 def getSubjectFromDb(args, props):
@@ -252,6 +288,38 @@ def getSubjectFromDb(args, props):
     else:
         return (None, res)
 
+def getIdentitiesFromNamespace(args, props):
+    protocol = props[DB_PROTOCOL]
+    host     = props[DB_HOST]
+    port     = props[DB_PORT]
+    username = props[DB_USERNAME]
+    password = props[DB_PASSWORD]
+    database = props[DB_WHISK_AUTHS]
+
+    url = '%(protocol)s://%(host)s:%(port)s/%(database)s/_design/subjects/_view/identities?key=["%(ns)s"]' % {
+        'protocol': protocol,
+        'host'    : host,
+        'port'    : port,
+        'username': username,
+        'database': database,
+        'ns'      : args.namespace
+    }
+
+    headers = {
+        'Content-Type': 'application/json',
+    }
+
+    res = request('GET', url, headers=headers, auth='%s:%s' % (username, password), verbose=args.verbose)
+    nslist = None
+    if res.status == 200:
+        doc = json.loads(res.read())
+        nslist = []
+        if 'rows' in doc and len(doc['rows']) > 0:
+            for row in doc['rows']:
+                if 'id' in row:
+                    nslist.append({"subject": row["id"], "uuid": row['value']['uuid'], "key": row['value']['key']})
+    return (nslist, res)
+
 def deleteUserCmd(args, props):
     protocol = props[DB_PROTOCOL]
     host     = props[DB_HOST]
@@ -264,30 +332,49 @@ def deleteUserCmd(args, props):
         print 'Subject must not be empty'
         return 2
 
-    (rev, res) = getSubjectFromDb(args, props)
-    if rev is None:
+    if args.namespace and args.namespace.strip() == '':
+        print 'Namespace must not be empty'
+        return 2
+
+    (prev, res) = getSubjectFromDb(args, props)
+    if prev is None:
         print 'Failed to delete subject (%s)' % res.read().strip()
         return 1
 
-    url = '%(protocol)s://%(host)s:%(port)s/%(database)s/%(subject)s?rev=%(rev)s' % {
-        'protocol': protocol,
-        'host'    : host,
-        'port'    : port,
-        'database': database,
-        'subject' : args.subject,
-        'rev'     : rev['_rev']
-    }
+    if not args.namespace:
+        url = '%(protocol)s://%(host)s:%(port)s/%(database)s/%(subject)s?rev=%(rev)s' % {
+            'protocol': protocol,
+            'host'    : host,
+            'port'    : port,
+            'database': database,
+            'subject' : args.subject.strip(),
+            'rev'     : prev['_rev']
+        }
 
-    headers = {
-        'Content-Type': 'application/json',
-    }
+        headers = {
+            'Content-Type': 'application/json',
+        }
 
-    res = request('DELETE', url, headers=headers, auth='%s:%s' % (username, password), verbose=args.verbose)
-    if res.status in [200, 202]:
-        print 'Subject deleted'
+        res = request('DELETE', url, headers=headers, auth='%s:%s' % (username, password), verbose=args.verbose)
+        if res.status in [200, 202]:
+            print 'Subject deleted'
+        else:
+            print 'Failed to delete subject (%s)' % res.read().strip()
+            return 1
     else:
-        print 'Failed to delete subject (%s)' % res.read().strip()
-        return 1
+        namespaceToDelete = args.namespace.strip()
+        namespaces = filter(lambda ns: ns['name'] != namespaceToDelete, prev['namespaces'])
+        if len(prev['namespaces']) == len(namespaces):
+            print 'Namespace "%s" does not exist for "%s"' % (namespaceToDelete, prev['_id'])
+            return 1
+        else:
+            prev['namespaces'] = namespaces
+            res = insertIntoDatabase(props, prev, args.verbose)
+            if res.status in [201, 202]:
+                print 'Namespace deleted'
+            else:
+                print 'Failed to remove namespace (%s)' % res.read().strip()
+                return 1
 
 def whoisUserCmd(args, props):
     protocol = props[DB_PROTOCOL]
@@ -374,6 +461,28 @@ def getDbCmd(args, props):
         return 0
     print 'Failed to get database (%s)' % res.read().strip()
     return 1
+
+def insertIntoDatabase(props, doc, verbose = False):
+    protocol = props[DB_PROTOCOL]
+    host     = props[DB_HOST]
+    port     = props[DB_PORT]
+    username = props[DB_USERNAME]
+    password = props[DB_PASSWORD]
+    database = props[DB_WHISK_AUTHS]
+
+    url = '%(protocol)s://%(host)s:%(port)s/%(database)s' % {
+        'protocol': protocol,
+        'host'    : host,
+        'port'    : port,
+        'database': database
+    }
+    body = json.dumps(doc)
+    headers = {
+        'Content-Type': 'application/json',
+    }
+
+    res = request('POST', url, body, headers, auth='%s:%s' % (username, password), verbose=verbose)
+    return res
 
 def getLogsCmd(args, props):
     path = '%s/%s/%s_logs.log' % (props[LOGS_DIR], args.component, args.component)

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -170,14 +170,21 @@ wskadmin user create <subject>
 
 This command will create a new *subject* with the authorization key shown on the console once you run `wskadmin`. This key is required when making API calls to OpenWhisk, or when using the command line interface (CLI). The namespace is the same as the `<subject>` name used to create the key.
 
-The same tool may be used to delete a subject.
+A namespace allows two or more subjects to share resources. Each subject will have their own authorization key to work with resources in a namespace, but will have equal rights to the namespace.
 
 ```
 vagrant ssh
-wskadmin user delete <subject>
+wskadmin user create <subject> --ns <namespace>
 ```
-  
- 
+
+The same tool may be used to remove a subject from a namespace or to delete a subject entirely.
+
+```
+vagrant ssh
+wskadmin user delete <subject> --ns <namespace>  # removes <subject> from <namespace>
+wskadmin user delete <subject>                   # deletes <subject>
+```
+
 
 ### SSL certificate configuration (Optional)
 


### PR DESCRIPTION
Adds route to allow web based activations. Actions invoked this way are anonymous in that the
caller is not authenticated. The intended action must be named in the path as a fully qualified
name as in `/experimental/web/some-namespace/some-package/some-action`. The package is optional in that the action may be in the default package. In which case, the string "default" must be used.

If the action doesn't exist (or the namespace is not valid) a `BadRequest` is generated.
Optionally, the result form the action may be projected based on a named property. As in
`/experimental/web/some-namespace/some-package/some-action/some-property`. If the property
does not exist in the result then a `BadRequest` is generated. By convention, the "html" property will attempt to respond with media type "text/html".

Actions may be exposed to this web proxy by adding an annotation ("export" -> true).
Demo video https://ibm.box.com/s/5c6ignvejihbai3f59uvqcxee9etf0lf.

Note the first commit rebases #1740. 
Fixes #1222.
Fixes #1449.
