### PR TITLE
merge variable stack instead of replace

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -5,6 +5,7 @@ retry_files_enabled = False
 host_key_checking = False
 inventory = environments/local
 callback_plugins = callbacks
+hash_behaviour = merge
 
 [ssh_connection]
 scp_if_ssh = True


### PR DESCRIPTION
This will allow us to provide only partial hashes if we want to test certain settings for individual deployments.

e.g. if we wanted to tweak the coreshare variable:

```
ansible-playbook (...) -e '{ "invoker": {"coreshare": "4"}}'
```

instead of having to replace the entire object as it is without this PR:

```
ansible-playbook (...) -e '{ "invoker": {"port": "12001", "numcore": "2", "coreshare: "4", "serializeDockerOp": "true", "serializeDockerPull": "true}}'
```
