### PR TITLE
Add kafka_python library to the Python action runtime

### DIFF
--- a/core/pythonAction/Dockerfile
+++ b/core/pythonAction/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
 RUN pip install \
     beautifulsoup4==4.5.1 \
     httplib2==0.9.2 \
+    kafka_python==1.3.1 \
     lxml==3.6.4 \
     python-dateutil==2.5.3 \
     requests==2.11.1 \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -321,6 +321,7 @@ In addition to the standard Python library, the following packages are also avai
 - itsdangerous v0.24
 - jinja2 v2.8
 - lxml v3.6.4
+- kafka_python v1.3.1
 - markupsafe v0.23
 - parsel v1.0.3
 - pyasn1 v0.1.9

--- a/tests/src/actionContainers/PythonActionContainerTests.scala
+++ b/tests/src/actionContainers/PythonActionContainerTests.scala
@@ -210,6 +210,7 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |import simplejson as json
                 |from twisted.internet import protocol, reactor, endpoints
                 |import socket
+                |from kafka import BrokerConnection
                 |
                 |def main(args):
                 |    socket.setdefaulttimeout(120)
@@ -218,6 +219,7 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |    t = parse('2016-02-22 11:59:00 EST')
                 |    r = requests.get('https://openwhisk.ng.bluemix.net/api/v1')
                 |    j = json.dumps({'foo':'bar'}, separators = (',', ':'))
+                |    kafka = BrokerConnection("it works", 9093, None)
                 |
                 |    return {
                 |       "bs4": str(b.title),
@@ -225,7 +227,8 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 |       "dateutil": t.strftime("%A"),
                 |       "lxml": etree.Element("root").tag,
                 |       "json": j,
-                |       "request": r.status_code
+                |       "request": r.status_code,
+                |       "kafka_python": kafka.host
                 |    }
             """.stripMargin
 
@@ -242,7 +245,8 @@ class PythonActionContainerTests extends BasicActionRunnerTests with WskActorSys
                 "dateutil" -> "Monday".toJson,
                 "lxml" -> "root".toJson,
                 "json" -> JsObject("foo" -> "bar".toJson).compactPrint.toJson,
-                "request" -> 200.toJson)))
+                "request" -> 200.toJson,
+                "kafka_python" -> "it works".toJson)))
         }
 
         checkStreams(out, err, {


### PR DESCRIPTION
This is to enable new "produce" actions in the kafka package: https://github.com/openwhisk/openwhisk-package-kafka/pull/131

This change adds approximately 1.7MB to the pythonaction Docker image.