### PR TITLE
Clarify Node.js action sample

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -343,7 +343,6 @@ First, `package.json`:
 ```
 {
   "name": "my-action",
-  "version": "1.0.0",
   "main": "index.js",
   "dependencies" : {
     "left-pad" : "1.1.3"
@@ -362,7 +361,7 @@ function myAction(args) {
 exports.main = myAction;
 ```
 
-Note that the action is exposed through `exports.main`; the action handler itself can have any name, as long as it conforms to the usual signature of accepting an object and returning an object (or a `Promise` of an object).
+Note that the action is exposed through `exports.main`; the action handler itself can have any name, as long as it conforms to the usual signature of accepting an object and returning an object (or a `Promise` of an object). Per Node.js convention, you must either name this file `index.js` or specify the the file name you prefer as the `main` property in package.json.
 
 To create an OpenWhisk action from this package:
 


### PR DESCRIPTION
Remove `version` attribute from package.json. OpenWhisk doesn't explicitly use it and it could be confused with the OW action version.
Clarify that the name of the main file must either be "index.js" OR specified as the `main` property in package.json

Closes #1774 