### PR TITLE
Fix revision preserving behaviour of WhiskAction

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -123,9 +123,7 @@ case class WhiskAction(
      * Merges parameters (usually from package) with existing action parameters.
      * Existing parameters supersede those in p.
      */
-    def inherit(p: Parameters) = {
-        WhiskAction(namespace, name, exec, p ++ parameters, limits, version, publish, annotations)
-    }
+    def inherit(p: Parameters) = copy(parameters = p ++ parameters).revision[WhiskAction](rev)
 
     /**
      * Gets the container image name for the action (if one is required).
@@ -192,7 +190,7 @@ case class WhiskAction(
                 val newExec = SequenceExec(components map {
                     c => FullyQualifiedEntityName(c.path.resolveNamespace(userNamespace), c.name)
                 })
-                WhiskAction(namespace, name, newExec, parameters, limits, version, publish, annotations)
+                copy(exec = newExec).revision[WhiskAction](rev)
             case _ => this
         }
     }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -89,35 +89,8 @@ case class WhiskActivation(
         }
     }
 
-    def withoutLogs = WhiskActivation(
-        namespace = namespace,
-        name = name,
-        subject = subject,
-        activationId = activationId,
-        start = start,
-        end = end,
-        cause = cause,
-        response = response,
-        logs = ActivationLogs(),
-        version = version,
-        publish = publish,
-        annotations = annotations,
-        duration = duration)
-
-    def withLogs(logs: ActivationLogs) = WhiskActivation(
-        namespace = namespace,
-        name = name,
-        subject = subject,
-        activationId = activationId,
-        start = start,
-        end = end,
-        cause = cause,
-        response = response,
-        logs = logs,
-        version = version,
-        publish = publish,
-        annotations = annotations,
-        duration = duration)
+    def withoutLogs = copy(logs = ActivationLogs()).revision[WhiskActivation](rev)
+    def withLogs(logs: ActivationLogs) = copy(logs = logs).revision[WhiskActivation](rev)
 }
 
 object WhiskActivation

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskPackage.scala
@@ -80,17 +80,13 @@ case class WhiskPackage(
      * Merges parameters into existing set of parameters for package.
      * Existing parameters supersede those in p.
      */
-    def inherit(p: Parameters): WhiskPackage = {
-        WhiskPackage(namespace, name, binding, p ++ parameters, version, publish, annotations)
-    }
+    def inherit(p: Parameters): WhiskPackage = copy(parameters = p ++ parameters).revision[WhiskPackage](rev)
 
     /**
      * Merges parameters into existing set of parameters for package.
      * The parameters from p supersede parameters from this.
      */
-    def mergeParameters(p: Parameters): WhiskPackage = {
-        WhiskPackage(namespace, name, binding, parameters ++ p, version, publish, annotations)
-    }
+    def mergeParameters(p: Parameters): WhiskPackage = copy(parameters = parameters ++ p).revision[WhiskPackage](rev)
 
     /**
      * Gets the full path for the package.

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskTrigger.scala
@@ -76,7 +76,7 @@ case class WhiskTrigger(
 
     def toJson = WhiskTrigger.serdes.write(this).asJsObject
 
-    def withoutRules = WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, None)
+    def withoutRules = copy(rules = None).revision[WhiskTrigger](rev)
 
     /**
      * Inserts the rulename, its status and the action to be fired into the trigger.
@@ -87,8 +87,8 @@ case class WhiskTrigger(
      */
     def addRule(rulename: FullyQualifiedEntityName, rule: ReducedRule) = {
         val entry = rulename -> rule
-        val links = rules getOrElse Map[FullyQualifiedEntityName, ReducedRule]()
-        WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
+        val links = rules getOrElse Map.empty[FullyQualifiedEntityName, ReducedRule]
+        copy(rules = Some(links + entry)).revision[WhiskTrigger](docinfo.rev)
     }
 
     /**
@@ -98,7 +98,7 @@ case class WhiskTrigger(
      * trigger. After removing the rule, it won't be fired anymore by this trigger.
      */
     def removeRule(rule: FullyQualifiedEntityName) = {
-        WhiskTrigger(namespace, name, parameters, limits, version, publish, annotations, rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
+        copy(rules = rules.map(_ - rule)).revision[WhiskTrigger](docinfo.rev)
     }
 }
 

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -109,6 +109,9 @@ class Invoker(
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;
         // if the doc revision is missing, then bypass cache
+        if (actionid.rev == DocRevision()) {
+            error(this, s"revision was not provided for ${actionid.id}")
+        }
         WhiskAction.get(entityStore, actionid.id, actionid.rev, fromCache = actionid.rev != DocRevision()) onComplete {
             case Success(action) =>
                 // only Exec instances that are subtypes of CodeExec reach the invoker

--- a/tests/src/whisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/whisk/core/entity/test/WhiskEntityTests.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity.test
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+import whisk.core.entity.EntityPath
+import whisk.core.entity.EntityName
+import whisk.core.entity.Exec
+import whisk.core.entity.WhiskAction
+import whisk.core.entity.DocRevision
+import whisk.core.entity.Parameters
+import whisk.core.entity.FullyQualifiedEntityName
+import whisk.core.entity.SequenceExec
+import whisk.core.entity.WhiskPackage
+import whisk.core.entity.WhiskActivation
+import whisk.core.entity.Subject
+import whisk.core.entity.ActivationId
+import java.time.Instant
+import whisk.core.entity.ActivationLogs
+import whisk.core.entity.WhiskTrigger
+import whisk.core.entity.ReducedRule
+import whisk.core.entity.Status
+
+@RunWith(classOf[JUnitRunner])
+class WhiskEntityTests extends FlatSpec with Matchers {
+
+    val namespace = EntityPath("testspace")
+    val name = EntityName("testname")
+    val revision = DocRevision("test")
+
+    behavior of "WhiskAction"
+
+    it should "correctly inherit parameters and preserve revision through the process" in {
+        def withParameters(p: Parameters) = WhiskAction(
+            namespace,
+            name,
+            Exec.js("js1"), parameters = p).revision[WhiskAction](revision)
+
+        val toInherit = Parameters("testParam", "testValue")
+        Seq(Parameters(),
+            Parameters("testParam2", "testValue"),
+            Parameters("testParam", "testValue2")
+        ).foreach { params =>
+                val action = withParameters(params)
+                val inherited = action.inherit(toInherit)
+                inherited shouldBe action.copy(parameters = toInherit ++ action.parameters)
+                inherited.rev shouldBe action.rev
+            }
+    }
+
+    it should "correctly resolve default namespace and preserve its revision through the process" in {
+        val user = "testuser"
+        val sequenceAction = FullyQualifiedEntityName(EntityPath("_"), EntityName("testaction"))
+        val action = WhiskAction(
+            namespace,
+            name,
+            Exec.sequence(Vector(sequenceAction))).revision[WhiskAction](revision)
+
+        val resolved = action.resolve(EntityName(user))
+        resolved.exec.asInstanceOf[SequenceExec].components.head shouldBe sequenceAction.copy(path = EntityPath(user))
+        action.rev shouldBe resolved.rev
+    }
+
+    behavior of "WhiskPackage"
+
+    it should "correctly inherit parameters and preserve revision through the process" in {
+        def withParameters(p: Parameters) = WhiskPackage(
+            namespace,
+            name, parameters = p).revision[WhiskPackage](revision)
+
+        val toInherit = Parameters("testParam", "testValue")
+        Seq(Parameters(),
+            Parameters("testParam2", "testValue"),
+            Parameters("testParam", "testValue2")
+        ).foreach { params =>
+                val pkg = withParameters(params)
+                val inherited = pkg.inherit(toInherit)
+                inherited shouldBe pkg.copy(parameters = toInherit ++ pkg.parameters)
+                inherited.rev shouldBe pkg.rev
+            }
+    }
+
+    it should "correctly merge parameters and preserve revision through the process" in {
+        def withParameters(p: Parameters) = WhiskPackage(
+            namespace,
+            name, parameters = p).revision[WhiskPackage](revision)
+
+        val toOverride = Parameters("testParam", "testValue")
+        Seq(Parameters(),
+            Parameters("testParam2", "testValue"),
+            Parameters("testParam", "testValue2")
+        ).foreach { params =>
+                val pkg = withParameters(params)
+                val inherited = pkg.mergeParameters(toOverride)
+                inherited shouldBe pkg.copy(parameters = pkg.parameters ++ toOverride)
+                inherited.rev shouldBe pkg.rev
+            }
+    }
+
+    behavior of "WhiskActivation"
+
+    it should "add and remove logs and preserve revision in the process" in {
+        val activation = WhiskActivation(
+            namespace,
+            name,
+            Subject(),
+            ActivationId(),
+            Instant.now(),
+            Instant.now()).revision[WhiskActivation](revision)
+        val logs = ActivationLogs(Vector("testlog"))
+
+        val withLogs = activation.withLogs(logs)
+        withLogs shouldBe activation.copy(logs = logs)
+        withLogs.rev shouldBe activation.rev
+
+        val withoutLogs = withLogs.withoutLogs
+        withoutLogs shouldBe activation
+        withoutLogs.rev shouldBe activation.rev
+    }
+
+    behavior of "WhiskTrigger"
+
+    it should "add and remove rules and preserve revision in the process" in {
+        val fqn = FullyQualifiedEntityName(namespace, name)
+        val trigger = WhiskTrigger(
+            namespace,
+            name).revision[WhiskTrigger](revision)
+        val rule = ReducedRule(fqn, Status.ACTIVE)
+
+        // Add a rule
+        val ruleAdded = trigger.addRule(fqn, rule)
+        ruleAdded.rules shouldBe Some(Map(fqn -> rule))
+        ruleAdded.rev shouldBe trigger.rev
+
+        // Remove the rule
+        val ruleRemoved = ruleAdded.removeRule(fqn)
+        ruleRemoved.rules shouldBe Some(Map.empty[FullyQualifiedEntityName, ReducedRule])
+        ruleRemoved.rev shouldBe trigger.rev
+
+        // Remove all rules
+        val rulesRemoved = ruleAdded.withoutRules
+        rulesRemoved.rules shouldBe None
+        rulesRemoved.rev shouldBe trigger.rev
+    }
+}


### PR DESCRIPTION
Constructing new objects results in a loss of the DocumentRevision and thus breaks caching in the invoker.