### PR TITLE
Add nginx rewrite rule to permit vanity URLs for web actions.

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -19,6 +19,9 @@ http {
     server {
         listen 443 default ssl;
 
+        # match namespace, note while OpenWhisk allows a space and period, they are not permitted here
+        server_name ~^(?<namespace>[\w@-]+)\.*.*$;
+ 
         ssl_session_cache    shared:SSL:1m;
         ssl_session_timeout  10m;
         ssl_certificate      /etc/nginx/openwhisk-cert.pem;
@@ -28,6 +31,18 @@ http {
         ssl_ciphers RC4:HIGH:!aNULL:!MD5;
         ssl_prefer_server_ciphers on;
         proxy_ssl_session_reuse off;
+
+        # proxy to the web action path
+        location / {
+            rewrite    /(.*) /api/v1/experimental/web/${namespace}/$1 break;
+            proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+        }
+
+        # proxy to 'public/html' web action by convention
+        location = / {
+            rewrite    ^ /api/v1/experimental/web/${namespace}/public/index.html break;
+            proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};
+        }
 
         location /docs {
             proxy_pass http://{{ groups['controllers']|first }}:{{ controller.port }};

--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -166,3 +166,14 @@ When an OpenWhisk action fails, there are two different failure modes. The first
 
 Developers should be aware of how web actions might be used and generate error responses accordingly. For example, a web action that is used with the `.http` extension
 should return an HTTP response, for example: `{error: { code: 400 }`. Failing to do so will in a mismatch between the implied content-type from the extension and the action content-type in the error response. Special consideration must be given to web actions that are sequences, so that components that make up a sequence can generate adequate errors when necessary.
+
+## Vanity URL
+
+Web actions may be accessed via an alternate URL which treats the OpenWhisk namespace as a subdomain to the API host. This is suitable for developing web actions that use cookies or local storage so that data is not inadvertently made visible to other web actions in other namespaces. The namespaces must match the regular expression `[\w@-]+` for the edge router to rewrite the subdomain to the corresponding URI. For a conforming namespace, the URL `https://guest.openwhisk.host/public/index.html` becomes a alias for `https://openwhisk.host/api/v1/experimental/web/guest/public/index.html`.
+
+For added convenience, and to provide the equivalent of an `index.html`, the edge router will also proxy `https://guest.openwhisk.host` to `https://openwhisk.host/api/v1/experimental/web/guest/public/index.html` where `/guest/public/index.html` (i.e., action is called `index` in a package called `public`) is a web action that responds with HTML content. If the action does not exist, the API host will respond with 404 Not Found.
+
+For a local deployment, you will need to provide name resolution for the vanity URL to work. The easiest solution is to add an entry in `/etc/host` for `<namespace>.openwhisk.host`. Here is an example:
+```bash
+> grep guest /etc/hosts 192.168.99.100  guest.openwhisk.host
+```


### PR DESCRIPTION
 Add nginx rewrite rule to permit vanity URLs for web actions:
`https://guest.openwhisk.host/public/index.html` becomes a proxy for
`https://openwhisk.host/api/v1/experimental/web/guest/public/index.html`

and for added convenience, and by convention
`https://guest.openwhisk.host` becomes a proxy for
`https://openwhisk.host/api/v1/experimental/web/guest/public/index.html`

this of course requires DNS resolution; for local development an entry in `/etc/hosts` will do.
For example:
```
> grep guest /etc/hosts
192.168.99.100  guest.dockerhost
```
![screen shot 2017-02-17 at 2 33 46 pm](https://cloud.githubusercontent.com/assets/4959922/23080268/1ce58a9a-f51e-11e6-93d4-59eb843151f4.png)
