### PR TITLE
Increase timeout value for entitlement tests

### DIFF
--- a/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/whisk/core/controller/test/EntitlementProviderTests.scala
@@ -18,7 +18,6 @@ package whisk.core.controller.test
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
-import scala.language.postfixOps
 
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
@@ -50,7 +49,7 @@ class EntitlementProviderTests
 
     behavior of "Entitlement Provider"
 
-    val requestTimeout = 1 second
+    val requestTimeout = 10.seconds
     val someUser = Subject().toIdentity(AuthKey())
     val adminUser = Subject("admin").toIdentity(AuthKey())
     val guestUser = Subject("anonym").toIdentity(AuthKey())


### PR DESCRIPTION
Various entitlement tests often throw java.util.concurrent.TimeoutException: Futures timed out after [1 second].  Increasing the timeout value.