### PR TITLE
Access HTTP Body from Web Actions

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -56,7 +56,8 @@ private case class Context(
     def metadata(user: Option[Identity]): Map[String, JsValue] = {
         Map("__ow_meta_verb" -> method.value.toLowerCase.toJson,
             "__ow_meta_headers" -> headers.map(h => h.lowercaseName -> h.value).toMap.toJson,
-            "__ow_meta_path" -> path.toJson) ++
+            "__ow_meta_path" -> path.toJson,
+            "__ow_meta_body" -> body.toJson) ++
             user.map(u => "__ow_meta_namespace" -> u.namespace.asString.toJson)
     }
 }

--- a/tests/src/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/whisk/core/controller/test/MetaApiTests.scala
@@ -215,7 +215,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
                 JsObject(
                     params.toJson.asJsObject.fields ++
                         body.map(_.fields).getOrElse(Map()) ++
-                        Context(HttpMethods.getForKey(method.toUpperCase).get, List(), path, Map()).metadata(identity))
+                        Context(HttpMethods.getForKey(method.toUpperCase).get, List(), path, Map(), body).metadata(identity))
             }
         }.get
     }


### PR DESCRIPTION
- Provide __ow_meta_body argument that allows access to the content of the HTTP body passed to a Web Action