### PR TITLE
Handle bytes to string conversion in actionproxy.

### DIFF
--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -134,17 +134,23 @@ class ActionRunner:
             return error(e)
 
         # run the process and wait until it completes.
+        # stdout/stderr will always be set because we passed PIPEs to Popen
         (o, e) = p.communicate()
 
-        if o is not None:
-            process_output_lines = o.strip().split('\n')
-            last_line = process_output_lines[-1]
-            for line in process_output_lines[:-1]:
-                sys.stdout.write('%s\n' % line)
-        else:
-            last_line = '{}'
+        # stdout/stderr may be either text or bytes, depending on Python
+        # version.   In the latter case, decode to text.
+        if isinstance(o, bytes):
+            o = o.decode('utf-8')
+        if isinstance(e, bytes):
+            e = e.decode('utf-8')
 
-        if e is not None:
+        # get the last line of stdout, even if empty
+        process_output_lines = o.strip().split('\n')
+        last_line = process_output_lines[-1]
+        for line in process_output_lines[:-1]:
+            sys.stdout.write('%s\n' % line)
+
+        if e:
             sys.stderr.write(e)
 
         try:

--- a/core/swift3Action/swift3runner.py
+++ b/core/swift3Action/swift3runner.py
@@ -61,14 +61,28 @@ class Swift3Runner(ActionRunner):
             os.chmod(self.binary, 0o555)
             return
 
-        p = subprocess.Popen(BUILD_PROCESS, cwd=DEST_SCRIPT_DIR)
+        p = subprocess.Popen(
+            BUILD_PROCESS,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=DEST_SCRIPT_DIR)
+
+        # run the process and wait until it completes.
+        # stdout/stderr will not be None because we passed PIPEs to Popen
         (o, e) = p.communicate()
 
-        if o is not None:
+        # stdout/stderr may be either text or bytes, depending on Python
+        # version.   In the latter case, decode to text.
+        if isinstance(o, bytes):
+            o = o.decode('utf-8')
+        if isinstance(e, bytes):
+            e = e.decode('utf-8')
+
+        if o:
             sys.stdout.write(o)
             sys.stdout.flush()
 
-        if e is not None:
+        if e:
             sys.stderr.write(e)
             sys.stderr.flush()
 


### PR DESCRIPTION
[actionproxy.py](https://github.com/openwhisk/openwhisk/blob/master/core/actionProxy/actionproxy.py#L130) assumes that subprocess output is a string, which is true in Python 2.  However,
Python 3 default behavior switched to returning bytes instead of strings.  (This [SO answer](http://stackoverflow.com/questions/21689365/python-3-typeerror-must-be-str-not-bytes-with-sys-stdout-write) provides a good explanation).  

If a user creates a Docker action that uses python 3 in their container, for example, invoking the action will fail with an internal error:

```
{
  "error": "Internal error."
}
```

After some local debugging in my own Docker container (using python 3), the issue is:

```
Traceback (most recent call last):
  File "actionproxy.py", line 207, in run
    (code, result) = runner.run(args, runner.env(message if message else {}))
  File "actionproxy.py", line 132, in run
    process_output_lines = o.strip().split('\n')
TypeError: a bytes-like object is required, not 'str'
```

or 

```
Traceback (most recent call last):
  File "actionproxy.py", line 207, in run
    (code, result) = runner.run(args, runner.env(message if message else {}))
  File "actionproxy.py", line 140, in run
    sys.stderr.write(e)
TypeError: write() argument must be str, not bytes
```

These changes work in both Python 2 and Python 3 environments.

Note that other spots like `sys.stdout.write('%s\n' % line)` work because of the implicit conversion to `str`.  In other words, we're getting lucky.  