### PR TITLE
Reject activation if entity size exceeds limit

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationEntityLimit.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+import whisk.core.entity.size.SizeInt
+
+/**
+ * ActivationEntityLimit defines the limits on the input/output payloads for actions
+ * and triggers. This refers to the invoke-time parameters for actions or the trigger-time
+ * parameters for triggers.
+ */
+protected[core] object ActivationEntityLimit {
+    protected[core] val MAX_ACTIVATION_ENTITY_LIMIT = 1.MB
+}

--- a/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
@@ -34,8 +34,8 @@ import whisk.core.entity.size.SizeInt
  * The constructor is private so that argument requirements are checked and normalized
  * before creating a new instance.
  *
- * FIXME: Int because of JSON deserializer vs. <code>ByteSize</code> and compatibility
- * with <code>MemoryLimit</code>
+ * Argument type is Int because of JSON deserializer vs. <code>ByteSize</code> and
+ * compatibility with <code>MemoryLimit</code>
  *
  * @param megabytes the memory limit in megabytes for the action
  */

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskEntity.scala
@@ -20,12 +20,10 @@ import java.time.Clock
 import java.time.Instant
 
 import scala.Stream
-import scala.language.postfixOps
 import scala.util.Try
 
 import spray.json._
 import whisk.core.database.DocumentUnreadable
-import whisk.core.entity.size.SizeInt
 import whisk.http.Messages
 
 /**
@@ -95,6 +93,8 @@ abstract class WhiskEntity protected[entity] (en: EntityName) extends WhiskDocum
 object WhiskEntity {
 
     val sharedFieldName = "publish"
+    val paramsFieldName = "parameters"
+    val annotationsFieldName = "annotations"
 
     /**
      * Gets fully qualified name of an activation based on its namespace and activation id.
@@ -153,14 +153,29 @@ object LimitedWhiskEntityPut extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LimitedWhiskEntityPut.apply)
 }
 
+case class SizeError(field: String, is: ByteSize, allowed: ByteSize)
+
 case class LimitedWhiskEntityPut(
     exec: Option[Exec] = None,
     parameters: Option[Parameters] = None,
     annotations: Option[Parameters] = None) {
 
-    def isWithinSizeLimits: Boolean = {
-        exec.map(_.size).getOrElse(0 B) <= Exec.sizeLimit &&
-            parameters.map(_.size).getOrElse(0 B) <= Parameters.sizeLimit &&
-            annotations.map(_.size).getOrElse(0 B) <= Parameters.sizeLimit
+    def isWithinSizeLimits: Option[SizeError] = {
+        exec.flatMap { e =>
+            val is = e.size
+            if (is <= Exec.sizeLimit) None else Some {
+                SizeError(WhiskAction.execFieldName, is, Exec.sizeLimit)
+            }
+        } orElse parameters.flatMap { p =>
+            val is = p.size
+            if (is <= Parameters.sizeLimit) None else Some {
+                SizeError(WhiskEntity.paramsFieldName, is, Parameters.sizeLimit)
+            }
+        } orElse annotations.flatMap { a =>
+            val is = a.size
+            if (is <= Parameters.sizeLimit) None else Some {
+                SizeError(WhiskEntity.annotationsFieldName, is, Parameters.sizeLimit)
+            }
+        }
     }
 }

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -24,14 +24,15 @@ import spray.http.MediaType
 import spray.http.StatusCode
 import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
-import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
-import spray.json.DefaultJsonProtocol._
+import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.json._
+import spray.json.DefaultJsonProtocol._
 import spray.routing.Directives
 import spray.routing.Rejection
 import spray.routing.StandardRoute
 import whisk.common.TransactionId
+import whisk.core.entity.SizeError
 
 object Messages {
     /** Standard message for reporting resource conflicts. */
@@ -84,6 +85,11 @@ object Messages {
     /** Error messages for activations. */
     val abnormalInitialization = "The action did not initialize and exited unexpectedly."
     val abnormalRun = "The action did not produce a valid response and exited unexpectedly."
+
+    /** Error message for size conformance. */
+    def entityTooBig(error: SizeError) = {
+        s"${error.field} larger than allowed: ${error.is.toBytes} > ${error.allowed.toBytes} bytes."
+    }
 
     /** Error for meta api. */
     val propertyNotFound = "Response does not include requested property."


### PR DESCRIPTION
Action and trigger activations are subject to limits on the content payload. This pull request enforces the limit earlier in the pipeline.

PG2//971 approved.
Fixes #1059.
