### PR TITLE
Change logging to Akka-logging

### DIFF
--- a/common/scala/src/main/resources/log4j.properties
+++ b/common/scala/src/main/resources/log4j.properties
@@ -15,9 +15,9 @@
 log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout 
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
 # note the timezone in the timestamp format
-log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT}] [%p] %m [%c:%L] %n
+log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT}] [%p] %m %n
 
 log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
@@ -26,10 +26,10 @@ log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
 log4j.logger.org.apache.zookeeper=WARN
 
-# LightCouch 
-log4j.logger.org.lightcouch=INFO 
+# LightCouch
+log4j.logger.org.lightcouch=INFO
 
-# Apache HttpClient 
+# Apache HttpClient
 log4j.logger.org.apache.http=ERROR
 
 

--- a/common/scala/src/main/resources/logging.conf
+++ b/common/scala/src/main/resources/logging.conf
@@ -1,4 +1,4 @@
 akka {
-  loglevel = "DEBUG"
+  loglevel = "INFO"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }

--- a/common/scala/src/main/scala/whisk/common/Config.scala
+++ b/common/scala/src/main/scala/whisk/common/Config.scala
@@ -44,8 +44,8 @@ import scala.util.Try
 class Config(
     requiredProperties: Map[String, String],
     optionalProperties: Set[String] = Set())(
-        env: Map[String, String] = sys.env)
-    extends Logging {
+        env: Map[String, String] = sys.env)(
+            implicit logging: Logging) {
 
     private val settings = getProperties().toMap.filter {
         case (k, v) => requiredProperties.contains(k) ||
@@ -111,17 +111,17 @@ class Config(
 /**
  * Singleton object which provides global methods to manage configuration.
  */
-object Config extends Logging {
+object Config {
     /**
      * Reads a Map of key-value pairs from the environment -- store them in the
      * mutable properties object.
      */
-    def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String], env: Map[String, String]) = {
+    def readPropertiesFromEnvironment(properties: scala.collection.mutable.Map[String, String], env: Map[String, String])(implicit logging: Logging) = {
         for (p <- properties.keys) {
             val envp = p.replace('.', '_').toUpperCase
             val envv = env.get(envp)
             if (envv.isDefined) {
-                info(this, s"environment set value for $p")
+                logging.info(this, s"environment set value for $p")
                 properties += p -> envv.get.trim
             }
         }
@@ -133,10 +133,10 @@ object Config extends Logging {
      * @param required a key-value map where the keys are required properties
      * @param properties a set of properties to check
      */
-    def validateProperties(required: Map[String, String], properties: Map[String, String]): Boolean = {
+    def validateProperties(required: Map[String, String], properties: Map[String, String])(implicit logging: Logging): Boolean = {
         required.keys.forall { key =>
             val value = properties(key)
-            if (value == null) error(this, s"required property $key still not set")
+            if (value == null) logging.error(this, s"required property $key still not set")
             value != null
         }
     }

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -21,28 +21,19 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import akka.event.Logging.LogLevel
+
 import akka.event.Logging.{ DebugLevel, InfoLevel, WarningLevel, ErrorLevel }
+import akka.event.Logging.LogLevel
+import akka.event.LoggingAdapter
 
-/**
- * A logging facility in which output is one line and fields are bracketed.
- */
-trait Logging extends PrintStreamEmitter {
-    /**
-     * Sets the loglevel for this implementor to log on. See
-     * {@link akka.event.Logging.LogLevel} for details.
-     */
-    def setVerbosity(level: LogLevel) = this.level = level
-    def getVerbosity() = level
-
+trait Logging {
     /**
      * Prints a message on DEBUG level
      *
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level >= DebugLevel) emit(DebugLevel, id, from, message)
+    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(DebugLevel, id, from, message)
 
     /**
      * Prints a message on INFO level
@@ -50,8 +41,7 @@ trait Logging extends PrintStreamEmitter {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level >= InfoLevel) emit(InfoLevel, id, from, message)
+    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(InfoLevel, id, from, message)
 
     /**
      * Prints a message on WARN level
@@ -59,8 +49,7 @@ trait Logging extends PrintStreamEmitter {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level >= WarningLevel) emit(WarningLevel, id, from, message)
+    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(WarningLevel, id, from, message)
 
     /**
      * Prints a message on ERROR level
@@ -68,32 +57,41 @@ trait Logging extends PrintStreamEmitter {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level >= ErrorLevel) emit(ErrorLevel, id, from, message)
-
-    private var level = InfoLevel
-}
-
-/**
- * Facility that is used by Logger to write down the log-output to the standard output stream.
- */
-trait PrintStreamEmitter {
-    /**
-     * The output stream, defaults to Console.out.
-     * This is mutable to allow unit tests to capture the stream.
-     */
-    var outputStream: PrintStream = Console.out
+    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(ErrorLevel, id, from, message)
 
     /**
-     * Prints a message to the output stream
+     * Prints a message to the output.
      *
      * @param loglevel The level to log on
      * @param id <code>TransactionId</code> to include in the log
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
-     * @param marker A LogMarkerToken. They are defined in <code>LoggingMarkers</code>.
      */
-    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String, marker: Option[LogMarker] = None) = {
+    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String)
+}
+
+/**
+ * Implementaion of Logging, that uses akka logging.
+ */
+class AkkaLogging(loggingAdapter: LoggingAdapter) extends Logging {
+    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
+        val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
+
+        val logMessage = Seq(message).collect {
+            case msg if msg.nonEmpty =>
+                msg.split('\n').map(_.trim).mkString(" ")
+        }
+
+        val parts = Seq(s"[$id]") ++ Seq(s"[$name]") ++ logMessage
+        loggingAdapter.log(loglevel, parts.mkString(" "))
+    }
+}
+
+/**
+ * Implementaion of Logging, that uses the output stream.
+ */
+class PrintStreamLogging(outputStream: PrintStream = Console.out) extends Logging {
+    def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: String) = {
         val now = Instant.now(Clock.systemUTC)
         val time = Emitter.timeFormat.format(now)
         val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
@@ -110,7 +108,7 @@ trait PrintStreamEmitter {
                 msg.split('\n').map(_.trim).mkString(" ")
         }
 
-        val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage ++ marker
+        val parts = Seq(s"[$time]", s"[$level]", s"[$id]") ++ Seq(s"[$name]") ++ logMessage
         outputStream.println(parts.mkString(" "))
     }
 }

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -33,7 +33,9 @@ trait Logging {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(DebugLevel, id, from, message)
+    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+        emit(DebugLevel, id, from, message)
+    }
 
     /**
      * Prints a message on INFO level
@@ -41,7 +43,9 @@ trait Logging {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(InfoLevel, id, from, message)
+    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+        emit(InfoLevel, id, from, message)
+    }
 
     /**
      * Prints a message on WARN level
@@ -49,7 +53,9 @@ trait Logging {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(WarningLevel, id, from, message)
+    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+        emit(WarningLevel, id, from, message)
+    }
 
     /**
      * Prints a message on ERROR level
@@ -57,7 +63,9 @@ trait Logging {
      * @param from Reference, where the method was called from.
      * @param message Message to write to the log
      */
-    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = emit(ErrorLevel, id, from, message)
+    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) = {
+        emit(ErrorLevel, id, from, message)
+    }
 
     /**
      * Prints a message to the output.

--- a/common/scala/src/main/scala/whisk/common/SimpleExec.scala
+++ b/common/scala/src/main/scala/whisk/common/SimpleExec.scala
@@ -22,15 +22,15 @@ import scala.sys.process.stringSeqToProcess
 /**
  * Utility to exec processes
  */
-object SimpleExec extends Logging {
+object SimpleExec {
     /**
      * Runs a external process.
      *
      * @param cmd an array of String -- their concatenation is the command to exec
      * @return a triple of (stdout, stderr, exitcode) from running the command
      */
-    def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId): (String, String, Int) = {
-        info(this, s"Running command: ${cmd.mkString(" ")}")
+    def syncRunCmd(cmd: Seq[String])(implicit transid: TransactionId, logging: Logging): (String, String, Int) = {
+        logging.info(this, s"Running command: ${cmd.mkString(" ")}")
         val pb = stringSeqToProcess(cmd)
 
         val outs = new StringBuilder()
@@ -46,7 +46,7 @@ object SimpleExec extends Logging {
                 errs.append("\n")
             })
 
-        info(this, s"Done running command: ${cmd.mkString(" ")}")
+        logging.info(this, s"Done running command: ${cmd.mkString(" ")}")
 
         def noLastNewLine(sb: StringBuilder) = {
             if (sb.isEmpty) "" else sb.substring(0, sb.size - 1)

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -109,7 +109,7 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
     def deltaToMarker(startMarker: StartMarker, endTime: Instant = Instant.now(Clock.systemUTC)) = Duration.between(startMarker.start, endTime).toMillis
 
     /**
-     * Include the marker into the logmessage with the right format.
+     * Formats log message to include marker.
      *
      * @param message: The log message without the marker
      * @param marker: The marker to add to the message
@@ -138,13 +138,13 @@ protected case class TransactionMetadata(val id: Long, val start: Instant)
 
 object TransactionId {
     val unknown = TransactionId(0)
-    val testing = TransactionId(-1) // Common id for for unit testing
-    val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
+    val testing = TransactionId(-1)         // Common id for for unit testing
+    val invoker = TransactionId(-100)       // Invoker startup/shutdown or GC activity
     val invokerWarmup = TransactionId(-101) // Invoker warmup thread that makes stem-cell containers
-    val invokerNanny = TransactionId(-102) // Invoker nanny thread
-    val dispatcher = TransactionId(-110) // Kafka message dispatcher
-    val loadbalancer = TransactionId(-120) // Loadbalancer thread
-    val controller = TransactionId(-130) // Controller startup
+    val invokerNanny = TransactionId(-102)  // Invoker nanny thread
+    val dispatcher = TransactionId(-110)    // Kafka message dispatcher
+    val loadbalancer = TransactionId(-120)  // Loadbalancer thread
+    val controller = TransactionId(-130)    // Controller startup
 
     def apply(tid: BigDecimal): TransactionId = {
         Try {

--- a/common/scala/src/main/scala/whisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/whisk/common/TransactionId.scala
@@ -17,19 +17,19 @@
 package whisk.common
 
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.math.BigDecimal.int2bigDecimal
 import scala.util.Try
 
+import akka.event.Logging.{ InfoLevel, WarningLevel }
+import akka.event.Logging.LogLevel
 import spray.json.JsArray
 import spray.json.JsNumber
 import spray.json.JsValue
 import spray.json.RootJsonFormat
-import java.time.Duration
-import akka.event.Logging.LogLevel
-import akka.event.Logging.{ InfoLevel, WarningLevel }
 
 /**
  * A transaction id for tracking operations in the system that are specific to a request.
@@ -48,8 +48,8 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
      * @param message An additional message that is written into the log, together with the other information.
      * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
      */
-    def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit emitter: PrintStreamEmitter) = {
-        emitter.emit(logLevel, this, from, message, Some(LogMarker(marker, deltaToStart)))
+    def mark(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit logging: Logging) = {
+        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
     }
 
     /**
@@ -63,8 +63,8 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
      *
      * @return startMarker that has to be passed to the finished or failed method to calculate the time difference.
      */
-    def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit emitter: PrintStreamEmitter): StartMarker = {
-        emitter.emit(logLevel, this, from, message, Some(LogMarker(marker, deltaToStart)))
+    def started(from: AnyRef, marker: LogMarkerToken, message: String = "", logLevel: LogLevel = InfoLevel)(implicit logging: Logging): StartMarker = {
+        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(marker, deltaToStart)))
         StartMarker(Instant.now, marker)
     }
 
@@ -77,9 +77,9 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
      * @param logLevel The Loglevel, the message should have. Default is <code>InfoLevel</code>.
      * @param endTime Manually set the timestamp of the end. By default it is NOW.
      */
-    def finished(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = InfoLevel, endTime: Instant = Instant.now(Clock.systemUTC))(implicit emitter: PrintStreamEmitter) = {
+    def finished(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = InfoLevel, endTime: Instant = Instant.now(Clock.systemUTC))(implicit logging: Logging) = {
         val endMarker = LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.finish)
-        emitter.emit(logLevel, this, from, message, Some(LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker, endTime)))))
+        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker, endTime)))))
     }
 
     /**
@@ -90,9 +90,9 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
      * @param message An additional message that is written into the log, together with the other information.
      * @param logLevel The <code>LogLevel</code> the message should have. Default is <code>WarningLevel</code>.
      */
