### PR TITLE
Allow for binary data response for http actions.

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -90,6 +90,9 @@ object Messages {
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
     val contentTypeNotSupported = "Content type not supported."
     val contentTypeRequired = "Content type is missing."
+    val responseNotReady = "Response not yet ready."
+    val httpUnknownContentType = "Response did not specify a known content-type."
+    val httpContentTypeError = "Response type in header did not match generated content type."
 
     def invalidInitResponse(actualResponse: String) = {
         "The action failed during initialization" + {


### PR DESCRIPTION
The http web action must respond with either a plain text body or a base64 encoded body.
The header content-type must be set to interpret the reponse if base64 encoded body is given. (This applies to a JSON response as well.) Content-type must be one of known Spray types - no custom headers permitted.

This PR can subsume #1771 - the last commit adds binary support. PG1/1113.
Fixes #567.