### PR TITLE
Handle application errors in web actions.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ActivationResult.scala
@@ -39,9 +39,9 @@ protected[core] case class ActivationResponse private (
     }
 
     def isSuccess = statusCode == ActivationResponse.Success
-    def isWhiskError = statusCode == ActivationResponse.WhiskError
-    def isContainerError = statusCode == ActivationResponse.ContainerError
     def isApplicationError = statusCode == ActivationResponse.ApplicationError
+    def isContainerError = statusCode == ActivationResponse.ContainerError
+    def isWhiskError = statusCode == ActivationResponse.WhiskError
 
     override def toString = toJsonObject.compactPrint
 }
@@ -50,10 +50,10 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
     /* The field name that is universally recognized as the marker of an error, from the application or otherwise. */
     val ERROR_FIELD: String = "error"
 
-    val Success          = 0
-    val ApplicationError = 1
-    val ContainerError   = 2
-    val WhiskError       = 3
+    val Success          = 0 // action ran successfully and produced a result
+    val ApplicationError = 1 // action ran but there was an error and it was handled
+    val ContainerError   = 2 // action ran but failed to handle an error, or action did not run and failed to initialize
+    val WhiskError       = 3 // internal system error
 
     protected[core] def messageForCode(code: Int) = {
         require(code >= 0 && code <= 3)

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -52,10 +52,10 @@ object Messages {
     val resourceDoesNotExist = "The requested resource does not exist."
 
     /** Standard message for too many activation requests within a rolling time window. */
-    val tooManyRequests = "Too many requests from user in a given amount of time."
+    val tooManyRequests = "Too many requests in a given amount of time for namespace."
 
     /** Standard message for too many concurrent activation requests within a time window. */
-    val tooManyConcurrentRequests = "The user has sent too many concurrent requests."
+    val tooManyConcurrentRequests = "Too many concurrent requests in flight for namespace."
 
     /** Standard message when supplied authkey is not authorized for an operation. */
     val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
@@ -112,6 +112,7 @@ object Messages {
     val responseNotReady = "Response not yet ready."
     val httpUnknownContentType = "Response did not specify a known content-type."
     val httpContentTypeError = "Response type in header did not match generated content type."
+    val errorProcessingRequest = "There was an error processing your request."
 
     def invalidInitResponse(actualResponse: String) = {
         "The action failed during initialization" + {

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -107,8 +107,8 @@ object Messages {
     /** Error for meta api. */
     val propertyNotFound = "Response does not include requested property."
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
-    val contentTypeNotSupported = "Content type not supported."
-    val contentTypeRequired = "Content type is missing."
+    val contentTypeNotSupported = """Content type must be specified and one of ["json", "html", "http", "text"]."""
+
     val responseNotReady = "Response not yet ready."
     val httpUnknownContentType = "Response did not specify a known content-type."
     val httpContentTypeError = "Response type in header did not match generated content type."

--- a/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/whisk/core/controller/test/ControllerTestCommon.scala
@@ -69,7 +69,7 @@ protected trait ControllerTestCommon
     override val loadBalancer = new DegenerateLoadBalancerService(whiskConfig)
 
     override val iam = new NamespaceProvider(whiskConfig, forceLocal = true)
-    override val entitlementProvider: EntitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer, iam)
+    override lazy val entitlementProvider: EntitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer, iam)
 
     override val activationIdFactory = new ActivationId.ActivationIdGenerator() {
         // need a static activation id to test activations api

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -482,7 +482,6 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
             failThrottleForSubject = Some(subject)
             val content = JsObject("extra" -> "read all about it".toJson, "yummy" -> true.toJson)
             Post(s"/$routePath/heavymeta?a=b&c=d", content) ~> sealRoute(routes(creds)) ~> check {
-                println(subject)
                 status shouldBe {
                     // activations are counted against to the authenticated user's quota
                     if (subject == systemId) OK else {
@@ -798,7 +797,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
                 }
             }
 
-        // this should fail for reasong quota
+        // this should fail for exceeding quota
         Seq(s"$systemId/proxy/export_c.text/content/z").
             foreach { path =>
                 failThrottleForSubject = Some(systemId)

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -847,7 +847,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         protected[core] override def checkThrottles(user: Identity)(
             implicit transid: TransactionId): Future[Unit] = {
             val subject = user.subject
-            debug(this, s"test throttle is checking user '$subject' has not exceeded activation quota")
+            logging.debug(this, s"test throttle is checking user '$subject' has not exceeded activation quota")
 
             failThrottleForSubject match {
                 case Some(subject) if subject == user.subject =>


### PR DESCRIPTION
If the activaiton result is an activation error, treat it like a successful
activation with one distinction: rather than projecting the result per the
path specified in the URL, project only the error field. The resulting JSON
value must be of the expected type otherwise an appropriate error is reported.

This change will allow an http response to set it own status code on error
for example, but also means that the action producing the error response must
be aware of the extension type.

The extension type is not passed to the action - perhaps it should be. Even so,
in the case of a sequence, one would need to forward this type to individual
components to handle the error case (or result) correctly.

@starpit FYI. This adopt's @markusthoemmes' suggestion but does not solve the bigger issue discussed in #1793.

PG2/1006.