### PR TITLE
Run invoker as privileged container

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -32,7 +32,7 @@
         --userns=host
         --privileged
         -v /sys/fs/cgroup:/sys/fs/cgroup
-        -v /usr/bin/runc:/usr/bin/runc
+        -v /usr/bin/docker-runc:/usr/bin/docker-runc
         -v /run/runc:/run/runc
         --name invoker{{play_hosts.index(inventory_hostname)}}
         --hostname invoker{{play_hosts.index(inventory_hostname)}}

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -32,8 +32,9 @@
         --userns=host
         --privileged
         -v /sys/fs/cgroup:/sys/fs/cgroup
-        -v /usr/bin/docker-runc:/usr/bin/docker-runc
         -v /run/runc:/run/runc
+        -v /usr/bin/docker-runc:/usr/bin/docker-runc
+        -v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1
         --name invoker{{play_hosts.index(inventory_hostname)}}
         --hostname invoker{{play_hosts.index(inventory_hostname)}}
         --restart {{ docker.restart.policy }}
@@ -51,6 +52,7 @@
         --userns host
         {{docker_registry}}{{ docker_image_prefix }}/invoker:{{docker_image_tag}}
         /bin/sh -c "/invoker/bin/invoker {{play_hosts.index(inventory_hostname)}} >> /logs/invoker{{play_hosts.index(inventory_hostname)}}_logs.log 2>&1"
+  register: invokerOutput
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved
 

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -28,6 +28,12 @@
 - name: start invoker using docker cli
   shell: >
         docker run -d
+        --pid=host
+        --userns=host
+        --privileged
+        -v /sys/fs/cgroup:/sys/fs/cgroup
+        -v /usr/bin/runc:/usr/bin/runc
+        -v /run/runc:/run/runc
         --name invoker{{play_hosts.index(inventory_hostname)}}
         --hostname invoker{{play_hosts.index(inventory_hostname)}}
         --restart {{ docker.restart.policy }}

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -25,16 +25,18 @@
     mode: 0777
   become: true
 
+- name: define options when deploying invoker on Ubuntu
+  set_fact:
+    linuxOptions: "-v /sys/fs/cgroup:/sys/fs/cgroup -v /run/runc:/run/runc -v {{ runcLocation | default('/usr/bin/docker-runc') }}:/usr/bin/docker-runc -v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"
+  when: whisk_version_name != "mac"
+
 - name: start invoker using docker cli
   shell: >
         docker run -d
-        --pid=host
         --userns=host
+        --pid=host
         --privileged
-        -v /sys/fs/cgroup:/sys/fs/cgroup
-        -v /run/runc:/run/runc
-        -v /usr/bin/docker-runc:/usr/bin/docker-runc
-        -v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1
+        {{ linuxOptions | default('') }}
         --name invoker{{play_hosts.index(inventory_hostname)}}
         --hostname invoker{{play_hosts.index(inventory_hostname)}}
         --restart {{ docker.restart.policy }}
@@ -49,10 +51,9 @@
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs
         -v {{dockerInfo["json"]["DockerRootDir"]}}/containers/:/containers
         -p {{invoker.port + play_hosts.index(inventory_hostname)}}:8080
-        --userns host
         {{docker_registry}}{{ docker_image_prefix }}/invoker:{{docker_image_tag}}
         /bin/sh -c "/invoker/bin/invoker {{play_hosts.index(inventory_hostname)}} >> /logs/invoker{{play_hosts.index(inventory_hostname)}}_logs.log 2>&1"
-  register: invokerOutput
+
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved
 

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -29,7 +29,7 @@ object RuncUtils extends Logging {
     }
 
     /**
-     * Synchronously runs the given docker command returning stdout if successful.
+     * Synchronously runs the given runc command returning stdout if successful.
      */
     def runRuncCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): String = {
         val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD("runc_" + args(0)))

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -60,7 +60,7 @@ object RuncUtils extends Logging {
      *  Any global flags are added here.
      */
     private def getRuncCmd(): Seq[String] = {
-        val runcBin = "/usr/bin/runc"
+        val runcBin = "/usr/bin/docker-runc"
         Seq(runcBin)
     }
 

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.container
+
+import akka.event.Logging.ErrorLevel
+
+import whisk.common.{ Logging, SimpleExec, TransactionId, LoggingMarkers, PrintStreamEmitter }
+
+object RuncUtils extends Logging {
+
+    private implicit val emitter: PrintStreamEmitter = this
+
+    def list()(implicit transid: TransactionId): String = {
+        runRuncCmd(false, Seq("list"))
+    }
+
+    /**
+     * Synchronously runs the given docker command returning stdout if successful.
+     */
+    def runRuncCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): String = {
+        val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD("runc_" + args(0)))
+        try {
+            val fullCmd = getRuncCmd() ++ args
+
+            val (stdout, stderr, exitCode) = SimpleExec.syncRunCmd(fullCmd)
+
+            if (exitCode == 0) {
+                transid.finished(this, start)
+                stdout.trim
+            } else {
+                if (!skipLogError) {
+                    transid.failed(this, start, s"stdout:\n$stdout\nstderr:\n$stderr", ErrorLevel)
+                } else {
+                    transid.failed(this, start)
+                }
+                "error"
+            }
+        } catch {
+            case t: Throwable =>
+                transid.failed(this, start, "error: " + t.getMessage, ErrorLevel)
+                "error"
+        }
+    }
+
+    /*
+     *  Any global flags are added here.
+     */
+    private def getRuncCmd(): Seq[String] = {
+        val runcBin = "/usr/bin/runc"
+        Seq(runcBin)
+    }
+
+
+}

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -38,7 +38,7 @@ import whisk.connector.kafka.{ KafkaConsumerConnector, KafkaProducerConnector }
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.{ consulServer, dockerImagePrefix, dockerRegistry, kafkaHost, logsDir, servicePort, whiskVersion }
 import whisk.core.connector.{ ActivationMessage, CompletionMessage }
-import whisk.core.container.{ BlackBoxContainerError, ContainerPool, Interval, RunResult, WhiskContainer, WhiskContainerError }
+import whisk.core.container.{ BlackBoxContainerError, ContainerPool, Interval, RunResult, WhiskContainer, WhiskContainerError, RuncUtils }
 import whisk.core.dispatcher.{ Dispatcher, MessageHandler }
 import whisk.core.dispatcher.ActivationFeed.{ ActivationNotification, ContainerReleased, FailedActivation }
 import whisk.core.entity._
@@ -77,6 +77,18 @@ class Invoker(
         authStore.setVerbosity(level)
         activationStore.setVerbosity(level)
         producer.setVerbosity(level)
+        checkRuncAccess()
+    }
+
+    /**
+     *  Test method that determines whether there is access from the invoker (inside a container)
+     *  to the hosts's runc binary.  Logging shows success of failure but the method returns
+     *  without exception in any case.
+     */
+    def checkRuncAccess() {
+        implicit val tid = TransactionId.invokerNanny
+        val runcListResult = RuncUtils.list()
+        info(this, s"runc list result: ${runcListResult}")
     }
 
     /**


### PR DESCRIPTION
The invoker container needs access to privileged operations that are not available through the docker daemon.  In particular, access to the underlying runc binary is needed to improve performance.