### PR TITLE
fix check in actionLimitTest

### DIFF
--- a/tests/src/whisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/whisk/core/limits/ActionLimitsTests.scala
@@ -229,8 +229,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers {
                     n.toInt should be >= minExpectedOpenFiles
 
                     activation.logs.getOrElse(List()).filter {
-                        // drop time stamp and stdout/err markers
-                        _.split(" ").drop(2).mkString(" ").startsWith("ERROR: opened files = ")
+                        _.contains("ERROR: opened files = ")
                     }.length shouldBe 1
             }
     }


### PR DESCRIPTION
testcase sometimes failes parsing the log string( because of the spaces after timestamp):
"2017-02-15T10:13:58.82285493Z  stdout: ERROR: opened files =  1011"

