### PR TITLE
Properly Handle Errors Received from Blocking Invocations

### DIFF
--- a/tests/dat/actions/applicationError3.js
+++ b/tests/dat/actions/applicationError3.js
@@ -1,0 +1,3 @@
+function main() {
+  return { error: true }
+}

--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -357,6 +357,17 @@ class WskBasicTests
             }
     }
 
+    it should "create and invoke a blocking action resulting in an application error response" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "applicationError3"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("applicationError3.js")))
+            }
+
+            wsk.action.invoke(name, blocking = true, result = true, expectedExitCode = 246)
+              .stderr.parseJson.asJsObject shouldBe JsObject("error" -> JsBoolean(true))
+    }
+
     it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "errorResponseObject"

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -321,11 +321,12 @@ func parseErrorResponse(resp *http.Response, data []byte, v interface{}) (*http.
             return resp, werr
         }
     } else {
-        Debug(DbgError, "HTTP response with unexpected body failed due to contents parsing error: '%v'\n", err)
-        errStr := wski18n.T("The connection failed, or timed out. (HTTP status code {{.code}})",
-            map[string]interface{}{"code": resp.StatusCode})
-        werr := MakeWskError(errors.New(errStr), resp.StatusCode - 256, DISPLAY_MSG, NO_DISPLAY_USAGE)
-        return resp, werr
+        Debug(DbgInfo, "Detected response status `%s` that an application error was returned\n")
+        errMsg := wski18n.T("The following application error was received: {{.err}}",
+            map[string]interface{}{"err": string(data)})
+        whiskErr := MakeWskError(errors.New(errMsg), resp.StatusCode - 256, NO_DISPLAY_MSG, NO_DISPLAY_USAGE,
+            NO_MSG_DISPLAYED, APPLICATION_ERR)
+        return parseSuccessResponse(resp, data, v), whiskErr
     }
 }
 


### PR DESCRIPTION
- Display proper error message during a blocking invocation when result flag is being used

Closes https://github.com/openwhisk/openwhisk/issues/1813