### PR TITLE
Minor fixes

### DIFF
--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -146,7 +146,7 @@ object WhiskConfig extends Logging {
     def readPropertiesFromConsul(properties: scala.collection.mutable.Map[String, String])(implicit system: ActorSystem) = {
         //try to get consulServer prop
         val consulString = for {
-            server <- properties.get(consulServerHost).filter(_ != null)
+            server <- properties.get(consulServerHost).filter(s => s != null && s.trim.nonEmpty)
             port <- properties.get(consulPort).filter(_ != null)
         } yield server + ":" + port
 

--- a/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/whisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -265,7 +265,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
 
                     if (allowedToAssumeCompletion && actualEntry.grabWriteLock(transid, currentState, desiredEntry.unpack)) {
                         // this transaction is now responsible for updating the cache entry
-                        logger.info(this, s"write initiated on existing cache entry invalidating $key")
+                        logger.info(this, s"write initiated on existing cache entry, invalidating $key")
                         listenForWriteDone(key, actualEntry, generator)
                     } else {
                         // there is a conflicting operation in progress on this key

--- a/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/DocInfo.scala
@@ -67,7 +67,13 @@ protected[core] class DocRevision private (val rev: String) extends AnyVal {
  * @param rev the document revision, optional; this is an opaque value determined by the datastore
  */
 protected[core] case class DocInfo protected[entity] (id: DocId, rev: DocRevision = DocRevision()) {
-    override def toString = s"id: $id, rev: $rev"
+    override def toString = {
+        if (rev.empty) {
+            s"id: $id"
+        } else {
+            s"id: $id, rev: $rev"
+        }
+    }
 
     override def hashCode = {
         if (rev.empty) {

--- a/common/scala/src/main/scala/whisk/utils/JsHelpers.scala
+++ b/common/scala/src/main/scala/whisk/utils/JsHelpers.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.utils
+
+import spray.json.JsObject
+import spray.json.JsValue
+
+object JsHelpers {
+    def getFieldPath(js: JsObject, path: List[String]): Option[JsValue] = {
+        path match {
+            case Nil      => Option(js)
+            case p :: Nil => js.fields.get(p)
+            case p :: tail => js.fields.get(p) match {
+                case Some(o: JsObject) => getFieldPath(o, tail)
+                case Some(_)           => None // head exists but value is not an object so cannot project further
+                case None              => None // head doesn't exist, cannot project further
+            }
+        }
+    }
+
+    def getFieldPath(js: JsObject, path: String*): Option[JsValue] = {
+        getFieldPath(js, path.toList)
+    }
+
+    def fieldPathExists(js: JsObject, path: List[String]): Boolean = getFieldPath(js, path).isDefined
+    def fieldPathExists(js: JsObject, path: String*): Boolean = fieldPathExists(js, path.toList)
+}

--- a/core/controller/src/main/scala/whisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Actions.scala
@@ -308,8 +308,8 @@ trait WhiskActionsApi
         // offer an option to fetch entities with full docs yet.
         //
         // the complication with actions is that providing docs on actions in
-        // package bindings is complicated; it cannot be do readily with a cloudant
-        // (couchdb) view and would require finding all bindings in namespace and
+        // package bindings is cannot be do readily done with a couchdb view
+        // and would require finding all bindings in namespace and
         // joining the actions explicitly here.
         val docs = false
         parameter('skip ? 0, 'limit ? collection.listLimit, 'count ? false) {

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -72,7 +72,7 @@ trait Authenticate extends Logging {
                 future
             }.toOption
         } getOrElse {
-            userpass.map(_ => info(this, s"credentials are malformed"))
+            userpass.foreach(_ => info(this, s"credentials are malformed"))
             Future.successful(None)
         }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -72,7 +72,7 @@ trait Authenticate extends Logging {
                 future
             }.toOption
         } getOrElse {
-            info(this, s"credentials are malformed")
+            userpass.map(_ => info(this, s"credentials are malformed"))
             Future.successful(None)
         }
     }

--- a/tests/src/common/JsHelpers.scala
+++ b/tests/src/common/JsHelpers.scala
@@ -14,31 +14,25 @@
  * limitations under the License.
  */
 
+// This is a copy of the JsHelpers as a trait to allow
+// catalog tests to still work until they are migrated
 package common
-
-import scala.language.postfixOps
-import scala.util.Try
 
 import spray.json.JsObject
 import spray.json.JsValue
 
+/**
+ * @deprecated Use {@link whisk.common.JsHelpers} instead.
+ */
+@Deprecated
 trait JsHelpers {
     implicit class JsObjectHelper(js: JsObject) {
         def getFieldPath(path: String*): Option[JsValue] = {
-            if (path.size == 1) {
-                Try {
-                    js.fields(path(0))
-                } toOption
-            } else if (js.getFields(path(0)).size > 0) {
-                // current segment exists, but there are more...
-                js.fields(path(0)).asJsObject.getFieldPath(path.tail: _*)
-            } else {
-                None
-            }
+            whisk.utils.JsHelpers.getFieldPath(js, path.toList)
         }
 
         def fieldPathExists(path: String*): Boolean = {
-            !js.getFieldPath(path: _*).isEmpty
+            whisk.utils.JsHelpers.fieldPathExists(js, path.toList)
         }
     }
 }

--- a/tests/src/common/WskTestHelpers.scala
+++ b/tests/src/common/WskTestHelpers.scala
@@ -206,7 +206,7 @@ trait WskTestHelpers extends Matchers {
                 implicit wskprops: WskProps): Unit = {
 
         val activationIds = wsk.pollFor(N, Some(entity), since = since, retries = (totalWait / pollPeriod).toInt, pollPeriod = pollPeriod)
-        withClue(s"did not find $N activations for $entity since $since") {
+        withClue(s"expecting $N activations matching '$entity' name since $since but found ${activationIds.mkString(",")} instead") {
             activationIds.length shouldBe N
         }
 

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -29,7 +29,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
-import akka.event.Logging.DebugLevel
+import akka.event.Logging.ErrorLevel
 import whisk.common.TransactionId
 import whisk.connector.kafka.KafkaConsumerConnector
 import whisk.connector.kafka.KafkaProducerConnector
@@ -58,8 +58,8 @@ class KafkaConnectorTests extends FlatSpec with Matchers with WskActorSystem wit
     val producer = new KafkaProducerConnector(config.kafkaHost, ec)
     val consumer = new TestKafkaConsumerConnector(config.kafkaHost, groupid, topic, sessionTimeout = sessionTimeout)
 
-    producer.setVerbosity(DebugLevel)
-    consumer.setVerbosity(DebugLevel)
+    producer.setVerbosity(ErrorLevel)
+    consumer.setVerbosity(ErrorLevel)
 
     override def afterAll() {
         producer.close()

--- a/tests/src/system/basic/CLIPythonTests.scala
+++ b/tests/src/system/basic/CLIPythonTests.scala
@@ -27,14 +27,12 @@ import spray.json.DefaultJsonProtocol.StringJsonFormat
 import common.TestHelpers
 import common.WskTestHelpers
 import common.WskProps
-import common.JsHelpers
 import common.WhiskProperties
 
 @RunWith(classOf[JUnitRunner])
 class CLIPythonTests
     extends TestHelpers
     with WskTestHelpers
-    with JsHelpers
     with Matchers {
 
     implicit val wskprops = WskProps()

--- a/tests/src/system/basic/Swift3WhiskObjectTests.scala
+++ b/tests/src/system/basic/Swift3WhiskObjectTests.scala
@@ -29,13 +29,11 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.json.pimpAny
-import common.JsHelpers
 
 @RunWith(classOf[JUnitRunner])
 class Swift3WhiskObjectTests
     extends TestHelpers
-    with WskTestHelpers
-    with JsHelpers {
+    with WskTestHelpers {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk

--- a/tests/src/system/basic/WskBasicNodeTests.scala
+++ b/tests/src/system/basic/WskBasicNodeTests.scala
@@ -16,23 +16,21 @@
 
 package system.basic
 
-import org.junit.runner.RunWith
 import scala.concurrent.duration.DurationInt
+
+import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils.ANY_ERROR_EXIT
+import common.TestUtils.RunResult
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.pimpAny
-import spray.json.pimpString
-import spray.json.JsString
-import common.TestUtils.RunResult
-import spray.json.JsObject
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 @RunWith(classOf[JUnitRunner])
 class WskBasicNodeTests

--- a/tests/src/system/basic/WskRuleTests.scala
+++ b/tests/src/system/basic/WskRuleTests.scala
@@ -19,7 +19,6 @@ package system.basic
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
 import common.Wsk
@@ -32,7 +31,6 @@ import java.time.Instant
 @RunWith(classOf[JUnitRunner])
 class WskRuleTests
     extends TestHelpers
-    with JsHelpers
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()

--- a/tests/src/system/basic/WskSequenceTests.scala
+++ b/tests/src/system/basic/WskSequenceTests.scala
@@ -25,7 +25,6 @@ import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils._
@@ -47,7 +46,6 @@ import scala.util.matching.Regex
 @RunWith(classOf[JUnitRunner])
 class WskSequenceTests
     extends TestHelpers
-    with JsHelpers
     with ScalatestRouteTest
     with WskTestHelpers {
 

--- a/tests/src/whisk/core/cli/test/SequenceMigrationTests.scala
+++ b/tests/src/whisk/core/cli/test/SequenceMigrationTests.scala
@@ -19,7 +19,6 @@ import java.util.Date
 import scala.concurrent.duration.DurationInt
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
 import common.Wsk
@@ -45,7 +44,6 @@ class SequenceMigrationTests
     extends TestHelpers
     with BeforeAndAfter
     with DbUtils
-    with JsHelpers
     with ScalatestRouteTest
     with WskTestHelpers {
 

--- a/tests/src/whisk/core/cli/test/WskActionSequenceTests.scala
+++ b/tests/src/whisk/core/cli/test/WskActionSequenceTests.scala
@@ -19,7 +19,6 @@ package whisk.core.cli.test
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import common.JsHelpers
 import common.TestHelpers
 import common.TestUtils
 import common.Wsk
@@ -34,7 +33,6 @@ import spray.json._
 @RunWith(classOf[JUnitRunner])
 class WskActionSequenceTests
     extends TestHelpers
-    with JsHelpers
     with WskTestHelpers {
 
     implicit val wskprops = WskProps()

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
-import akka.event.Logging.InfoLevel
+import akka.event.Logging.ErrorLevel
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.dockerEndpoint
@@ -70,7 +70,7 @@ class ContainerPoolTests extends FlatSpec
 
     assert(config.isValid)
 
-    val pool = new ContainerPool(config, 0, InfoLevel, true, true)
+    val pool = new ContainerPool(config, 0, ErrorLevel, true, true)
     pool.logDir = "/tmp"
 
     val datastore = WhiskEntityStore.datastore(config)

--- a/tests/src/whisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActionsApiTests.scala
@@ -416,7 +416,9 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         val stream = new ByteArrayOutputStream
         val printstream = new PrintStream(stream)
         val savedstream = authStore.outputStream
+        val savedVerbosity = entityStore.getVerbosity()
         entityStore.outputStream = printstream
+        entityStore.setVerbosity(akka.event.Logging.InfoLevel)
         try {
             // first request invalidates any previous entries and caches new result
             Put(s"$collectionPath/$name", content) ~> sealRoute(routes(creds)(transid())) ~> check {
@@ -453,6 +455,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             stream.reset()
         } finally {
             entityStore.outputStream = savedstream
+            entityStore.setVerbosity(savedVerbosity)
             stream.close()
             printstream.close()
         }

--- a/tests/src/whisk/core/controller/test/AuthenticateTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthenticateTests.scala
@@ -66,7 +66,9 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
         val stream = new ByteArrayOutputStream
         val printstream = new PrintStream(stream)
         val savedstream = authStore.outputStream
+        val savedVerbosity = authStore.getVerbosity()
         authStore.outputStream = printstream
+        authStore.setVerbosity(akka.event.Logging.InfoLevel)
         try {
             val user = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
             user.get should be(creds)
@@ -80,6 +82,7 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
             stream.reset()
         } finally {
             authStore.outputStream = savedstream
+            authStore.setVerbosity(savedVerbosity)
             stream.close()
             printstream.close()
         }

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
-import akka.event.Logging.{ InfoLevel, LogLevel }
+import akka.event.Logging.{ ErrorLevel, InfoLevel, LogLevel }
 import spray.http.BasicHttpCredentials
 import spray.json.DefaultJsonProtocol
 import spray.json.JsString
@@ -143,12 +143,12 @@ protected trait ControllerTestCommon
         }
     }
 
-    setVerbosity(InfoLevel)
-    Collection.initialize(entityStore, InfoLevel)
-    entityStore.setVerbosity(InfoLevel)
-    activationStore.setVerbosity(InfoLevel)
-    authStore.setVerbosity(InfoLevel)
-    entitlementProvider.setVerbosity(InfoLevel)
+    setVerbosity(ErrorLevel)
+    Collection.initialize(entityStore, ErrorLevel)
+    entityStore.setVerbosity(ErrorLevel)
+    activationStore.setVerbosity(ErrorLevel)
+    authStore.setVerbosity(ErrorLevel)
+    entitlementProvider.setVerbosity(ErrorLevel)
 
     val ACTIONS = Collection(Collection.ACTIONS)
     val TRIGGERS = Collection(Collection.TRIGGERS)

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -162,7 +162,7 @@ protected trait ControllerTestCommon
     }
 
     override def afterAll() {
-        println("Shutting down cloudant connections");
+        println("Shutting down db connections");
         entityStore.shutdown()
         activationStore.shutdown()
         authStore.shutdown()

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -36,6 +36,7 @@ import spray.json.DefaultJsonProtocol._
 import whisk.core.entitlement.Privilege
 import whisk.core.entity._
 import whisk.core.entity.size.SizeInt
+import whisk.utils.JsHelpers
 
 @RunWith(classOf[JUnitRunner])
 class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
@@ -553,5 +554,27 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
         val id = "213174381920559471141441e1"
         assert(ActivationId.unapply(id).isEmpty)
         assert(Try { ActivationId.serdes.read(JsString(id)) }.failed.get.getMessage.contains("too short"))
+    }
+
+    behavior of "Js Helpers"
+
+    it should "project paths from json object" in {
+        val js = JsObject("a" -> JsObject("b" -> JsObject("c" -> JsString("v"))), "b" -> JsString("v"))
+        JsHelpers.fieldPathExists(js) shouldBe true
+        JsHelpers.fieldPathExists(js, "a") shouldBe true
+        JsHelpers.fieldPathExists(js, "a", "b") shouldBe true
+        JsHelpers.fieldPathExists(js, "a", "b", "c") shouldBe true
+        JsHelpers.fieldPathExists(js, "a", "b", "c", "d") shouldBe false
+        JsHelpers.fieldPathExists(js, "b") shouldBe true
+        JsHelpers.fieldPathExists(js, "c") shouldBe false
+
+        JsHelpers.getFieldPath(js) shouldBe Some(js)
+        JsHelpers.getFieldPath(js, "x") shouldBe None
+        JsHelpers.getFieldPath(js, "b") shouldBe Some(JsString("v"))
+        JsHelpers.getFieldPath(js, "a") shouldBe Some(JsObject("b" -> JsObject("c" -> JsString("v"))))
+        JsHelpers.getFieldPath(js, "a", "b") shouldBe Some(JsObject("c" -> JsString("v")))
+        JsHelpers.getFieldPath(js, "a", "b", "c") shouldBe Some(JsString("v"))
+        JsHelpers.getFieldPath(js, "a", "b", "c", "d") shouldBe None
+        JsHelpers.getFieldPath(JsObject()) shouldBe Some(JsObject())
     }
 }


### PR DESCRIPTION
Fix couple of bugs in JsHelpers where there was an assumption that nested values are instances of JsObject. Move helper to whisk.common and make trait a singleton instead.

Also prevent logging of "malformed credentials" when there are none presented.
PG2/881.