### PR TITLE
Revert code that was not supposed to be part of last commit

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -59,19 +59,9 @@ class Container(
         s"container [$name] [$id] [$ip]"
     }
 
-    def pause(): Unit =
-        if (useRunc) {
-            RuncUtils.pause(containerId)
-        } else {
-            pauseContainer(containerId)
-        }
+    def pause(): Unit = pauseContainer(containerId)
 
-    def unpause(): Unit =
-        if (useRunc) {
-            RuncUtils.resume(containerId)
-        } else {
-            unpauseContainer(containerId)
-        }
+    def unpause(): Unit = unpauseContainer(containerId)
 
     /**
      * A prefix of the container id known to be displayed by docker ps.


### PR DESCRIPTION
Part of the runc pieces were prematurely committed.  This restores the intended commit pattern.