### PR TITLE
Rework replicator tests to use environment-specific prefix

### DIFF
--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -48,7 +48,7 @@ def replicateDatabases(args):
             "continuous": args.continuous
         })
 
-    def isBackupDb(dbName): return re.match("backup_\d+_", dbName)
+    def isBackupDb(dbName): return re.match("^backup_\d+_" + args.dbPrefix, dbName)
     def extractTimestamp(dbName): return int(dbName.split("_")[1])
     def isExpired(timestamp): return now - args.expires > timestamp
 


### PR DESCRIPTION
Use the dbPrefix of the environment, where the test runs as part of the dbPrefix for all replicator tests.
Also delete databases in replicator only, if the database is a backup of a db with the current prefix.

PG2#1075 started.