### PR TITLE
Whisk object in Swift 3 container

### DIFF
--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -42,7 +42,7 @@ class Swift3WhiskObjectTests
 
     behavior of "Swift 3 Whisk backend API"
 
-    ignore should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
+    it should "allow Swift actions to invoke other actions" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // use CLI to create action from dat/actions/invokeAction.swift
             val file = TestUtils.getTestActionFilename("invoke.swift")
@@ -66,7 +66,7 @@ class Swift3WhiskObjectTests
             }
     }
 
-    ignore should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
+    it should "allow Swift actions to trigger events" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             // create a trigger
             val triggerName = s"TestTrigger ${System.currentTimeMillis()}"


### PR DESCRIPTION
Fixes Issue #1705 where Whisk object was failing to invoke actions and triggers in the Swift 3 container. Blue PG 871.  This fix:

- now parses for the protocol prefix in the __OW_API_HOST environment variable
- refactors how we wait for the async call to return.  We leave the dispatch group at the end of the post function call instead of in the callback passed to the post function call.  

I also added a URLSession based function that can replace the KituraNet implementation.  Its more limited right now (can't handle self-signed certificates because URLCredential is not completely implemented in the Linux-based Foundation) so this function is unused right now.