### PR TITLE
Make LoadBalancer's round-robin parameter configurable

### DIFF
--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -91,3 +91,5 @@ db.whisk.auths={{ db_auth }}
 apigw.auth.user={{apigw_auth_user}}
 apigw.auth.pwd={{apigw_auth_pwd}}
 apigw.host={{apigw_host}}
+
+loadbalancer.activationCountBeforeNextInvoker={{ loadbalancer_activation_count_before_next_invoker | default(10) }}

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -86,6 +86,16 @@ class Config(
     }
 
     /**
+     * Returns the value of a given key parsed as an integer.
+     * If parsing fails, return the default value.
+     *
+     * @param key the property that has to be returned.
+     */
+    def getAsInt(key: String, defaultValue: Int): Int = {
+        Try { getProperty(key).toInt } getOrElse { defaultValue }
+    }
+
+    /**
      * Converts the set of property to a string for debugging.
      */
     def mkString: String = settings.mkString("\n")

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -79,6 +79,7 @@ class WhiskConfig(
     val wskApiHost = this(WhiskConfig.wskApiHost)
     val controllerHost = this(WhiskConfig.controllerHostName) + ":" + this(WhiskConfig.controllerHostPort)
     val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
+    val loadbalancerActivationCountBeforeNextInvoker = this.getAsInt(WhiskConfig.loadbalancerActivationCountBeforeNextInvoker, 10)
 
     val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
     val kafkaHost = this(WhiskConfig.kafkaHostName) + ":" + this(WhiskConfig.kafkaHostPort)
@@ -242,6 +243,8 @@ object WhiskConfig extends Logging {
     private val controllerHostName = "controller.host"
     private val controllerHostPort = "controller.host.port"
     private val controllerBlackboxFraction = "controller.blackboxFraction"
+
+    val loadbalancerActivationCountBeforeNextInvoker = "loadbalancer.activationCountBeforeNextInvoker"
 
     val kafkaHostName = "kafka.host"
     val loadbalancerHostName = "loadbalancer.host"

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -47,7 +47,7 @@ import whisk.common.TransactionId
 import whisk.connector.kafka.KafkaConsumerConnector
 import whisk.connector.kafka.KafkaProducerConnector
 import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.{ consulServer, kafkaHost }
+import whisk.core.WhiskConfig.{ consulServer, kafkaHost, loadbalancerActivationCountBeforeNextInvoker }
 import whisk.core.connector.{ ActivationMessage, CompletionMessage }
 import whisk.core.entity.{ ActivationId, CodeExec, WhiskAction, WhiskActivation }
 
@@ -95,7 +95,8 @@ class LoadBalancerService(
     info(this, s"blackboxFraction = $blackboxFraction")
 
     /** We run this often on an invoker before going onto the next. */
-    private val activationCountBeforeNextInvoker = 10
+    private val activationCountBeforeNextInvoker = Math.max(1, config.loadbalancerActivationCountBeforeNextInvoker)
+    info(this, s"activationCountBeforeNextInvoker = $activationCountBeforeNextInvoker")
 
     /**
      * Gets invoker health as a dictionary.
@@ -321,6 +322,7 @@ class LoadBalancerService(
 object LoadBalancerService {
     def requiredProperties = kafkaHost ++
         consulServer ++
+        Map(loadbalancerActivationCountBeforeNextInvoker -> null) ++
         InvokerHealth.requiredProperties
 }
 


### PR DESCRIPTION
The parameter in the load-balancer that decides when to dispatch to the next invoker is hard-coded. We need to make the parameter configurable per environment by adding a property to WhiskConfig.

Property Name: loadbalancer_activation_count_before_next_invoker
Default Value: 10