### PR TITLE
restoring original location for apigateway container image

### DIFF
--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -1,13 +1,13 @@
 ---
 # This role will install apigateway
 
-- name: "pull the openwhisk/openwhisk-apigateway image"
-  shell: "docker pull openwhisk/openwhisk-apigateway"
+- name: "pull the openwhisk/apigateway image"
+  shell: "docker pull openwhisk/apigateway"
 
 - name: (re)start apigateway
   docker_container:
     name: apigateway
-    image: openwhisk/openwhisk-apigateway
+    image: openwhisk/apigateway
     state: started
     recreate: true
     restart_policy: "{{ docker.restart.policy }}"


### PR DESCRIPTION
Figure out how to re-configure docker hub image `openwhisk/apigateway` to point to new named git location `openwhisk/openwhisk-apigateway`

This is enable and building automatically.
https://hub.docker.com/r/openwhisk/apigateway/

I will delete bad location a week from now 
https://hub.docker.com/r/openwhisk/openwhisk-apigateway/