-    def failed(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = WarningLevel)(implicit emitter: PrintStreamEmitter) = {
+    def failed(from: AnyRef, startMarker: StartMarker, message: String = "", logLevel: LogLevel = WarningLevel)(implicit logging: Logging) = {
         val endMarker = LogMarkerToken(startMarker.startMarker.component, startMarker.startMarker.action, LoggingMarkers.error)
-        emitter.emit(logLevel, this, from, message, Some(LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker)))))
+        logging.emit(logLevel, this, from, createMessageWithMarker(message, LogMarker(endMarker, deltaToStart, Some(deltaToMarker(startMarker)))))
     }
 
     /**
@@ -107,6 +107,16 @@ case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
      * @param endTime Manually set the endtime. By default it is NOW.
      */
     def deltaToMarker(startMarker: StartMarker, endTime: Instant = Instant.now(Clock.systemUTC)) = Duration.between(startMarker.start, endTime).toMillis
+
+    /**
+     * Include the marker into the logmessage with the right format.
+     *
+     * @param message: The log message without the marker
+     * @param marker: The marker to add to the message
+     */
+    private def createMessageWithMarker(message: String, marker: LogMarker): String = {
+        (Option(message).filter(_.trim.nonEmpty) ++ Some(marker)).mkString(" ")
+    }
 }
 
 /**
@@ -128,13 +138,13 @@ protected case class TransactionMetadata(val id: Long, val start: Instant)
 
 object TransactionId {
     val unknown = TransactionId(0)
-    val testing = TransactionId(-1)         // Common id for for unit testing
-    val invoker = TransactionId(-100)       // Invoker startup/shutdown or GC activity
+    val testing = TransactionId(-1) // Common id for for unit testing
+    val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
     val invokerWarmup = TransactionId(-101) // Invoker warmup thread that makes stem-cell containers
-    val invokerNanny = TransactionId(-102)  // Invoker nanny thread
-    val dispatcher = TransactionId(-110)    // Kafka message dispatcher
-    val loadbalancer = TransactionId(-120)  // Loadbalancer thread
-    val controller = TransactionId(-130)    // Controller startup
+    val invokerNanny = TransactionId(-102) // Invoker nanny thread
+    val dispatcher = TransactionId(-110) // Kafka message dispatcher
+    val loadbalancer = TransactionId(-120) // Loadbalancer thread
+    val controller = TransactionId(-130) // Controller startup
 
     def apply(tid: BigDecimal): TransactionId = {
         Try {

--- a/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/ArtifactStore.scala
@@ -16,23 +16,24 @@
 
 package whisk.core.database
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl._
 import akka.util.ByteString
-
 import spray.json.JsObject
 import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.entity.DocInfo
 
 /** Basic client to put and delete artifacts in a data store. */
