### PR TITLE
Update Action Doc for Docker Actions

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -675,9 +675,6 @@ For the instructions that follow, assume that the Docker user ID is `janesmith` 
   $ cd dockerSkeleton
   ```
   ```
-  $ chmod +x buildAndPush.sh
-  ```
-  ```
   $ ./buildAndPush.sh janesmith/blackboxdemo
   ```
 


### PR DESCRIPTION
- Remove `chmod +x buildAndPush.sh` as file permissions are now perserved from .tar files

Closes https://github.com/openwhisk/openwhisk/issues/1129