### PR TITLE
Limit entity names.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationId.scala
@@ -24,14 +24,10 @@ import scala.util.Success
 import scala.util.Try
 
 import spray.json.DefaultJsonProtocol.StringJsonFormat
-import spray.json.DeserializationException
-import spray.json.JsNumber
-import spray.json.JsObject
-import spray.json.JsString
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.pimpAny
+import spray.json._
+
+import whisk.core.entity.size._
+import whisk.http.Messages
 
 /**
  * An activation id, is a unique id assigned to activations (invoke action or fire trigger).
@@ -97,12 +93,12 @@ protected[core] object ActivationId extends ArgNormalizer[ActivationId] {
             value match {
                 case JsString(s) => stringToActivationId(s)
                 case JsNumber(n) => bigIntToActivationId(n.toBigInt)
-                case _           => deserializationError("activation id is malformed")
+                case _           => deserializationError(Messages.activationIdIllegal)
             }
         } match {
             case Success(a)                                 => a
             case Failure(DeserializationException(t, _, _)) => deserializationError(t)
-            case Failure(t)                                 => deserializationError("activation id is malformed")
+            case Failure(t)                                 => deserializationError(Messages.activationIdIllegal)
         }
     }
 
@@ -124,10 +120,9 @@ protected[core] object ActivationId extends ArgNormalizer[ActivationId] {
                 val up = new BigInteger(s.substring(16, 32), 16)
                 val uuid = new java.util.UUID(lb.longValue, up.longValue)
                 ActivationId(uuid)
-            } else if (s.length > 32) {
-                deserializationError("activation id is malformed (too long)")
-            } else {
-                deserializationError("activation id is malformed (too short)")
+            } else deserializationError {
+                Messages.activationIdLengthError(
+                    SizeError("Activation id", s.length.B, 32.B))
             }
         } else {
             ActivationId(java.util.UUID.fromString(s))

--- a/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/EntityPath.scala
@@ -175,12 +175,14 @@ protected[core] class EntityName private (val name: String) extends AnyVal {
 }
 
 protected[core] object EntityName {
+    protected[core] val ENTITY_NAME_MAX_LENGTH = 256
+
     /**
      * Allowed path part or entity name format (excludes path separator): first character
      * is a letter|digit|underscore, followed by one or more allowed characters in [\w@ .-].
      * The name may not have trailing white space.
      */
-    protected[core] val REGEX = """\A([\w]|[\w][\w@ .-]*[\w@.-]+)\z"""
+    protected[core] val REGEX = raw"\A([\w]|[\w][\w@ .-]{0,${ENTITY_NAME_MAX_LENGTH-2}}[\w@.-])\z"
 
     /**
      * Unapply method for convenience of case matching.

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -61,6 +61,17 @@ object Messages {
 
     /** Standard error message for malformed fully qualified entity names. */
     val malformedFullyQualifiedEntityName = "The fully qualified name of the entity must contain at least the namespace and the name of the entity."
+    def entityNameTooLong(error: SizeError) = {
+        s"${error.field} longer than allowed: ${error.is.toBytes} > ${error.allowed.toBytes}."
+    }
+    val entityNameIllegal = "The name of the entity contains illegal characters."
+    val namespaceIllegal = "The namespace contains illegal characters."
+
+    /** Standard error for malformed activation id. */
+    val activationIdIllegal = "The activation id is not valid."
+    def activationIdLengthError(error: SizeError) = {
+        s"${error.field} length is ${error.is.toBytes} but must be ${error.allowed.toBytes}."
+    }
 
     /** Error messages for sequence actions. */
     val sequenceIsTooLong = "Too many actions in the sequence."

--- a/core/controller/src/main/scala/whisk/core/controller/Activations.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Activations.scala
@@ -17,31 +17,28 @@
 package whisk.core.controller
 
 import java.time.Instant
-import scala.util.Try
+
+import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
+
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
 import spray.httpx.unmarshalling.DeserializationError
 import spray.httpx.unmarshalling.FromStringDeserializer
 import spray.httpx.unmarshalling.MalformedContent
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.DeserializationException
 import spray.routing.Directives
+import spray.json.DefaultJsonProtocol.RootJsObjectFormat
+import spray.json._
+
 import whisk.common.TransactionId
