### PR TITLE
Update new location for apigateway location on docker hub

### DIFF
--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -1,13 +1,13 @@
 ---
 # This role will install apigateway
 
-- name: "pull the openwhisk/apigateway image"
-  shell: "docker pull openwhisk/apigateway"
+- name: "pull the openwhisk/openwhisk-apigateway image"
+  shell: "docker pull openwhisk/openwhisk-apigateway"
 
 - name: (re)start apigateway
   docker_container:
     name: apigateway
-    image: openwhisk/apigateway
+    image: openwhisk/openwhisk-apigateway
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"


### PR DESCRIPTION
New location of docker image is here now: https://hub.docker.com/r/openwhisk/openwhisk-apigateway/

docker hub doesn't offer a way to rename the github url, and for some reason it doesn't handle the github 301 redirection.