-trait ArtifactStore[DocumentAbstraction] extends Logging {
+trait ArtifactStore[DocumentAbstraction] {
 
     /** Execution context for futures */
     protected[core] implicit val executionContext: ExecutionContext
+
+    implicit val logging: Logging
 
     /**
      * Puts (saves) document to database using a future.

--- a/common/scala/src/main/scala/whisk/core/database/CloudantRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CloudantRestClient.scala
@@ -19,17 +19,17 @@ package whisk.core.database
 import scala.concurrent.Future
 
 import akka.actor.ActorSystem
-
 import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.model.StatusCode
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+import whisk.common.Logging
 
 /**
  * This class only handles the basic communication to the proper endpoints
  *  ("JSON in, JSON out"). It is up to its clients to interpret the results.
  */
-class CloudantRestClient(host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem)
+class CloudantRestClient(host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem, logging: Logging)
     extends CouchDbRestClient("https", host, port, username, password, db) {
 
     // https://cloudant.com/blog/cloudant-query-grows-up-to-handle-ad-hoc-queries/#.VvllCD-0z2C

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestClient.scala
@@ -19,28 +19,25 @@ package whisk.core.database
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-import scala.util.{ Success, Failure }
 import scala.concurrent.Future
 import scala.concurrent.Promise
-
-import spray.json._
-
-import whisk.common.Logging
-
-import akka.util.ByteString
-import akka.stream.ActorMaterializer
-import akka.stream.OverflowStrategy
-import akka.stream.QueueOfferResult
-import akka.stream.scaladsl._
+import scala.util.{ Success, Failure }
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.HostConnectionPool
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.unmarshalling._
+import akka.stream.ActorMaterializer
+import akka.stream.OverflowStrategy
+import akka.stream.QueueOfferResult
+import akka.stream.scaladsl._
+import akka.util.ByteString
+import spray.json._
+import whisk.common.Logging
 
 /**
  * This class only handles the basic communication to the proper endpoints
@@ -50,7 +47,7 @@ import akka.http.scaladsl.unmarshalling._
  *  up the pool corresponding to the host. It is also easier to add an extra
  *  queueing mechanism.
  */
-class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem) extends Logging {
+class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem, logging: Logging) {
     require(protocol == "http" || protocol == "https", "Protocol must be one of { http, https }.")
 
     private implicit val context = system.dispatcher
@@ -191,7 +188,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
             case f: Float   => JsNumber(f)
             case s: String  => JsString(s)
             case _ =>
-                warn(this, s"Serializing uncontrolled type '${any.getClass}' to string in JSON conversion ('${any.toString}').")
+                logging.warn(this, s"Serializing uncontrolled type '${any.getClass}' to string in JSON conversion ('${any.toString}').")
                 JsString(any.toString)
         }
 

--- a/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/whisk/core/database/CouchDbRestStore.scala
@@ -26,8 +26,8 @@ import akka.http.scaladsl.model._
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import spray.json._
+import whisk.common.Logging
 import whisk.common.LoggingMarkers
-import whisk.common.PrintStreamEmitter
 import whisk.common.TransactionId
 import whisk.core.entity.DocInfo
 import whisk.core.entity.DocRevision
@@ -51,13 +51,11 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](
     dbPort: Int,
     dbUsername: String,
     dbPassword: String,
-    dbName: String)(implicit system: ActorSystem, jsonFormat: RootJsonFormat[DocumentAbstraction])
+    dbName: String)(implicit system: ActorSystem, val logging: Logging, jsonFormat: RootJsonFormat[DocumentAbstraction])
     extends ArtifactStore[DocumentAbstraction]
     with DefaultJsonProtocol {
 
     protected[core] implicit val executionContext = system.dispatcher
-
-    private implicit val emitter: PrintStreamEmitter = this
 
     private val client: CouchDbRestClient = new CouchDbRestClient(dbProtocol, dbHost, dbPort.toInt, dbUsername, dbPassword, dbName)
 

--- a/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/whisk/core/database/DocumentFactory.scala
@@ -16,25 +16,22 @@
 
 package whisk.core.database
 
-import scala.concurrent.Future
-import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
-
-import akka.http.scaladsl.model.ContentType
-import akka.stream.scaladsl.StreamConverters
-import akka.stream.IOResult
-
 import java.io.InputStream
 import java.io.OutputStream
 
-import whisk.common.Logging
-import whisk.core.entity.DocRevision
-import whisk.common.TransactionId
-import whisk.core.entity.DocInfo
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
+import akka.http.scaladsl.model.ContentType
+import akka.stream.IOResult
+import akka.stream.scaladsl.StreamConverters
 import spray.json.JsObject
+import whisk.common.TransactionId
 import whisk.core.entity.DocId
+import whisk.core.entity.DocInfo
+import whisk.core.entity.DocRevision
 
 /**
  * A common trait for all records that are stored in the datastore requiring an _id field,
@@ -139,7 +136,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             require(db != null, "db undefined")
             require(doc != null, "doc undefined")
         } map { _ =>
-            implicit val logger = db: Logging
+            implicit val logger = db.logging
             implicit val ec = db.executionContext
 
             val key = cacheKeyForUpdate(doc)
@@ -165,7 +162,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             require(db != null, "db undefined")
             require(doc != null, "doc undefined")
         } map { _ =>
-            implicit val logger: Logging = db
+            implicit val logger = db.logging
             implicit val ec = db.executionContext
 
             val key = doc.id.asDocInfo
@@ -187,7 +184,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
             require(db != null, "db undefined")
             require(doc != null, "doc undefined")
         } map { _ =>
-            implicit val logger: Logging = db
+            implicit val logger = db.logging
             implicit val ec = db.executionContext
 
             val key = doc.id.asDocInfo
@@ -220,7 +217,7 @@ trait DocumentFactory[W] extends MultipleReadersSingleWriterCache[W, DocInfo] {
         Try {
             require(db != null, "db undefined")
         } map {
-            implicit val logger = db: Logging
+            implicit val logger = db.logging
             implicit val ec = db.executionContext
             val key = doc.asDocInfo(rev)
             _ => cacheLookup(key, db.get[W](key), fromCache)

--- a/common/scala/src/main/scala/whisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Identity.scala
@@ -44,7 +44,7 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
      */
     def get(datastore: AuthStore, namespace: EntityName)(
         implicit transid: TransactionId): Future[Identity] = {
-        implicit val logger: Logging = datastore
+        implicit val logger: Logging = datastore.logging
         implicit val ec = datastore.executionContext
         val ns = namespace.asString
 
@@ -66,7 +66,7 @@ object Identity extends MultipleReadersSingleWriterCache[Identity, DocInfo] with
 
     def get(datastore: AuthStore, authkey: AuthKey)(
         implicit transid: TransactionId): Future[Identity] = {
-        implicit val logger: Logging = datastore
+        implicit val logger: Logging = datastore.logging
         implicit val ec = datastore.executionContext
 
         cacheLookup(authkey, {

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -16,22 +16,19 @@
 
 package whisk.core.entity
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import scala.util.{ Try, Success, Failure }
-
-import akka.http.scaladsl.model.ContentType
-import akka.http.scaladsl.model.MediaTypes
-
-import spray.json._
-import spray.json.DefaultJsonProtocol._
-
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-import whisk.common.Logging
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.{ Try, Success, Failure }
+
+import akka.http.scaladsl.model.ContentType
+import akka.http.scaladsl.model.MediaTypes
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 import whisk.common.TransactionId
 import whisk.core.database.ArtifactStore
 import whisk.core.database.DocumentFactory
@@ -248,7 +245,7 @@ object WhiskAction
         } map { _ =>
             doc.exec match {
                 case JavaExec(Inline(jar), main) =>
-                    implicit val logger = db: Logging
+                    implicit val logger = db.logging
                     implicit val ec = db.executionContext
 
                     val newDoc = doc.copy(exec = JavaExec(Attached(jarAttachmentName, jarContentType), main))

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskStore.scala
@@ -16,29 +16,32 @@
 
 package whisk.core.entity
 
+import java.time.Instant
+
 import scala.concurrent.Future
+import scala.language.postfixOps
 import scala.util.Try
+
 import akka.actor.ActorSystem
 import spray.json.JsObject
 import spray.json.JsString
 import spray.json.RootJsonFormat
+import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
-import whisk.core.WhiskConfig.dbProvider
-import whisk.core.WhiskConfig.dbProtocol
 import whisk.core.WhiskConfig.dbActivations
 import whisk.core.WhiskConfig.dbAuths
-import whisk.core.WhiskConfig.dbPassword
-import whisk.core.WhiskConfig.dbUsername
 import whisk.core.WhiskConfig.dbHost
+import whisk.core.WhiskConfig.dbPassword
 import whisk.core.WhiskConfig.dbPort
+import whisk.core.WhiskConfig.dbProtocol
+import whisk.core.WhiskConfig.dbProvider
+import whisk.core.WhiskConfig.dbUsername
 import whisk.core.WhiskConfig.dbWhisk
 import whisk.core.database.ArtifactStore
 import whisk.core.database.CouchDbRestStore
 import whisk.core.database.DocumentRevisionProvider
 import whisk.core.database.DocumentSerializer
-import java.time.Instant
-import scala.language.postfixOps
 
 package object types {
     type AuthStore = ArtifactStore[WhiskAuth]
@@ -85,7 +88,8 @@ protected[core] trait WhiskDocument
 protected[core] object Util {
     def makeStore[D <: DocumentSerializer](config: WhiskConfig, name: WhiskConfig => String)(
         implicit jsonFormat: RootJsonFormat[D],
-        actorSystem: ActorSystem): ArtifactStore[D] = {
+        actorSystem: ActorSystem,
+        logging: Logging): ArtifactStore[D] = {
         require(config != null && config.isValid, "config is undefined or not valid")
         require(config.dbProvider == "Cloudant" || config.dbProvider == "CouchDB", "Unsupported db.provider: " + config.dbProvider)
         assume(Set(config.dbProtocol, config.dbHost, config.dbPort, config.dbUsername, config.dbPassword, name(config)).forall(_.nonEmpty), "At least one expected property is missing")
@@ -104,7 +108,7 @@ object WhiskAuthStore {
             dbPort -> null,
             dbAuths -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem) =
+    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
         Util.makeStore[WhiskAuth](config, _.dbAuths)
 }
 
@@ -118,7 +122,7 @@ object WhiskAuthV2Store {
             dbPort -> null,
             dbAuths -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem) =
+    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
         Util.makeStore[WhiskAuthV2](config, _.dbAuths)
 }
 
@@ -132,8 +136,8 @@ object WhiskEntityStore {
             dbPort -> null,
             dbWhisk -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem) =
-        Util.makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system)
+    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
+        Util.makeStore[WhiskEntity](config, _.dbWhisk)(WhiskEntityJsonFormat, system, logging)
 }
 
 object WhiskActivationStore {
@@ -146,7 +150,7 @@ object WhiskActivationStore {
             dbPort -> null,
             dbActivations -> null)
 
-    def datastore(config: WhiskConfig)(implicit system: ActorSystem) =
+    def datastore(config: WhiskConfig)(implicit system: ActorSystem, logging: Logging) =
         Util.makeStore[WhiskActivation](config, _.dbActivations)
 }
 

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -45,25 +45,28 @@ import spray.routing.Route
 import spray.routing.directives.DebuggingDirectives
 import spray.routing.directives.LogEntry
 import spray.routing.directives.LoggingMagnet.forMessageFromFullShow
+import whisk.common.LogMarker
+import whisk.common.LogMarkerToken
 import whisk.common.Logging
+import whisk.common.LoggingMarkers
 import whisk.common.TransactionCounter
 import whisk.common.TransactionId
-import akka.event.Logging
-import whisk.common.LoggingMarkers
-import whisk.common.LogMarkerToken
-import whisk.common.LogMarker
-import whisk.common.LogMarker
 
 /**
  * This trait extends the spray HttpService trait with logging and transaction counting
  * facilities common to all OpenWhisk REST services.
  */
-trait BasicHttpService extends HttpService with TransactionCounter with Logging {
+trait BasicHttpService extends HttpService with TransactionCounter {
 
     /**
      * Gets the actor context.
      */
     implicit def actorRefFactory: ActorContext
+
+    /**
+     * Gets the logging
+     */
+    implicit def logging: Logging
 
     /**
      * Gets the routes implemented by the HTTP service.
@@ -99,7 +102,7 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
     /** Rejection handler to terminate connection on a bad request. Delegates to Spray handler. */
     protected def customRejectionHandler(implicit transid: TransactionId) = RejectionHandler {
         case rejections =>
-            info(this, s"[REJECT] $rejections")
+            logging.info(this, s"[REJECT] $rejections")
             BasicHttpService.customRejectionHandler.apply(rejections)
     }
 

--- a/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicHttpService.scala
@@ -118,10 +118,12 @@ trait BasicHttpService extends HttpService with TransactionCounter with Logging 
             val p = req.uri.path.toString
             val l = loglevelForRoute(p)
 
+            val name = "BasicHttpService"
+
             val token = LogMarkerToken("http", s"${m.toLowerCase}.${res.status.intValue}", LoggingMarkers.count)
             val marker = LogMarker(token, tid.deltaToStart, Some(tid.deltaToStart))
 
-            Some(LogEntry(s"[$tid] $marker", l))
+            Some(LogEntry(s"[$tid] [$name] $marker", l))
         case _ => None // other kind of responses
     }
 }

--- a/common/scala/src/main/scala/whisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/whisk/http/BasicRasService.scala
@@ -20,8 +20,9 @@ import akka.actor.Actor
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.japi.Creator
-import whisk.common.TransactionId
 import spray.httpx.SprayJsonSupport._
+import whisk.common.Logging
+import whisk.common.TransactionId
 
 /**
  * This trait extends the BasicHttpService with a standard "ping" endpoint which
@@ -49,7 +50,7 @@ trait BasicRasService extends BasicHttpService {
  */
 object BasicRasService {
 
-    def startService(system: ActorSystem, name: String, interface: String, port: Integer) = {
+    def startService(system: ActorSystem, name: String, interface: String, port: Integer)(implicit logging: Logging) = {
         BasicHttpService.startService(system, name, interface, port, new ServiceBuilder)
     }
 
@@ -57,14 +58,14 @@ object BasicRasService {
      * In spray, we send messages to an Akka Actor. A RasService represents an Actor
      * which extends the BasicRasService trait.
      */
-    private class RasService extends BasicRasService with Actor {
+    private class RasService(implicit val logging: Logging) extends BasicRasService with Actor {
         override def actorRefFactory = context
     }
 
     /**
      * Akka-style factory for RasService.
      */
-    private class ServiceBuilder extends Creator[RasService] {
+    private class ServiceBuilder(implicit logging: Logging) extends Creator[RasService] {
         def create = new RasService
     }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/ApiUtils.scala
@@ -113,7 +113,6 @@ trait ReadOps extends Directives {
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext
 
-    /** logging */
     protected implicit val logging: Logging
 
     /**
@@ -228,7 +227,6 @@ trait WriteOps extends Directives {
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext
 
-    /** logging */
     protected implicit val logging: Logging
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -37,13 +37,16 @@ object Authenticate {
 }
 
 /** A trait to validate basic auth credentials */
-trait Authenticate extends Logging {
+trait Authenticate {
 
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext
 
     /** Database service to lookup credentials */
     protected val authStore: AuthStore
+
+    /** logging */
+    protected implicit val logging: Logging
 
     /**
      * Validates credentials against the authentication database; may be used in
@@ -54,25 +57,25 @@ trait Authenticate extends Logging {
             Try {
                 // authkey deserialization is wrapped in a try to guard against malformed values
                 val authkey = AuthKey(UUID(pw.user), Secret(pw.pass))
-                info(this, s"authenticate: ${authkey.uuid}")
+                logging.info(this, s"authenticate: ${authkey.uuid}")
                 val future = Identity.get(authStore, authkey) map { result =>
                     if (authkey == result.authkey) {
-                        info(this, s"authentication valid")
+                        logging.info(this, s"authentication valid")
                         Some(result)
                     } else {
-                        info(this, s"authentication not valid")
+                        logging.info(this, s"authentication not valid")
                         None
                     }
                 } recover {
                     case _: NoDocumentException | _: IllegalArgumentException =>
-                        info(this, s"authentication not valid")
+                        logging.info(this, s"authentication not valid")
                         None
                 }
-                future onFailure { case t => error(this, s"authentication error: $t") }
+                future onFailure { case t => logging.error(this, s"authentication error: $t") }
                 future
             }.toOption
         } getOrElse {
-            userpass.foreach(_ => info(this, s"credentials are malformed"))
+            userpass.foreach(_ => logging.info(this, s"credentials are malformed"))
             Future.successful(None)
         }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Authenticate.scala
@@ -45,7 +45,6 @@ trait Authenticate {
     /** Database service to lookup credentials */
     protected val authStore: AuthStore
 
-    /** logging */
     protected implicit val logging: Logging
 
     /**

--- a/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -27,7 +27,6 @@ import spray.http.StatusCodes.InternalServerError
 import spray.routing.Directive1
 import spray.routing.Directives
 import spray.routing.RequestContext
-import whisk.common.Logging
 import whisk.common.TransactionId
 import whisk.core.entitlement._
 import whisk.core.entitlement.Privilege.Privilege
@@ -38,7 +37,7 @@ import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
 
 /** A trait for routes that require entitlement checks. */
-trait BasicAuthorizedRouteProvider extends Directives with Logging {
+trait BasicAuthorizedRouteProvider extends Directives {
     /** An execution context for futures */
     protected implicit val executionContext: ExecutionContext
 

--- a/core/controller/src/main/scala/whisk/core/controller/Backend.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Backend.scala
@@ -18,15 +18,16 @@ package whisk.core.controller
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
+import scala.language.postfixOps
 
 import akka.actor.ActorSystem
 import akka.event.Logging.InfoLevel
+import whisk.common.Logging
 import whisk.core.WhiskConfig
 import whisk.core.entitlement._
-import whisk.core.loadBalancer.{ LoadBalancer, LoadBalancerService }
-import scala.language.postfixOps
 import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.iam.NamespaceProvider
+import whisk.core.loadBalancer.{ LoadBalancer, LoadBalancerService }
 
 object WhiskServices {
 
@@ -38,7 +39,7 @@ object WhiskServices {
      * Creates instance of an entitlement service.
      */
     def entitlementService(config: WhiskConfig, loadBalancer: LoadBalancer, iam: NamespaceProvider, timeout: FiniteDuration = 5 seconds)(
-        implicit as: ActorSystem) = {
+        implicit as: ActorSystem, logging: Logging) = {
         // remote entitlement service requires a host:port definition. If not given,
         // i.e., the value equals ":" or ":xxxx", use a local entitlement flow.
         if (config.entitlementHost.startsWith(":")) {
@@ -51,7 +52,7 @@ object WhiskServices {
     /**
      * Creates instance of an identity provider.
      */
-    def iamProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds)(implicit as: ActorSystem) = {
+    def iamProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds)(implicit as: ActorSystem, logging: Logging) = {
         new NamespaceProvider(config, timeout)
     }
 
@@ -61,7 +62,7 @@ object WhiskServices {
      * @param config the configuration with loadbalancerHost defined
      * @return a load balancer component
      */
-    def makeLoadBalancerComponent(config: WhiskConfig)(implicit as: ActorSystem) = new LoadBalancerService(config, InfoLevel)
+    def makeLoadBalancerComponent(config: WhiskConfig)(implicit as: ActorSystem, logging: Logging) = new LoadBalancerService(config, InfoLevel)
 
 }
 

--- a/core/controller/src/main/scala/whisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Entities.scala
@@ -34,10 +34,10 @@ import whisk.common.TransactionId
 import whisk.core.entitlement.Privilege._
 import whisk.core.entitlement.Resource
 import whisk.core.entity._
+import whisk.core.entity.ActivationEntityLimit
 import whisk.core.entity.size._
 import whisk.http.ErrorResponse.terminate
 import whisk.http.Messages
-import whisk.core.entity.ActivationEntityLimit
 
 protected[controller] trait ValidateRequestSize extends Directives {
     protected def validateSize(check: => Option[SizeError])(
@@ -135,13 +135,13 @@ trait WhiskCollectionAPI
 
                     onComplete(checkIfSubjectOwnsResource) {
                         case Success(excludePrivate) =>
-                            info(this, s"[LIST] exclude private entities: required == $excludePrivate")
+                            logging.info(this, s"[LIST] exclude private entities: required == $excludePrivate")
                             list(user, resource.namespace, excludePrivate)
                         case Failure(r: RejectRequest) =>
-                            info(this, s"[LIST] namespaces lookup failed: ${r.message}")
+                            logging.info(this, s"[LIST] namespaces lookup failed: ${r.message}")
                             terminate(r.code, r.message)
                         case Failure(t) =>
-                            error(this, s"[LIST] namespaces lookup failed: ${t.getMessage}")
+                            logging.error(this, s"[LIST] namespaces lookup failed: ${t.getMessage}")
                             terminate(InternalServerError)
 
                     }

--- a/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Namespaces.scala
@@ -18,10 +18,11 @@ package whisk.core.controller
 
 import scala.util.Failure
 import scala.util.Success
+
 import spray.http.StatusCodes.InternalServerError
 import spray.http.StatusCodes.OK
-import spray.json.DefaultJsonProtocol._
 import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
 import spray.routing.Directives
 import whisk.common.TransactionId
 import whisk.core.entitlement.Collection
@@ -29,18 +30,18 @@ import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
 import whisk.core.entity.EntityPath
+import whisk.core.entity.Identity
 import whisk.core.entity.Subject
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskActivation
-import whisk.core.entity.WhiskPackage
-import whisk.core.entity.WhiskTrigger
-import whisk.core.entity.WhiskRule
-import whisk.core.entity.WhiskEntityStore
-import whisk.core.entity.types.EntityStore
-import whisk.http.ErrorResponse.terminate
 import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
-import whisk.core.entity.Identity
+import whisk.core.entity.WhiskEntityStore
+import whisk.core.entity.WhiskPackage
+import whisk.core.entity.WhiskRule
+import whisk.core.entity.WhiskTrigger
+import whisk.core.entity.types.EntityStore
 import whisk.core.iam.NamespaceProvider
+import whisk.http.ErrorResponse.terminate
 
 object WhiskNamespacesApi {
     def requiredProperties = WhiskEntityStore.requiredProperties
@@ -115,7 +116,7 @@ trait WhiskNamespacesApi
                 complete(OK, Namespaces.emptyNamespace ++ entities - WhiskActivation.collectionName)
             }
             case Failure(t) =>
-                error(this, s"[GET] namespaces failed: ${t.getMessage}")
+                logging.error(this, s"[GET] namespaces failed: ${t.getMessage}")
                 terminate(InternalServerError)
         }
     }
@@ -131,13 +132,13 @@ trait WhiskNamespacesApi
     private def getNamespaces(user: Subject)(implicit transid: TransactionId) = {
         onComplete(iam.namespaces(user)) {
             case Success(namespaces) =>
-                info(this, s"[GET] namespaces success: $namespaces")
+                logging.info(this, s"[GET] namespaces success: $namespaces")
                 complete(OK, namespaces)
             case Failure(r: RejectRequest) =>
-                info(this, s"[GET] namespaces failed: ${r.message}")
+                logging.info(this, s"[GET] namespaces failed: ${r.message}")
                 terminate(r.code, r.message)
             case Failure(t) =>
-                error(this, s"[GET] namespaces failed: ${t.getMessage}")
+                logging.error(this, s"[GET] namespaces failed: ${t.getMessage}")
                 terminate(InternalServerError)
         }
     }

--- a/core/controller/src/main/scala/whisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Packages.scala
@@ -74,7 +74,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
             entity(as[WhiskPackagePut]) { content =>
                 val request = content.resolve(entityName.namespace)
 
-                request.binding.map { b => info(this, "checking if package is accessible") }
+                request.binding.map { b => logging.info(this, "checking if package is accessible") }
                 val referencedentities = referencedEntities(request)
 
                 onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
@@ -95,7 +95,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
      * - 405 Not Allowed
      */
     override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(implicit transid: TransactionId) = {
-        error(this, "activate is not permitted on packages")
+        logging.error(this, "activate is not permitted on packages")
         reject
     }
 
@@ -256,7 +256,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
 
     private def rewriteEntitlementFailure(failure: Throwable)(
         implicit transid: TransactionId): RequestContext => Unit = {
-        info(this, s"rewriting failure $failure")
+        logging.info(this, s"rewriting failure $failure")
         failure match {
             case RejectRequest(NotFound, _) => terminate(BadRequest, Messages.bindingDoesNotExist)
             case RejectRequest(Conflict, _) => terminate(Conflict, Messages.requestedBindingIsNotValid)
@@ -286,29 +286,29 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
         wp.binding map {
             case b: Binding =>
                 val docid = b.fullyQualifiedName.toDocId
-                info(this, s"fetching package '$docid' for reference")
+                logging.info(this, s"fetching package '$docid' for reference")
                 getEntity(WhiskPackage, entityStore, docid, Some {
                     mergePackageWithBinding(Some { wp }) _
                 })
         } getOrElse {
             val pkg = ref map { _ inherit wp.parameters } getOrElse wp
-            info(this, s"fetching package actions in '${wp.fullPath}'")
+            logging.info(this, s"fetching package actions in '${wp.fullPath}'")
             val actions = WhiskAction.listCollectionInNamespace(entityStore, wp.fullPath, skip = 0, limit = 0) flatMap {
                 case Left(list) => Future.successful {
                     pkg withPackageActions (list map { o => WhiskPackageAction.serdes.read(o) })
                 }
                 case t => Future.failed {
-                    error(this, "unexpected result in package action lookup: $t")
+                    logging.error(this, "unexpected result in package action lookup: $t")
                     new IllegalStateException(s"unexpected result in package action lookup: $t")
                 }
             }
 
             onComplete(actions) {
                 case Success(p) =>
-                    info(this, s"[GET] entity success")
+                    logging.info(this, s"[GET] entity success")
                     complete(OK, p)
                 case Failure(t) =>
-                    error(this, s"[GET] failed: ${t.getMessage}")
+                    logging.error(this, s"[GET] failed: ${t.getMessage}")
                     terminate(InternalServerError)
             }
         }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -50,7 +50,6 @@ protected[actions] trait PrimitiveActions {
     /** An execution context for futures. */
     protected implicit val executionContext: ExecutionContext
 
-    /** logging */
     protected implicit val logging: Logging
 
     /** Database service to CRUD actions. */

--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -30,7 +30,6 @@ import spray.http.StatusCodes._
 import spray.json._
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
-import whisk.common.PrintStreamEmitter
 import whisk.common.StartMarker
 import whisk.common.TransactionId
 import whisk.core.connector.ActivationMessage
@@ -41,7 +40,7 @@ import whisk.core.entity.types.ActivationStore
 import whisk.core.entity.types.EntityStore
 import whisk.utils.ExecutionContextFactory.FutureExtensions
 
-protected[actions] trait PrimitiveActions extends Logging {
+protected[actions] trait PrimitiveActions {
     /** The core collections require backend services to be injected in this trait. */
     services: WhiskServices =>
 
@@ -51,13 +50,14 @@ protected[actions] trait PrimitiveActions extends Logging {
     /** An execution context for futures. */
     protected implicit val executionContext: ExecutionContext
 
+    /** logging */
+    protected implicit val logging: Logging
+
     /** Database service to CRUD actions. */
     protected val entityStore: EntityStore
 
     /** Database service to get activations. */
     protected val activationStore: ActivationStore
-
-    private implicit val emitter = this: PrintStreamEmitter
 
     /** Max duration for active ack. */
     protected val activeAckTimeout = 30 seconds
@@ -139,17 +139,17 @@ protected[actions] trait PrimitiveActions extends Logging {
         val promise = Promise[WhiskActivation]
         val docid = DocId(WhiskEntity.qualifiedName(user.namespace.toPath, activationId))
 
-        info(this, s"[POST] action activation will block on result up to $totalWaitTime")
+        logging.info(this, s"[POST] action activation will block on result up to $totalWaitTime")
 
         // the active ack will timeout after specified duration, causing the db polling to kick in
         activationResponse map {
             activation => promise.trySuccess(activation)
         } onFailure {
             case t: TimeoutException =>
-                info(this, s"[POST] switching to poll db, active ack expired")
+                logging.info(this, s"[POST] switching to poll db, active ack expired")
                 pollDbForResult(docid, activationId, promise)
             case t: Throwable =>
-                info(this, s"[POST] switching to poll db, active ack exception: ${t.getMessage}")
+                logging.info(this, s"[POST] switching to poll db, active ack exception: ${t.getMessage}")
                 pollDbForResult(docid, activationId, promise)
         }
 
@@ -186,14 +186,14 @@ protected[actions] trait PrimitiveActions extends Logging {
             } onFailure {
                 case e: NoDocumentException =>
                     Thread.sleep(500)
-                    debug(this, s"[POST] action activation not yet timed out, will poll for result")
+                    logging.debug(this, s"[POST] action activation not yet timed out, will poll for result")
                     pollDbForResult(docid, activationId, promise)
                 case t: Throwable =>
-                    error(this, s"[POST] action activation failed while waiting on result: ${t.getMessage}")
+                    logging.error(this, s"[POST] action activation failed while waiting on result: ${t.getMessage}")
                     promise.tryFailure(t)
             }
         } else {
-            info(this, s"[POST] action activation timed out, terminated polling for result")
+            logging.info(this, s"[POST] action activation timed out, terminated polling for result")
         }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -51,7 +51,6 @@ protected[actions] trait SequenceActions {
     /** An execution context for futures. */
     protected implicit val executionContext: ExecutionContext
 
-    /** logging */
     protected implicit val logging: Logging
 
     /** Database service to CRUD actions. */

--- a/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/SequenceActions.scala
@@ -32,7 +32,6 @@ import scala.util.Try
 import akka.actor.ActorSystem
 import spray.json._
 import whisk.common.Logging
-import whisk.common.PrintStreamEmitter
 import whisk.common.TransactionId
 import whisk.core.controller.WhiskActionsApi._
 import whisk.core.controller.WhiskServices
@@ -42,7 +41,7 @@ import whisk.core.entity.types._
 import whisk.http.Messages._
 import whisk.utils.ExecutionContextFactory.FutureExtensions
 
-protected[actions] trait SequenceActions extends Logging {
+protected[actions] trait SequenceActions {
     /** The core collections require backend services to be injected in this trait. */
     services: WhiskServices =>
 
@@ -52,13 +51,14 @@ protected[actions] trait SequenceActions extends Logging {
     /** An execution context for futures. */
     protected implicit val executionContext: ExecutionContext
 
+    /** logging */
+    protected implicit val logging: Logging
+
     /** Database service to CRUD actions. */
     protected val entityStore: EntityStore
 
     /** Database service to get activations. */
     protected val activationStore: ActivationStore
-
-    private implicit val emitter = this: PrintStreamEmitter
 
     /** A method that knows how to invoke a single primitive action. */
     protected[actions] def invokeSingleAction(
@@ -98,7 +98,7 @@ protected[actions] trait SequenceActions extends Logging {
 
         // create new activation id that corresponds to the sequence
         val seqActivationId = activationIdFactory.make()
-        info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
+        logging.info(this, s"invoking sequence $action topmost $topmost activationid '$seqActivationId'")
         val start = Instant.now(Clock.systemUTC())
         val seqActivationPromise = Promise[Option[WhiskActivation]]
         // the cause for the component activations is the current sequence
@@ -160,7 +160,7 @@ protected[actions] trait SequenceActions extends Logging {
                 // consider this whisk error
                 // TODO shall we attempt storing the activation if it exists or even inspect the futures?
                 // this should be a pretty serious whisk errror if it gets here
-                error(this, s"Sequence activation failed: ${t.getMessage}")
+                logging.error(this, s"Sequence activation failed: ${t.getMessage}")
         }
 
         response
@@ -170,10 +170,10 @@ protected[actions] trait SequenceActions extends Logging {
      * Stores sequence activation to database.
      */
     private def storeSequenceActivation(activation: WhiskActivation)(implicit transid: TransactionId): Unit = {
-        info(this, s"recording activation '${activation.activationId}'")
+        logging.info(this, s"recording activation '${activation.activationId}'")
         WhiskActivation.put(activationStore, activation) onComplete {
-            case Success(id) => info(this, s"recorded activation")
-            case Failure(t)  => error(this, s"failed to record activation")
+            case Success(id) => logging.info(this, s"recorded activation")
+            case Failure(t)  => logging.error(this, s"failed to record activation")
         }
     }
 
@@ -210,7 +210,7 @@ protected[actions] trait SequenceActions extends Logging {
         // compute duration
         val duration = (wskActivations map { activation =>
             activation.duration getOrElse {
-                error(this, s"duration for $activation is not defined")
+                logging.error(this, s"duration for $activation is not defined")
                 activation.end.toEpochMilli - activation.start.toEpochMilli
             }
         }).sum
@@ -282,7 +282,7 @@ protected[actions] trait SequenceActions extends Logging {
         cause: Option[ActivationId],
         atomicActionCnt: Int)(
             implicit transid: TransactionId): Vector[Future[(Either[ActivationResponse, WhiskActivation], Int)]] = {
-        info(this, s"invoke sequence $seqAction ($seqActivationId) with components $components")
+        logging.info(this, s"invoke sequence $seqAction ($seqActivationId) with components $components")
 
         // first retrieve the information/entities on all actions
         // do not wait to successfully retrieve all the actions before starting the execution
@@ -371,7 +371,7 @@ protected[actions] trait SequenceActions extends Logging {
         val futureWhiskActivationTuple = action.exec match {
             case SequenceExec(components) =>
                 // invoke a sequence
-                info(this, s"sequence invoking an enclosed sequence $action")
+                logging.info(this, s"sequence invoking an enclosed sequence $action")
                 // call invokeSequence to invoke the inner sequence
                 // true for blocking; false for topmost
                 invokeSequence(user, action, payload, blocking = true, topmost = false, components, cause, atomicActionCount) map {
@@ -380,7 +380,7 @@ protected[actions] trait SequenceActions extends Logging {
                 }
             case _ =>
                 // this is an invoke for an atomic action
-                info(this, s"sequence invoking an enclosed atomic action $action")
+                logging.info(this, s"sequence invoking an enclosed atomic action $action")
                 val timeout = action.limits.timeout.duration + blockingInvokeGrace
                 invokeSingleAction(user, action, payload, timeout, blocking = true, cause) map {
                     case (activationId, wskActivation) => (activationId, wskActivation, atomicActionCount + 1)

--- a/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/ActivationThrottler.scala
@@ -20,8 +20,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 import akka.actor.ActorSystem
-import spray.json.DefaultJsonProtocol._
 import spray.json._
+import spray.json.DefaultJsonProtocol._
 import whisk.common.ConsulClient
 import whisk.common.ConsulKV.ControllerKeys
 import whisk.common.Logging
@@ -38,9 +38,9 @@ import whisk.core.loadBalancer.LoadBalancer
  * @param config containing the config information needed (consulServer)
  */
 class ActivationThrottler(consulServer: String, loadBalancer: LoadBalancer, concurrencyLimit: Int, systemOverloadLimit: Int)(
-    implicit val system: ActorSystem) extends Logging {
+    implicit val system: ActorSystem, logging: Logging) {
 
-    info(this, s"concurrencyLimit = $concurrencyLimit, systemOverloadLimit = $systemOverloadLimit")
+    logging.info(this, s"concurrencyLimit = $concurrencyLimit, systemOverloadLimit = $systemOverloadLimit")
 
     implicit private val executionContext = system.dispatcher
 

--- a/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/whisk/core/entitlement/Collection.scala
@@ -20,7 +20,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import Privilege.Privilege
-import akka.event.Logging.LogLevel
 import spray.http.HttpMethod
 import spray.http.HttpMethods.DELETE
 import spray.http.HttpMethods.GET
@@ -47,8 +46,7 @@ import whisk.core.entity.types.EntityStore
  */
 protected[core] case class Collection protected (
     val path: String,
-    val listLimit: Int = 30)
-    extends Logging {
+    val listLimit: Int = 30) {
     override def toString = path
 
     /** Determines the right to request for the resources and context. */
@@ -111,7 +109,7 @@ protected[core] object Collection {
 
     protected[core] def apply(name: String) = collections.get(name).get
 
-    protected[core] def initialize(entityStore: EntityStore, verbosity: LogLevel) = {
+    protected[core] def initialize(entityStore: EntityStore)(implicit logging: Logging) = {
         register(new ActionCollection(entityStore))
         register(new Collection(TRIGGERS))
         register(new Collection(RULES))
@@ -136,7 +134,5 @@ protected[core] object Collection {
 
             protected override val allowedEntityRights = Set(Privilege.READ)
         })
-
-        collections foreach { case (n, c) => c.setVerbosity(verbosity) }
     }
 }

--- a/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
+++ b/core/controller/src/main/scala/whisk/core/iam/NamespaceProvider.scala
@@ -45,8 +45,7 @@ object NamespaceProvider {
 }
 
 protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDuration = 5 seconds, forceLocal: Boolean = false)(
-    implicit actorSystem: ActorSystem)
-    extends Logging {
+    implicit actorSystem: ActorSystem, logging: Logging) {
 
     private implicit val executionContext = actorSystem.dispatcher
     private val apiLocation = config.iamProviderHost
@@ -62,7 +61,7 @@ protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDura
      */
     protected[core] def namespaces(subject: Subject)(implicit transid: TransactionId): Future[Set[String]] = {
         if (useProvider) {
-            info(this, s"getting namespaces from ${apiLocation}")
+            logging.info(this, s"getting namespaces from ${apiLocation}")
 
             val url = Uri("http://" + apiLocation + "/namespaces").withQuery(
                 "subject" -> subject.asString)
@@ -74,7 +73,7 @@ protected[core] class NamespaceProvider(config: WhiskConfig, timeout: FiniteDura
 
             pipeline(Get(url))
         } else {
-            info(this, s"assuming default namespaces")
+            logging.info(this, s"assuming default namespaces")
             Future.successful(NamespaceProvider.defaultNamespaces(subject))
         }
     }

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -16,14 +16,16 @@
 
 package whisk.core.container
 
-import akka.event.Logging.ErrorLevel
 import java.io.{ File, FileNotFoundException }
-import scala.util.Try
-import scala.language.postfixOps
-import spray.json._
-import DefaultJsonProtocol._
 
-import whisk.common.{ Logging, SimpleExec, TransactionId, LoggingMarkers, PrintStreamEmitter }
+import scala.language.postfixOps
+import scala.util.Try
+
+import akka.event.Logging.ErrorLevel
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.{ Logging, SimpleExec, TransactionId, LoggingMarkers }
+import whisk.common.Logging
 import whisk.core.entity.ActionLimits
 
 /**
@@ -31,7 +33,10 @@ import whisk.core.entity.ActionLimits
  */
 case class ContainerState(id: ContainerHash, image: String, name: ContainerName)
 
-trait ContainerUtils extends Logging {
+trait ContainerUtils {
+
+    /** logging */
+    implicit val logging: Logging
 
     /** Defines the docker host, optional **/
     val dockerhost: String
@@ -141,7 +146,7 @@ trait ContainerUtils extends Logging {
             getDockerLogFile(containerId, mounted).length
         } catch {
             case e: Exception =>
-                error(this, s"getDockerLogSize failed on ${containerId.id}")
+                logging.error(this, s"getDockerLogSize failed on ${containerId.id}")
                 0
         }
     }
@@ -166,7 +171,7 @@ trait ContainerUtils extends Logging {
             buffer.array
         } catch {
             case e: Exception =>
-                error(this, s"getDockerLogContent failed on ${containerHash.hash}: ${e.getClass}: ${e.getMessage}")
+                logging.error(this, s"getDockerLogContent failed on ${containerHash.hash}: ${e.getClass}: ${e.getMessage}")
                 Array()
         } finally {
             if (fis != null) fis.close()
@@ -183,7 +188,7 @@ trait ContainerUtils extends Logging {
             getContainerIpAddrViaInspect(container)
         } else {
             getContainerIpAddrViaConfig(container, network).toOption orElse {
-                warn(this, "Failed to obtain IP address of container via config file.  Falling back to inspect.")
+                logging.warn(this, "Failed to obtain IP address of container via config file.  Falling back to inspect.")
                 getContainerIpAddrViaInspect(container)
             }
         }
@@ -210,7 +215,7 @@ trait ContainerUtils extends Logging {
      * Synchronously runs the given docker command returning stdout if successful.
      */
     private def runDockerCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): DockerOutput =
-        ContainerUtils.runDockerCmd(dockerhost, skipLogError, args)(transid)
+        ContainerUtils.runDockerCmd(dockerhost, skipLogError, args)(transid, logging)
 
     /**
      * Obtain the per container directory Docker maintains for each container.
@@ -257,14 +262,12 @@ trait ContainerUtils extends Logging {
     }
 }
 
-object ContainerUtils extends Logging {
-
-    private implicit val emitter: PrintStreamEmitter = this
+object ContainerUtils {
 
     /**
      * Synchronously runs the given docker command returning stdout if successful.
      */
-    def runDockerCmd(dockerhost: String, skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): DockerOutput = {
+    def runDockerCmd(dockerhost: String, skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId, logging: Logging): DockerOutput = {
         val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD(args(0)))
 
         try {
@@ -311,7 +314,7 @@ object ContainerUtils extends Logging {
      * Pulls container images.
      */
     @throws[ContainerError]
-    def pullImage(dockerhost: String, image: String)(implicit transid: TransactionId): DockerOutput = {
+    def pullImage(dockerhost: String, image: String)(implicit transid: TransactionId, logging: Logging): DockerOutput = {
         val cmd = Array("pull", image)
         val result = runDockerCmd(dockerhost, false, cmd)
         if (result != DockerOutput.unavailable) {

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerUtils.scala
@@ -35,7 +35,6 @@ case class ContainerState(id: ContainerHash, image: String, name: ContainerName)
 
 trait ContainerUtils {
 
-    /** logging */
     implicit val logging: Logging
 
     /** Defines the docker host, optional **/

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -17,21 +17,18 @@
 package whisk.core.container
 
 import akka.event.Logging.ErrorLevel
+import whisk.common.{ Logging, LoggingMarkers, SimpleExec, TransactionId }
 
-import whisk.common.{ Logging, SimpleExec, TransactionId, LoggingMarkers, PrintStreamEmitter }
+object RuncUtils {
 
-object RuncUtils extends Logging {
-
-    private implicit val emitter: PrintStreamEmitter = this
-
-    def list()(implicit transid: TransactionId): (Int, String) = {
+    def list()(implicit transid: TransactionId, logging: Logging): (Int, String) = {
         runRuncCmd(false, Seq("list"))
     }
 
     /**
      * Synchronously runs the given runc command returning stdout if successful.
      */
-    def runRuncCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId): (Int, String) = {
+    def runRuncCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId, logging: Logging): (Int, String) = {
         val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD("runc_" + args(0)))
         try {
             val fullCmd = getRuncCmd() ++ args
@@ -64,6 +61,5 @@ object RuncUtils extends Logging {
         val runcBin = "/usr/bin/docker-runc"
         Seq(runcBin)
     }
-
 
 }

--- a/core/invoker/src/main/scala/whisk/core/dispatcher/Dispatcher.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/Dispatcher.scala
@@ -25,7 +25,6 @@ import scala.util.Success
 import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.actor.actorRef2Scala
-import akka.event.Logging.LogLevel
 import whisk.common.Counter
 import whisk.common.Logging
 import whisk.common.TransactionId
@@ -47,17 +46,14 @@ import whisk.core.connector.MessageConsumer
  */
 @throws[IllegalArgumentException]
 class Dispatcher(
-    verbosity: LogLevel,
     consumer: MessageConsumer,
     pollDuration: FiniteDuration,
     maxPipelineDepth: Int,
-    actorSystem: ActorSystem)
-    extends Registrar
-    with Logging {
+    actorSystem: ActorSystem)(
+        implicit logging: Logging)
+    extends Registrar {
 
-    setVerbosity(verbosity)
-
-    val activationFeed = actorSystem.actorOf(Props(new ActivationFeed(this: Logging, consumer, maxPipelineDepth, pollDuration, process)))
+    val activationFeed = actorSystem.actorOf(Props(new ActivationFeed(logging, consumer, maxPipelineDepth, pollDuration, process)))
 
     def start() = activationFeed ! ActivationFeed.FillQueueWithMessages
     def stop() = consumer.close()
@@ -77,7 +73,7 @@ class Dispatcher(
                 handlers foreach {
                     case (name, handler) => handleMessage(handler, m)
                 }
-            case Failure(t) => info(this, errorMsg(raw, t))
+            case Failure(t) => logging.info(this, errorMsg(raw, t))
         }
     }
 
@@ -87,17 +83,17 @@ class Dispatcher(
 
         Future {
             val count = counter.next()
-            debug(this, s"activeCount = $count while handling ${handler.name}")
+            logging.debug(this, s"activeCount = $count while handling ${handler.name}")
             handler.onMessage(msg) // returns a future which is flat-mapped via identity to hang onComplete
         } flatMap (identity) onComplete {
-            case Success(a) => debug(this, s"activeCount = ${counter.prev()} after handling ${handler.name}")
-            case Failure(t) => error(this, s"activeCount = ${counter.prev()} ${errorMsg(handler, t)}")
+            case Success(a) => logging.debug(this, s"activeCount = ${counter.prev()} after handling ${handler.name}")
+            case Failure(t) => logging.error(this, s"activeCount = ${counter.prev()} ${errorMsg(handler, t)}")
         }
     }
 
     private def inform(matchers: TrieMap[String, MessageHandler])(implicit transid: TransactionId) = {
         val names = matchers map { _._2.name } reduce (_ + "," + _)
-        debug(this, s"matching message to ${matchers.size} handlers: $names")
+        logging.debug(this, s"matching message to ${matchers.size} handlers: $names")
         matchers
     }
 

--- a/tests/src/common/StreamLogging.scala
+++ b/tests/src/common/StreamLogging.scala
@@ -22,6 +22,12 @@ import java.io.PrintStream
 import whisk.common.Logging
 import whisk.common.PrintStreamLogging
 
+/**
+ * Logging facility, that can be used by tests.
+ *
+ * It contains the implicit Logging-instance, that is needed implicitly for some methods and classes.
+ * the logger logs to the stream, that can be accessed from your test, to check if a specific message has been written.
+ */
 trait StreamLogging {
     val stream = new ByteArrayOutputStream
     val printstream = new PrintStream(stream)

--- a/tests/src/common/StreamLogging.scala
+++ b/tests/src/common/StreamLogging.scala
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package whisk.core.invoker
+package common
 
-import akka.actor.Actor
-import whisk.http.BasicRasService
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 
-/**
- * Implements web server to handle certain REST API calls.
- * Currently provides a health ping route, only.
- */
-trait InvokerServer
-    extends BasicRasService
-    with Actor {
+import whisk.common.Logging
+import whisk.common.PrintStreamLogging
 
-    override def actorRefFactory = context
+trait StreamLogging {
+    val stream = new ByteArrayOutputStream
+    val printstream = new PrintStream(stream)
+    implicit val logging: Logging = new PrintStreamLogging(printstream)
 }

--- a/tests/src/system/basic/WskSequenceTests.scala
+++ b/tests/src/system/basic/WskSequenceTests.scala
@@ -21,23 +21,23 @@ import java.util.Date
 
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
+import scala.util.matching.Regex
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import common.StreamLogging
 import common.TestHelpers
 import common.TestUtils
 import common.TestUtils._
 import common.Wsk
 import common.WskProps
 import common.WskTestHelpers
-import spray.json.DefaultJsonProtocol._
 import spray.json._
+import spray.json.DefaultJsonProtocol._
 import spray.testkit.ScalatestRouteTest
 import whisk.core.WhiskConfig
 import whisk.http.Messages.sequenceIsTooLong
-
-import scala.util.matching.Regex
 
 /**
  * Tests sequence execution
@@ -47,7 +47,8 @@ import scala.util.matching.Regex
 class WskSequenceTests
     extends TestHelpers
     with ScalatestRouteTest
-    with WskTestHelpers {
+    with WskTestHelpers
+    with StreamLogging {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk
@@ -414,7 +415,7 @@ class WskSequenceTests
      * t trigger with payload
      * rule r: t -> s
      */
-    it should "execute a sequence that is part of a rule and pass the trigger parameters to the sequence" in withAssetCleaner(wskprops){
+    it should "execute a sequence that is part of a rule and pass the trigger parameters to the sequence" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val seqName = "seqRule"
             val actionName = "echo"
@@ -459,13 +460,13 @@ class WskSequenceTests
      * @param triggerPayload the payload used for the trigger (that should be reflected in the sequence result)
      */
     private def checkEchoSeqRuleResult(triggerFireRun: RunResult, seqName: String, triggerPayload: JsObject) = {
-         withActivation(wsk.activation, triggerFireRun) {
+        withActivation(wsk.activation, triggerFireRun) {
             triggerActivation =>
                 withActivationsFromEntity(wsk.activation, seqName, since = Some(Instant.ofEpochMilli(triggerActivation.start))) { activationList =>
                     activationList.head.response.result shouldBe Some(triggerPayload)
                     activationList.head.cause shouldBe None
                 }
-            }
+        }
     }
 
     /**

--- a/tests/src/whisk/common/ConfigTests.scala
+++ b/tests/src/whisk/common/ConfigTests.scala
@@ -21,8 +21,13 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
+import common.StreamLogging
+
 @RunWith(classOf[JUnitRunner])
-class ConfigTests extends FlatSpec with Matchers {
+class ConfigTests
+    extends FlatSpec
+    with Matchers
+    with StreamLogging {
 
     "Config" should "gets default value" in {
         val config = new Config(Map("a" -> "A"))(Map())

--- a/tests/src/whisk/common/SchedulerTests.scala
+++ b/tests/src/whisk/common/SchedulerTests.scala
@@ -19,6 +19,7 @@ package whisk.common
 import java.time.Instant
 
 import scala.collection.mutable.Buffer
+import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -29,12 +30,15 @@ import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
 import akka.actor.PoisonPill
-
+import common.StreamLogging
 import common.WskActorSystem
-import scala.concurrent.Await
 
 @RunWith(classOf[JUnitRunner])
-class SchedulerTests extends FlatSpec with Matchers with WskActorSystem {
+class SchedulerTests
+    extends FlatSpec
+    with Matchers
+    with WskActorSystem
+    with StreamLogging {
 
     val timeBetweenCalls = 50 milliseconds
     val callsToProduce = 5

--- a/tests/src/whisk/consul/ConsulClientTests.scala
+++ b/tests/src/whisk/consul/ConsulClientTests.scala
@@ -31,6 +31,7 @@ import akka.http.scaladsl.marshalling._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling._
 import akka.stream.ActorMaterializer
+import common.StreamLogging
 import common.WskActorSystem
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -40,7 +41,12 @@ import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 
 @RunWith(classOf[JUnitRunner])
-class ConsulClientTests extends FlatSpec with ScalaFutures with Matchers with WskActorSystem {
+class ConsulClientTests
+    extends FlatSpec
+    with ScalaFutures
+    with Matchers
+    with WskActorSystem
+    with StreamLogging {
 
     implicit val testConfig = PatienceConfig(5.seconds)
     implicit val materializer = ActorMaterializer()
@@ -58,12 +64,10 @@ class ConsulClientTests extends FlatSpec with ScalaFutures with Matchers with Ws
     def registerService(name: String, id: String, checkScript: Option[String] = None) = {
         val obj = Map(
             "ID" -> id.toJson,
-            "Name" -> name.toJson
-        ) ++ checkScript.map { script =>
+            "Name" -> name.toJson) ++ checkScript.map { script =>
                 "Check" -> JsObject(
                     "Script" -> script.toJson,
-                    "Interval" -> s"${checkInterval.toSeconds}s".toJson
-                )
+                    "Interval" -> s"${checkInterval.toSeconds}s".toJson)
             }
 
         Marshal(obj.toJson).to[RequestEntity].flatMap { entity =>
@@ -71,9 +75,7 @@ class ConsulClientTests extends FlatSpec with ScalaFutures with Matchers with Ws
                 HttpRequest(
                     method = HttpMethods.PUT,
                     uri = consulUri.withPath(Uri.Path("/v1/agent/service/register")),
-                    entity = entity
-                )
-            )
+                    entity = entity))
             r.flatMap { response =>
                 Unmarshal(response).to[Any]
             }
@@ -87,9 +89,7 @@ class ConsulClientTests extends FlatSpec with ScalaFutures with Matchers with Ws
         val r = Http().singleRequest(
             HttpRequest(
                 method = HttpMethods.PUT,
-                uri = consulUri.withPath(Uri.Path(s"/v1/agent/service/deregister/$id"))
-            )
-        )
+                uri = consulUri.withPath(Uri.Path(s"/v1/agent/service/deregister/$id"))))
         r.flatMap { response =>
             Unmarshal(response).to[Any]
         }

--- a/tests/src/whisk/consul/ConsulHealthTests.scala
+++ b/tests/src/whisk/consul/ConsulHealthTests.scala
@@ -16,6 +16,7 @@
 
 package whisk.consul
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 import org.junit.runner.RunWith
@@ -25,15 +26,19 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.time.Span.convertDurationToSpan
 
+import common.StreamLogging
+import common.WskActorSystem
 import whisk.common.ConsulClient
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 
-import common.WskActorSystem
-import scala.concurrent.Future
-
 @RunWith(classOf[JUnitRunner])
-class ConsulHealthTests extends FlatSpec with ScalaFutures with Matchers with WskActorSystem {
+class ConsulHealthTests
+    extends FlatSpec
+    with ScalaFutures
+    with Matchers
+    with WskActorSystem
+    with StreamLogging {
 
     implicit val testConfig = PatienceConfig(5.seconds)
 

--- a/tests/src/whisk/core/WhiskConfigTests.scala
+++ b/tests/src/whisk/core/WhiskConfigTests.scala
@@ -28,11 +28,16 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
+import common.StreamLogging
 import common.WskActorSystem
 import whisk.common.ConsulClient
 
 @RunWith(classOf[JUnitRunner])
-class WhiskConfigTests extends FlatSpec with Matchers with WskActorSystem {
+class WhiskConfigTests
+    extends FlatSpec
+    with Matchers
+    with WskActorSystem
+    with StreamLogging {
 
     behavior of "WhiskConfig"
 

--- a/tests/src/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
+++ b/tests/src/whisk/core/apigw/actions/test/ApiGwRoutemgmtActionTests.scala
@@ -19,20 +19,21 @@ package whisk.core.apigw.actions.test
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
-import spray.json.DefaultJsonProtocol._
-import spray.json._
 
 import common.JsHelpers
+import common.StreamLogging
 import common.TestHelpers
 import common.TestUtils.ANY_ERROR_EXIT
 import common.TestUtils.DONTCARE_EXIT
-import common.TestUtils.SUCCESS_EXIT
 import common.TestUtils.RunResult
+import common.TestUtils.SUCCESS_EXIT
 import common.Wsk
-import common.WskAdmin
 import common.WskActorSystem
+import common.WskAdmin
 import common.WskProps
 import common.WskTestHelpers
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 import whisk.core.WhiskConfig
 
 case class ApiAction(
@@ -47,8 +48,7 @@ case class ApiAction(
             "namespace" -> namespace.toJson,
             "backendMethod" -> backendMethod.toJson,
             "backendUrl" -> backendUrl.toJson,
-            "authkey" -> authkey.toJson
-        )
+            "authkey" -> authkey.toJson)
     }
 }
 
@@ -61,7 +61,8 @@ class ApiGwRoutemgmtActionTests
     with BeforeAndAfterAll
     with WskActorSystem
     with WskTestHelpers
-    with JsHelpers {
+    with JsHelpers
+    with StreamLogging {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk
@@ -297,30 +298,29 @@ class ApiGwRoutemgmtActionTests
             //createApi
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is required", Seq("-p", "__ow_meta_namespace", "_")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the namespace field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{}")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{}")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayBasePath field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_"}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayPath field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the gatewayMethod field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc is missing the action field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get"}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendMethod field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the backendUrl field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the namespace field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the name field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "action is missing the authkey field",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N"}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "swagger and gatewayBasePath are mutually exclusive and cannot be specified together",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", """{"namespace":"_","gatewayBasePath":"/ApiGwRoutemgmtActionTests_bp","gatewayPath":"ApiGwRoutemgmtActionTests_rp","gatewayMethod":"get","action":{"backendMethod":"post","backendUrl":"URL","namespace":"_","name":"N","authkey":"XXXX"},"swagger":{}}""")),
             ("/whisk.system/routemgmt/createApi", ANY_ERROR_EXIT, "apidoc field cannot be parsed. Ensure it is valid JSON",
-              Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{1:[}}}"))
-        )
+                Seq("-p", "__ow_meta_namespace", "_", "-p", "apidoc", "{1:[}}}")))
 
         invalidArgs foreach {
             case (action: String, exitcode: Int, errmsg: String, params: Seq[String]) =>
@@ -329,8 +329,7 @@ class ApiGwRoutemgmtActionTests
                     action,
                     "-i", "-b", "-r",
                     "--apihost", wskprops.apihost,
-                    "--auth", systemKey
-                ) ++ params
+                    "--auth", systemKey) ++ params
                 val rr = wsk.cli(cmd, expectedExitCode = exitcode)
                 rr.stderr should include regex (errmsg)
         }

--- a/tests/src/whisk/core/cli/test/SequenceMigrationTests.scala
+++ b/tests/src/whisk/core/cli/test/SequenceMigrationTests.scala
@@ -16,9 +16,15 @@
 package whisk.core.cli.test
 
 import java.util.Date
+
 import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
 import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfter
 import org.scalatest.junit.JUnitRunner
+
+import common.StreamLogging
 import common.TestHelpers
 import common.TestUtils
 import common.Wsk
@@ -29,11 +35,8 @@ import spray.json._
 import spray.json.DefaultJsonProtocol.StringJsonFormat
 import spray.testkit.ScalatestRouteTest
 import whisk.core.WhiskConfig
-import whisk.core.entity._
 import whisk.core.database.test.DbUtils
-import org.scalatest.BeforeAndAfter
-
-import scala.language.postfixOps
+import whisk.core.entity._
 
 /**
  * Tests that "old-style" sequences can be invoked
@@ -45,7 +48,8 @@ class SequenceMigrationTests
     with BeforeAndAfter
     with DbUtils
     with ScalatestRouteTest
-    with WskTestHelpers {
+    with WskTestHelpers
+    with StreamLogging {
 
     implicit val actorSystem = system
 

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -18,6 +18,7 @@ package whisk.core.container.test
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfter
@@ -26,25 +27,24 @@ import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
 import akka.event.Logging.ErrorLevel
+import common.StreamLogging
+import common.WskActorSystem
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.dockerEndpoint
 import whisk.core.WhiskConfig.edgeHostName
-import whisk.core.WhiskConfig.selfDockerEndpoint
 import whisk.core.WhiskConfig.invokerSerializeDockerOp
 import whisk.core.WhiskConfig.invokerSerializeDockerPull
+import whisk.core.WhiskConfig.selfDockerEndpoint
 import whisk.core.container.Container
 import whisk.core.container.ContainerPool
 import whisk.core.entity.AuthKey
 import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
 import whisk.core.entity.EntityPath
+import whisk.core.entity.Exec
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
-import scala.language.postfixOps
-
-import common.WskActorSystem
 
 /**
  * Unit tests for ContainerPool and, by association, Container and WhiskContainer.
@@ -53,19 +53,20 @@ import common.WskActorSystem
 class ContainerPoolTests extends FlatSpec
     with BeforeAndAfter
     with BeforeAndAfterAll
-    with WskActorSystem {
+    with WskActorSystem
+    with StreamLogging {
 
     implicit val transid = TransactionId.testing
 
     val config = new WhiskConfig(
         WhiskEntityStore.requiredProperties ++
-        WhiskAuthStore.requiredProperties ++
-        ContainerPool.requiredProperties ++
-        Map(selfDockerEndpoint -> "localhost",
-            dockerEndpoint -> null,
-            edgeHostName -> "localhost",
-            invokerSerializeDockerOp -> "true",
-            invokerSerializeDockerPull -> "true"))
+            WhiskAuthStore.requiredProperties ++
+            ContainerPool.requiredProperties ++
+            Map(selfDockerEndpoint -> "localhost",
+                dockerEndpoint -> null,
+                edgeHostName -> "localhost",
+                invokerSerializeDockerOp -> "true",
+                invokerSerializeDockerPull -> "true"))
 
     assert(config.isValid)
 

--- a/tests/src/whisk/core/controller/test/AuthenticateTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthenticateTests.scala
@@ -16,9 +16,6 @@
 
 package whisk.core.controller.test
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
-
 import scala.concurrent.Await
 
 import org.junit.runner.RunWith
@@ -63,29 +60,16 @@ class AuthenticateTests extends ControllerTestCommon with Authenticate {
         val pass = UserPass(creds.authkey.uuid.asString, creds.authkey.key.asString)
 
         // first query will be served from datastore
-        val stream = new ByteArrayOutputStream
-        val printstream = new PrintStream(stream)
-        val savedstream = authStore.outputStream
-        val savedVerbosity = authStore.getVerbosity()
-        authStore.outputStream = printstream
-        authStore.setVerbosity(akka.event.Logging.InfoLevel)
-        try {
-            val user = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
-            user.get should be(creds)
-            stream.toString should include regex (s"serving from datastore: ${creds.authkey.uuid.asString}")
-            stream.reset()
+        val user = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
+        user.get should be(creds)
+        stream.toString should include regex (s"serving from datastore: ${creds.authkey.uuid.asString}")
+        stream.reset()
 
-            // repeat query, should be served from cache
-            val cachedUser = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
-            cachedUser.get should be(creds)
-            stream.toString should include regex (s"serving from cache: ${creds.authkey.uuid.asString}")
-            stream.reset()
-        } finally {
-            authStore.outputStream = savedstream
-            authStore.setVerbosity(savedVerbosity)
-            stream.close()
-            printstream.close()
-        }
+        // repeat query, should be served from cache
+        val cachedUser = Await.result(validateCredentials(Some(pass))(transid()), dbOpTimeout)
+        cachedUser.get should be(creds)
+        stream.toString should include regex (s"serving from cache: ${creds.authkey.uuid.asString}")
+        stream.reset()
     }
 
     it should "not authorize a known user with an invalid key" in {

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -16,8 +16,6 @@
 
 package whisk.core.controller.test
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import java.time.Instant
 import java.util.Base64
 
@@ -29,7 +27,6 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
 
-import akka.event.Logging.InfoLevel
 import spray.http.FormData
 import spray.http.HttpMethods
 import spray.http.StatusCodes._
@@ -76,7 +73,6 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
 
     val creds = WhiskAuth(Subject(), AuthKey()).toIdentity
     val namespace = EntityPath(creds.subject.asString)
-    setVerbosity(InfoLevel)
 
     val packages = Seq(
         WhiskPackage(
@@ -162,7 +158,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
         if (namespace.asString == systemId.asString) {
             systemIdentity
         } else {
-            info(this, s"namespace has no identity")
+            logging.info(this, s"namespace has no identity")
             Future.failed(RejectRequest(BadRequest))
         }
     }
@@ -460,20 +456,11 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
 
     it should "warn if meta package is public" in {
         implicit val tid = transid()
-        val stream = new ByteArrayOutputStream
-        val printstream = new PrintStream(stream)
-        val savedstream = this.outputStream
-        this.outputStream = printstream
 
-        try {
-            Get(s"/$routePath/publicmeta") ~> sealRoute(routes(creds)) ~> check {
-                status should be(OK)
-                stream.toString should include regex (s"""[WARN] *.*publicmeta@0.0.1' is public""")
-                stream.reset()
-            }
-        } finally {
-            stream.close()
-            printstream.close()
+        Get(s"/$routePath/publicmeta") ~> sealRoute(routes(creds)) ~> check {
+            status should be(OK)
+            stream.toString should include regex (s"""[WARN] *.*publicmeta@0.0.1' is public""")
+            stream.reset()
         }
     }
 

--- a/tests/src/whisk/core/controller/test/RateThrottleTests.scala
+++ b/tests/src/whisk/core/controller/test/RateThrottleTests.scala
@@ -23,6 +23,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
+import common.StreamLogging
 import whisk.common.TransactionId
 import whisk.core.entitlement._
 import whisk.core.entity.Subject
@@ -34,7 +35,11 @@ import whisk.core.entity.Subject
  * "using Specification DSL to write unit tests, as in should, must, not, be"
  */
 @RunWith(classOf[JUnitRunner])
-class RateThrottleTests extends FlatSpec with Matchers {
+class RateThrottleTests
+    extends FlatSpec
+    with Matchers
+    with StreamLogging {
+
     implicit val transid = TransactionId.testing
     val subject = Subject()
 

--- a/tests/src/whisk/core/controller/test/SequenceApiTests.scala
+++ b/tests/src/whisk/core/controller/test/SequenceApiTests.scala
@@ -16,15 +16,12 @@
 
 package whisk.core.controller.test
 
-import java.io.PrintStream
-
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import akka.event.Logging.DebugLevel
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json._
@@ -51,9 +48,6 @@ class SequenceApiTests
     val defaultNamespace = EntityPath.DEFAULT
     def aname() = MakeName.next("sequence_tests")
     val allowedActionDuration = 120 seconds
-
-    // set logging level to debug
-    setVerbosity(DebugLevel)
 
     it should "reject creation of sequence with more actions than allowed limit" in {
         implicit val tid = transid()
@@ -300,19 +294,11 @@ class SequenceApiTests
         val sSeq = makeSimpleSequence(sSeqName, namespace, Vector(xSeqName, xSeqName), false) // x is installed in the db already
         val content = WhiskActionPut(Some(sSeq.exec))
 
-        implicit val stream = new java.io.ByteArrayOutputStream
-        this.outputStream = new PrintStream(stream)
-        try {
-            stream.reset()
-            Console.withOut(stream) {
-                Put(s"$collectionPath/$sSeqName", content) ~> sealRoute(routes(creds)) ~> check {
-                    status should be(OK)
-                    logContains(s"atomic action count ${2 * actionCnt}")
-                }
+        Console.withOut(stream) {
+            Put(s"$collectionPath/$sSeqName", content) ~> sealRoute(routes(creds)) ~> check {
+                status should be(OK)
+                logContains(s"atomic action count ${2 * actionCnt}")(stream)
             }
-        } finally {
-            stream.close()
-            this.outputStream.close()
         }
     }
 
@@ -348,56 +334,49 @@ class SequenceApiTests
         // create an action sequence s
         val content = WhiskActionPut(Some(sSeq.exec))
 
-        implicit val stream = new java.io.ByteArrayOutputStream
-        this.outputStream = new PrintStream(stream)
-        try {
-            stream.reset()
-            Console.withOut(stream) {
-                Put(s"$collectionPath/$sAct", content) ~> sealRoute(routes(creds)) ~> check {
-                    status should be(OK)
-                }
-                logContains("atomic action count 4")
+        stream.reset()
+        Console.withOut(stream) {
+            Put(s"$collectionPath/$sAct", content) ~> sealRoute(routes(creds)) ~> check {
+                status should be(OK)
             }
+            logContains("atomic action count 4")(stream)
+        }
 
-            // update action z to point to s --- should be rejected
-            val zUpdate = makeSimpleSequence(zAct, namespace, Vector(s"$sAct"), false) // s in the db already
-            val zUpdateContent = WhiskActionPut(Some(zUpdate.exec))
-            Put(s"$collectionPath/$zAct?overwrite=true", zUpdateContent) ~> sealRoute(routes(creds)) ~> check {
-                status should be(BadRequest)
-                responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-            }
+        // update action z to point to s --- should be rejected
+        val zUpdate = makeSimpleSequence(zAct, namespace, Vector(s"$sAct"), false) // s in the db already
+        val zUpdateContent = WhiskActionPut(Some(zUpdate.exec))
+        Put(s"$collectionPath/$zAct?overwrite=true", zUpdateContent) ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+        }
 
-            // update action s to point to a, s, b --- should be rejected
-            val sUpdate = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$sAct", s"$bAct"), false) // s in the db already
-            val sUpdateContent = WhiskActionPut(Some(sUpdate.exec))
-            Put(s"$collectionPath/$sAct?overwrite=true", sUpdateContent) ~> sealRoute(routes(creds)) ~> check {
-                status should be(BadRequest)
-                responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
-            }
+        // update action s to point to a, s, b --- should be rejected
+        val sUpdate = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$sAct", s"$bAct"), false) // s in the db already
+        val sUpdateContent = WhiskActionPut(Some(sUpdate.exec))
+        Put(s"$collectionPath/$sAct?overwrite=true", sUpdateContent) ~> sealRoute(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[ErrorResponse].error shouldBe Messages.sequenceIsCyclic
+        }
 
-            // update action z to point to y
-            val zSeq = makeSimpleSequence(zAct, namespace, Vector(s"$yAct"), false) // y  in the db already
-            val updateContent = WhiskActionPut(Some(zSeq.exec))
-            stream.reset()
-            Console.withOut(stream) {
-                Put(s"$collectionPath/$zAct?overwrite=true", updateContent) ~> sealRoute(routes(creds)) ~> check {
-                    status should be(OK)
-                }
-                logContains("atomic action count 1")
+        // update action z to point to y
+        val zSeq = makeSimpleSequence(zAct, namespace, Vector(s"$yAct"), false) // y  in the db already
+        val updateContent = WhiskActionPut(Some(zSeq.exec))
+        stream.reset()
+        Console.withOut(stream) {
+            Put(s"$collectionPath/$zAct?overwrite=true", updateContent) ~> sealRoute(routes(creds)) ~> check {
+                status should be(OK)
             }
-            // update sequence s to s -> a, x, y, a, b
-            val newS = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct", s"$aAct", s"$bAct"), false) // a, x, y, b  in the db already
-            val newSContent = WhiskActionPut(Some(newS.exec))
-            stream.reset()
-            Console.withOut(stream) {
-                Put(s"${collectionPath}/$sAct?overwrite=true", newSContent) ~> sealRoute(routes(creds)) ~> check {
-                    status should be(OK)
-                }
-                logContains("atomic action count 6")
+            logContains("atomic action count 1")(stream)
+        }
+        // update sequence s to s -> a, x, y, a, b
+        val newS = makeSimpleSequence(sAct, namespace, Vector(s"$aAct", s"$xAct", s"$yAct", s"$aAct", s"$bAct"), false) // a, x, y, b  in the db already
+        val newSContent = WhiskActionPut(Some(newS.exec))
+        stream.reset()
+        Console.withOut(stream) {
+            Put(s"${collectionPath}/$sAct?overwrite=true", newSContent) ~> sealRoute(routes(creds)) ~> check {
+                status should be(OK)
             }
-        } finally {
-            stream.close()
-            this.outputStream.close()
+            logContains("atomic action count 6")(stream)
         }
     }
 

--- a/tests/src/whisk/core/database/test/CouchDbRestClientTests.scala
+++ b/tests/src/whisk/core/database/test/CouchDbRestClientTests.scala
@@ -35,6 +35,7 @@ import akka.actor.Props
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl._
 import akka.util.ByteString
+import common.StreamLogging
 import common.WskActorSystem
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -48,7 +49,8 @@ class CouchDbRestClientTests extends FlatSpec
     with ScalaFutures
     with BeforeAndAfterAll
     with WskActorSystem
-    with DbUtils {
+    with DbUtils
+    with StreamLogging {
 
     override implicit val patienceConfig = PatienceConfig(timeout = 10.seconds, interval = 0.5.seconds)
 

--- a/tests/src/whisk/core/database/test/ExtendedCouchDbRestClient.scala
+++ b/tests/src/whisk/core/database/test/ExtendedCouchDbRestClient.scala
@@ -19,16 +19,15 @@ import scala.concurrent.Future
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-
+import whisk.common.Logging
 import whisk.core.database.CouchDbRestClient
 
 /**
  * Implementation of additional endpoints that should only be used in testing.
  */
-class ExtendedCouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem)
+class ExtendedCouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(implicit system: ActorSystem, logging: Logging)
     extends CouchDbRestClient(protocol, host, port, username, password, db) {
 
     // http://docs.couchdb.org/en/1.6.1/api/server/common.html#get--

--- a/tests/src/whisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/whisk/core/database/test/ReplicatorTests.scala
@@ -17,6 +17,7 @@
 package whisk.core.database.test
 
 import java.io.File
+import java.time.Instant
 
 import scala.concurrent.duration._
 import scala.language.implicitConversions
@@ -28,16 +29,16 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.junit.JUnitRunner
 
+import akka.http.scaladsl.model.StatusCodes
+import common.StreamLogging
 import common.TestUtils
+import common.WaitFor
 import common.WhiskProperties
 import common.WskActorSystem
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.core.WhiskConfig._
 import whisk.core.WhiskConfig
-import common.WaitFor
-import java.time.Instant
-import akka.http.scaladsl.model.StatusCodes
 import whisk.utils.retry
 
 @RunWith(classOf[JUnitRunner])
@@ -46,7 +47,8 @@ class ReplicatorTests extends FlatSpec
     with ScalaFutures
     with WskActorSystem
     with IntegrationPatience
-    with WaitFor {
+    with WaitFor
+    with StreamLogging {
 
     val config = new WhiskConfig(Map(
         dbProvider -> null,

--- a/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
+++ b/tests/src/whisk/core/dispatcher/test/ActivationResponseTests.scala
@@ -25,17 +25,17 @@ import org.scalatest.junit.JUnitRunner
 
 import spray.json.pimpAny
 import spray.json.pimpString
-import whisk.common.Logging
+import whisk.common.PrintStreamLogging
 import whisk.core.entity.ActivationResponse._
-import whisk.http.Messages._
 import whisk.core.entity.size.SizeInt
+import whisk.http.Messages._
 
 @RunWith(classOf[JUnitRunner])
 class ActivationResponseTests extends FlatSpec with Matchers {
 
     behavior of "ActivationResponse"
 
-    val logger = new Logging {}
+    val logger = new PrintStreamLogging()
 
     it should "interpret truncated response" in {
         val max = 5.B

--- a/tests/src/whisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/whisk/core/entity/test/DatastoreTests.scala
@@ -27,28 +27,26 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
 
-import akka.event.Logging.InfoLevel
+import common.StreamLogging
+import common.WskActorSystem
 import whisk.core.WhiskConfig
 import whisk.core.database.DocumentConflictException
 import whisk.core.database.NoDocumentException
 import whisk.core.database.test.DbUtils
 import whisk.core.entity._
 
-import common.WskActorSystem
-
 @RunWith(classOf[JUnitRunner])
 class DatastoreTests extends FlatSpec
     with BeforeAndAfter
     with BeforeAndAfterAll
     with WskActorSystem
-    with DbUtils {
+    with DbUtils
+    with StreamLogging {
 
     val namespace = EntityPath("test namespace")
     val config = new WhiskConfig(WhiskAuthStore.requiredProperties ++ WhiskEntityStore.requiredProperties)
     val datastore = WhiskEntityStore.datastore(config)
     val authstore = WhiskAuthStore.datastore(config)
-    datastore.setVerbosity(InfoLevel)
-    authstore.setVerbosity(InfoLevel)
 
     override def afterAll() {
         println("Shutting down store connections")

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -18,13 +18,20 @@ package whisk.core.entity.test
 
 import java.time.Clock
 import java.time.Instant
+
 import scala.concurrent.Await
+import scala.language.postfixOps
 import scala.util.Try
+
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+
+import common.StreamLogging
+import common.WskActorSystem
 import spray.json.JsObject
 import whisk.core.WhiskConfig
 import whisk.core.database.test.DbUtils
@@ -32,28 +39,23 @@ import whisk.core.entity.ActivationId
 import whisk.core.entity.AuthKey
 import whisk.core.entity.Binding
 import whisk.core.entity.EntityName
-import whisk.core.entity.Exec
 import whisk.core.entity.EntityPath
+import whisk.core.entity.Exec
+import whisk.core.entity.FullyQualifiedEntityName
 import whisk.core.entity.Subject
 import whisk.core.entity.WhiskAction
 import whisk.core.entity.WhiskActivation
 import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityQueries.listAllInNamespace
-import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
-import whisk.core.entity.WhiskEntityQueries.listCollectionInAnyNamespace
 import whisk.core.entity.WhiskEntityQueries.listCollectionByName
+import whisk.core.entity.WhiskEntityQueries.listCollectionInAnyNamespace
 import whisk.core.entity.WhiskEntityQueries.listCollectionInNamespace
+import whisk.core.entity.WhiskEntityQueries.listEntitiesInNamespace
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskPackage
 import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
-import org.scalatest.BeforeAndAfterAll
-import scala.language.postfixOps
-import akka.event.Logging.InfoLevel
-
-import common.WskActorSystem
-import whisk.core.entity.FullyQualifiedEntityName
 
 @RunWith(classOf[JUnitRunner])
 class ViewTests extends FlatSpec
@@ -61,7 +63,8 @@ class ViewTests extends FlatSpec
     with BeforeAndAfterAll
     with Matchers
     with DbUtils
-    with WskActorSystem {
+    with WskActorSystem
+    with StreamLogging {
 
     def aname = MakeName.next("viewtests")
     def afullname(namespace: EntityPath) = FullyQualifiedEntityName(namespace, aname)
@@ -82,7 +85,6 @@ class ViewTests extends FlatSpec
 
     val config = new WhiskConfig(WhiskEntityStore.requiredProperties)
     val datastore = WhiskEntityStore.datastore(config)
-    datastore.setVerbosity(InfoLevel)
 
     after {
         cleanup()


### PR DESCRIPTION
This PR changes the logging of OpenWhisk.
Currently we have a trait, that can be extended if you want to log something. The problem is, that this uses `println`, which locks our processes on heavy load.
Now, one `logging`-instance is created on startup and passed around. The new logging also uses akka logging.