### PR TITLE
Remove Mentions of Namespace CLI Configuration Requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ There are two required properties to configure in order to use the CLI:
 1. **API host** (name or IP address) for the OpenWhisk deployment you want to use.
 2. **Authorization key** (username and password) which grants you access to the OpenWhisk API.
 
-The API host can be acquired from the `edge.host` property in `whisk.properties` file, which is generated during
+The API host can be acquired from the `api.host` property in `whisk.properties` file, which is generated during
 deployment of OpenWhisk. Run the following command from your `openwhisk` directory to set the API host:
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,46 +21,28 @@ A list of downloadable CLIs for various operating systems, and CPU architectures
 location `{BASE URL}/cli/go/download`. The `{BASE URL}` is the OpenWhisk API hostname or IP address
 (e.g., openwhisk.ng.bluemix.net).
 
-There are three properties to configure the CLI with:
+There are two required properties to configure in order to use the CLI:
 
 1. **API host** (name or IP address) for the OpenWhisk deployment you want to use.
 2. **Authorization key** (username and password) which grants you access to the OpenWhisk API.
-3. **Namespace** where your OpenWhisk assets are stored.
 
-The CLI will usually have an API host already set. You can check its value with
-`wsk property get --apihost`.
-
-If you know your authorization key and namespace, you can configure the CLI to use them. Otherwise
-you will need to provide one or both for most CLI operations.
+The API host can be acquired from the `edge.host` property in `whisk.properties` file, which is generated during
+deployment of OpenWhisk. Run the following command from your `openwhisk` directory to set the API host:
 
 ```
-wsk property set [--apihost <openwhisk_baseurl>] --auth <username:password> --namespace <namespace>
+./bin/wsk property set --apihost <openwhisk_baseurl>
 ```
 