-import whisk.core.entity.ActivationId
-import whisk.core.entity.DocId
-import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
-import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskEntity
-import whisk.core.entity.WhiskActivationStore
-import whisk.core.entity.types.ActivationStore
 import whisk.core.entitlement.Collection
 import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
-import scala.language.postfixOps
-import whisk.core.entity.Identity
+import whisk.core.entity._
+import whisk.core.entity.types.ActivationStore
+import whisk.http.Messages
 
 object WhiskActivationsApi {
     def requiredProperties = WhiskActivationStore.requiredProperties
@@ -74,7 +71,7 @@ trait WhiskActivationsApi
         val activationId = Try { ActivationId(n) }
         validate(activationId.isSuccess, activationId match {
             case Failure(DeserializationException(t, _, _)) => t
-            case _ => "invalid activation id"
+            case _ => Messages.activationIdIllegal
         }) & extract(_ => n)
     }
 

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -32,9 +32,10 @@ import whisk.common.TransactionId
 import whisk.core.entitlement._
 import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Resource
-import whisk.core.entity.EntityPath
-import whisk.core.entity.Identity
+import whisk.core.entity._
+import whisk.core.entity.size._
 import whisk.http.ErrorResponse.terminate
+import whisk.http.Messages
 
 /** A trait for routes that require entitlement checks. */
 trait BasicAuthorizedRouteProvider extends Directives with Logging {
@@ -87,9 +88,21 @@ trait BasicAuthorizedRouteProvider extends Directives with Logging {
 
     /** Extracts namespace for user from the matched path segment. */
     protected def namespace(user: Identity, ns: String) = {
-        validate(isNamespace(ns), "namespace contains invalid characters") &
-            extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace.asString else ns))
+        validate(isNamespace(ns), {
+            if (ns.length > EntityName.ENTITY_NAME_MAX_LENGTH) {
+                Messages.entityNameTooLong(
+                    SizeError(
+                        namespaceDescriptionForSizeError,
+                        ns.length.B,
+                        EntityName.ENTITY_NAME_MAX_LENGTH.B))
+            } else {
+                Messages.namespaceIllegal
+            }
+        }) & extract(_ => EntityPath(if (EntityPath(ns) == EntityPath.DEFAULT) user.namespace.asString else ns))
     }
+
+    /** Validates entity name from the matched path segment. */
+    protected val namespaceDescriptionForSizeError = "Namespace"
 
     /** Extracts the HTTP method which is used to determine privilege for resource. */
     protected val requestMethod = extract(_.request.method)

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -145,8 +145,20 @@ trait WhiskCollectionAPI
     }
 
     /** Validates entity name from the matched path segment. */
+    protected val segmentDescriptionForSizeError = "Name segement"
+
     protected override final def entityname(s: String) = {
-        validate(isEntity(s), s"name '$s' contains illegal characters") & extract(_ => s)
+        validate(isEntity(s), {
+            if (s.length > EntityName.ENTITY_NAME_MAX_LENGTH) {
+                Messages.entityNameTooLong(
+                    SizeError(
+                        segmentDescriptionForSizeError,
+                        s.length.B,
+                        EntityName.ENTITY_NAME_MAX_LENGTH.B))
+            } else {
+                Messages.entityNameIllegal
+            }
+        }) & extract(_ => s)
     }
 
     /** Confirms that a path segment is a valid entity name. Used to reject invalid entity names. */

--- a/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/ActivationsApiTests.scala
@@ -28,6 +28,7 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.core.controller.WhiskActivationsApi
 import whisk.core.entity._
+import whisk.core.entity.size._
 import whisk.http.ErrorResponse
 import whisk.http.Messages
 
@@ -302,12 +303,12 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
 
         Get(s"$collectionPath/$tooshort") ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] should include("too short")
+            responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", tooshort.length.B, 32.B))
         }
 
         Get(s"$collectionPath/$toolong") ~> sealRoute(routes(creds)) ~> check {
             status should be(BadRequest)
-            responseAs[String] should include("too long")
+            responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", toolong.length.B, 32.B))
         }
 
         Get(s"$collectionPath/$malformed") ~> sealRoute(routes(creds)) ~> check {


### PR DESCRIPTION
Limit namespace, package, and entity names to 256 characters per segment.
Separating this from #1780.
PG2/1005.