### PR TITLE
Add Runc pause capability (but unused)

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -31,6 +31,7 @@ import whisk.common.Counter
  */
 class Container(
     originalId: TransactionId,
+    useRunc: Boolean,
     val dockerhost: String,
     mounted: Boolean,
     val key: ActionContainerId,

--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -62,9 +62,19 @@ class Container(
         s"container [$name] [$id] [$ip]"
     }
 
-    def pause(): Unit = pauseContainer(containerId)
+    def pause(): Unit =
+        if (useRunc) {
+            RuncUtils.pause(containerId)
+        } else {
+            pauseContainer(containerId)
+        }
 
-    def unpause(): Unit = unpauseContainer(containerId)
+    def unpause(): Unit =
+        if (useRunc) {
+            RuncUtils.resume(containerId)
+        } else {
+            unpauseContainer(containerId)
+        }
 
     /**
      * A prefix of the container id known to be displayed by docker ps.

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -628,7 +628,7 @@ class ContainerPool(
                 // because of the docker lock, by the time the container gets around to be started
                 // there could be a container to reuse (from a previous run of the same action, or
                 // from a stem cell container); should revisit this logic
-                new WhiskContainer(transid, this.dockerhost, mounted, key, containerName, imageName,
+                new WhiskContainer(transid, useRunc, this.dockerhost, mounted, key, containerName, imageName,
                     network, cpuShare, policy, env, limits, logLevel = this.getVerbosity())
             }
         }
@@ -647,7 +647,8 @@ class ContainerPool(
      */
     private def makeContainer(key: ActionContainerId, imageName: String, args: Array[String])(implicit transid: TransactionId): WhiskContainer = {
         val con = runDockerOp {
-            new WhiskContainer(transid, this.dockerhost, mounted, key, makeContainerName("testContainer"), imageName,
+            new WhiskContainer(transid, useRunc, this.dockerhost, mounted,
+                key, makeContainerName("testContainer"), imageName,
                 config.invokerContainerNetwork, ContainerPool.cpuShare(config),
                 config.invokerContainerPolicy, Map(), ActionLimits(), args,
                 this.getVerbosity())

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -28,11 +28,11 @@ object RuncUtils extends Logging {
         runRuncCmd(false, Seq("list"))
     }
 
-    def pause()(implicit transid: TransactionId, id: ContainerIdentifier): (Int, String) = {
+    def pause(id: ContainerIdentifier)(implicit transid: TransactionId): (Int, String) = {
         runRuncCmd(false, Seq("pause", id.toString))
     }
 
-    def resume()(implicit transid: TransactionId, id: ContainerIdentifier): (Int, String) = {
+    def resume(id: ContainerIdentifier)(implicit transid: TransactionId): (Int, String) = {
         runRuncCmd(false, Seq("resume", id.toString))
     }
 

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -28,6 +28,14 @@ object RuncUtils extends Logging {
         runRuncCmd(false, Seq("list"))
     }
 
+    def pause()(implicit transid: TransactionId, id: ContainerIdentifier): (Int, String) = {
+        runRuncCmd(false, Seq("pause", id.toString))
+    }
+
+    def resume()(implicit transid: TransactionId, id: ContainerIdentifier): (Int, String) = {
+        runRuncCmd(false, Seq("resume", id.toString))
+    }
+
     /**
      * Synchronously runs the given runc command returning stdout if successful.
      */

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -47,6 +47,7 @@ import whisk.core.entity.ActivationResponse._
  */
 class WhiskContainer(
     originalId: TransactionId,
+    useRunc: Boolean,
     dockerhost: String,
     mounted: Boolean,
     key: ActionContainerId,
@@ -59,7 +60,7 @@ class WhiskContainer(
     limits: ActionLimits,
     args: Array[String] = Array(),
     logLevel: LogLevel)
-    extends Container(originalId, dockerhost, mounted, key, Some(containerName), image, network, cpuShare, policy, limits, env, args, logLevel) {
+    extends Container(originalId, useRunc, dockerhost, mounted, key, Some(containerName), image, network, cpuShare, policy, limits, env, args, logLevel) {
 
     var lastLogSize = 0L
     private implicit val emitter: PrintStreamEmitter = this


### PR DESCRIPTION
If whisk config requests use of runc and dynamic check of runc passes, then use runc for pausing and unpausing containers.   PG2-1044 (and 1045 after rebase).