### PR TITLE
Change runc marker to existing format

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -191,6 +191,7 @@ object LoggingMarkers {
     // Time in invoker
     val INVOKER_ACTIVATION = LogMarkerToken(invoker, activation, start)
     def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
+    def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
 
     val DATABASE_CACHE_HIT = LogMarkerToken(database, "cacheHit", count)
     val DATABASE_CACHE_MISS = LogMarkerToken(database, "cacheMiss", count)

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -37,7 +37,7 @@ object RuncUtils {
      * Synchronously runs the given runc command returning stdout if successful.
      */
     def runRuncCmd(skipLogError: Boolean, args: Seq[String])(implicit transid: TransactionId, logging: Logging): (Int, String) = {
-        val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD("runc_" + args(0)))
+        val start = transid.started(this, LoggingMarkers.INVOKER_RUNC_CMD(args(0)))
         try {
             val fullCmd = getRuncCmd() ++ args
 


### PR DESCRIPTION
FYI @RSulzmann 

This PR changes the runc log markers to the format we use with all other markers.

PG1#1186 is running.