-The API host is set automatically when you build the CLI for your environment. A _guest_ account is available
-in local installations with an authorization key located in [ansible/files/auth.guest](../ansible/files/auth.guest) and the namespace `guest`.
-To configure the CLI to use the guest account, you can run the following command from your `openwhisk` directory:
+If you know your authorization key, you can configure the CLI to use it. Otherwise, you will need to obtain an
+authorization key for most CLI operations. A _guest_ account is available in local installations with an authorization
+key located in [ansible/files/auth.guest](../ansible/files/auth.guest). To configure the CLI to use the guest account,
+you can run the following command from your `openwhisk` directory:
 
 ```
-./bin/wsk property set --namespace guest --auth `cat ansible/files/auth.guest`
+./bin/wsk property set --auth `cat ansible/files/auth.guest`
 ```
 
 To verify your CLI setup, try [creating and running an action](#openwhisk-hello-world-example).
-
-## Setting up the deprecated OpenWhisk CLI (Python based)
-- The OpenWhisk command line interface (CLI) requires Python 2.7.
-
-- If you cloned the OpenWhisk repository, you will find the CLI in `openwhisk/bin/wsk`.
-
-- Otherwise, download the CLI from an existing deployment. You will need to know the base URL for the deployment you
-want to use and install it using [pip](https://pip.pypa.io/).
-
-```
-sudo pip install --upgrade https://{BASE URL}/openwhisk-0.1.0.tar.gz [--trusted-host {BASE URL}]
-```
-
-The `{BASE URL}` is the OpenWhisk API hostname or IP address (e.g., openwhisk.ng.bluemix.net).
-The `--trusted-host` option allows you to download the CLI from a host with a [self-signed (i.e., untrusted) certificate](../tools/vagrant/README.md#ssl-certificate-configuration-optional).
 
 ## Using the OpenWhisk CLI
 

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -66,8 +66,8 @@ Call the binary directly or setup your environment variable PATH to include the 
 From your _host_, configure `wsk` to use your Vagrant-hosted OpenWhisk deployment and run the "echo" action again to test.
 The following commands assume that you have `wsk` setup correctly in your PATH.
 ```
-# Set your OpenWhisk Namespace and Authorization Key.
-wsk -i property set --apihost 192.168.33.13 --namespace guest --auth `vagrant ssh -- cat openwhisk/ansible/files/auth.guest`
+# Set your OpenWhisk Authorization Key.
+wsk -i property set --apihost 192.168.33.13 --auth `vagrant ssh -- cat openwhisk/ansible/files/auth.guest`
 
 # Run the hello sample action
 wsk -i action invoke /whisk.system/utils/echo -p message hello --blocking --result
@@ -76,7 +76,7 @@ wsk -i action invoke /whisk.system/utils/echo -p message hello --blocking --resu
 }
 ```
 **Tip:** To connect to a different host API (i.e. bluemix.net) with the CLI, you will need to 
-configure the CLI with new values for __apihost__, __namespace__, and __auth__ key.
+configure the CLI with new values for __apihost__, and __auth__ key.
  
 ### Use the wsk CLI inside the VM
 For your convenience, a `wsk` wrapper is provided inside the VM which delegates CLI commands to `$OPENWHISK_HOME/bin/linux/amd64/wsk` and adds the `-i` parameter that is required for insecure access to the local OpenWhisk deployment.
@@ -157,9 +157,8 @@ You can check that containers are running by using the docker cli with the comma
 
 ### Adding OpenWhisk users (Optional)
 
-An OpenWhisk user, also known as a *subject*, requires a valid authorization key and namespace.
+An OpenWhisk user, also known as a *subject*, requires a valid authorization key.
 OpenWhisk is preconfigured with a guest key located in `ansible/files/auth.guest`.
-The default namespace is __guest__.
 
 You may use this key if you like, or use `wskadmin` inside the VM to create a new key.
 
@@ -167,24 +166,6 @@ You may use this key if you like, or use `wskadmin` inside the VM to create a ne
 vagrant ssh
 wskadmin user create <subject>
 ```
-
-This command will create a new *subject* with the authorization key shown on the console once you run `wskadmin`. This key is required when making API calls to OpenWhisk, or when using the command line interface (CLI). The namespace is the same as the `<subject>` name used to create the key.
-
-A namespace allows two or more subjects to share resources. Each subject will have their own authorization key to work with resources in a namespace, but will have equal rights to the namespace.
-
-```
-vagrant ssh
-wskadmin user create <subject> --ns <namespace>
-```
-
-The same tool may be used to remove a subject from a namespace or to delete a subject entirely.
-
-```
-vagrant ssh
-wskadmin user delete <subject> --ns <namespace>  # removes <subject> from <namespace>
-wskadmin user delete <subject>                   # deletes <subject>
-```
-
 
 ### SSL certificate configuration (Optional)
 

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -167,6 +167,23 @@ vagrant ssh
 wskadmin user create <subject>
 ```
 
+This command will create a new *subject* with the authorization key shown on the console once you run `wskadmin`. This key is required when making API calls to OpenWhisk, or when using the command line interface (CLI). The namespace is the same as the `<subject>` name used to create the key.
+
+A namespace allows two or more subjects to share resources. Each subject will have their own authorization key to work with resources in a namespace, but will have equal rights to the namespace.
+
+```
+vagrant ssh
+wskadmin user create <subject> --ns <namespace>
+```
+
+The same tool may be used to remove a subject from a namespace or to delete a subject entirely.
+
+```
+vagrant ssh
+wskadmin user delete <subject> --ns <namespace>  # removes <subject> from <namespace>
+wskadmin user delete <subject>                   # deletes <subject>
+```
+
 ### SSL certificate configuration (Optional)
 
 OpenWhisk includes a _self-signed_ SSL certificate and the `wsk` CLI allows untrusted certificates via `-i` on the command line.


### PR DESCRIPTION
- Do not inform the user that he or she must configure a namespace before using the CLI
- Remove Python CLI mentions

Closes https://github.com/openwhisk/openwhisk/issues/1797