### PR TITLE
Refactor CLI so that additional commands won't need common code updates

### DIFF
--- a/tests/src/system/basic/WskBasicTests.scala
+++ b/tests/src/system/basic/WskBasicTests.scala
@@ -308,7 +308,7 @@ class WskBasicTests
 
             wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
             wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*\\\\n \\* Hello, world.\\\\n \\*\\/\\\\nfunction main\\(params\\) \\{\\\\n    console.log\\('hello', params.payload\\+'!'\\);\\\\n\\}\\\\n"\n\\}""")
+            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    console.log\\('hello', params.payload\\+'!'\\);[\\\\r]*\\\\n\\}[\\\\r]*\\\\n"\n\\}""")
             wsk.action.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("annotations")).stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("limits")).stdout should include regex (s"""$successMsg limits\n\\{\\s+"timeout":\\s+60000,\\s+"memory":\\s+256,\\s+"logs":\\s+10\\s+\\}""")

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -35,9 +35,9 @@ import (
 // Commands //
 //////////////
 
-var apiCmd = &cobra.Command{
+var apiExperimentalCmd = &cobra.Command{
     Use:   "api-experimental",
-    Short: wski18n.T("work with APIs"),
+    Short: wski18n.T("work with APIs (experimental)"),
 }
 
 var apiCreateCmd = &cobra.Command{
@@ -250,8 +250,7 @@ var apiDeleteCmd = &cobra.Command{
     SilenceUsage:  true,
     SilenceErrors: true,
     PreRunE:       setupClientConfig,
-    RunE: func(cmd *cobra.Command, args []string) error {
-
+    RunE:          func(cmd *cobra.Command, args []string) error {
         if whiskErr := checkArgs(args, 1, 3, "Api delete",
             wski18n.T("An API base path or API name is required.  An optional API relative path and operation may also be provided.")); whiskErr != nil {
             return whiskErr
@@ -768,7 +767,7 @@ func init() {
     apiListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))
     apiListCmd.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("display full description of each API"))
 
-    apiCmd.AddCommand(
+    apiExperimentalCmd.AddCommand(
         apiCreateCmd,
         //apiUpdateCmd,
         apiGetCmd,

--- a/tools/cli/go-whisk-cli/commands/commands.go
+++ b/tools/cli/go-whisk-cli/commands/commands.go
@@ -29,9 +29,10 @@ import (
 )
 
 var client *whisk.Client
+const DefaultOpenWhiskApiPath string = "/api"
 
 func setupClientConfig(cmd *cobra.Command, args []string) (error){
-    baseURL, err := getURLBase(Properties.APIHost)
+    baseURL, err := getURLBase(Properties.APIHost, DefaultOpenWhiskApiPath)
 
     // Determine if the parent command will require the API host to be set
     apiHostRequired := (cmd.Parent().Name() == "property" && cmd.Name() == "get" && (flags.property.auth ||
@@ -42,7 +43,7 @@ func setupClientConfig(cmd *cobra.Command, args []string) (error){
 
     // Display an error if the parent command requires an API host to be set, and the current API host is not valid
     if err != nil && !apiHostRequired {
-        whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s\n", Properties.APIHost, err)
+        whisk.Debug(whisk.DbgError, "getURLBase(%s, %s) error: %s\n", Properties.APIHost, DefaultOpenWhiskApiPath, err)
         errMsg := wski18n.T("The API host is not valid: {{.err}}", map[string]interface{}{"err": err})
         whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
             whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -17,11 +17,9 @@
 package commands
 
 import (
-    "bufio"
     "errors"
     "fmt"
     "os"
-    "strings"
 
     "github.com/mitchellh/go-homedir"
     "github.com/spf13/cobra"
@@ -88,11 +86,11 @@ var propertySetCmd = &cobra.Command{
         }
 
         if apiHost := flags.property.apihostSet; len(apiHost) > 0 {
-            baseURL, err := getURLBase(apiHost)
+            baseURL, err := getURLBase(apiHost, DefaultOpenWhiskApiPath)
 
             if err != nil {
                 // Not aborting now.  Subsequent commands will result in error
-                whisk.Debug(whisk.DbgError, "getURLBase(%s) error: %s", apiHost, err)
+                whisk.Debug(whisk.DbgError, "getURLBase(%s, %s) error: %s", apiHost, DefaultOpenWhiskApiPath, err)
                 errStr := fmt.Sprintf(
                     wski18n.T("Unable to set API host value; the API host value '{{.apihost}}' is invalid: {{.err}}",
                         map[string]interface{}{"apihost": apiHost, "err": err}))
@@ -479,10 +477,10 @@ func parseConfigFlags(cmd *cobra.Command, args []string) error {
 
         if client != nil {
             client.Config.Host = apiHost
-            baseURL, err := getURLBase(apiHost)
+            baseURL, err := getURLBase(apiHost, DefaultOpenWhiskApiPath)
 
             if err != nil {
-                whisk.Debug(whisk.DbgError, "getURLBase(%s) failed: %s\n", apiHost, err)
+                whisk.Debug(whisk.DbgError, "getURLBase(%s, %s) failed: %s\n", apiHost, DefaultOpenWhiskApiPath, err)
                 errStr := wski18n.T("Invalid host address '{{.host}}': {{.err}}",
                         map[string]interface{}{"host": Properties.APIHost, "err": err})
                 werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -502,60 +500,3 @@ func parseConfigFlags(cmd *cobra.Command, args []string) error {
     return nil
 }
 
-func readProps(path string) (map[string]string, error) {
-
-    props := map[string]string{}
-
-    file, err := os.Open(path)
-    if err != nil {
-        // If file does not exist, just return props
-        whisk.Debug(whisk.DbgWarn, "Unable to read whisk properties file '%s' (file open error: %s); falling back to default properties\n" ,path, err)
-        return props, nil
-    }
-    defer file.Close()
-
-    lines := []string{}
-    scanner := bufio.NewScanner(file)
-    for scanner.Scan() {
-        lines = append(lines, scanner.Text())
-    }
-
-    props = map[string]string{}
-    for _, line := range lines {
-        kv := strings.Split(line, "=")
-        if len(kv) != 2 {
-            // Invalid format; skip
-            continue
-        }
-        props[kv[0]] = kv[1]
-    }
-
-    return props, nil
-
-}
-
-func writeProps(path string, props map[string]string) error {
-
-    file, err := os.Create(path)
-    if err != nil {
-        whisk.Debug(whisk.DbgError, "os.Create(%s) failed: %s\n", path, err)
-        errStr := wski18n.T("Whisk properties file write failure: {{.err}}", map[string]interface{}{"err": err})
-        werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-        return werr
-    }
-    defer file.Close()
-
-    writer := bufio.NewWriter(file)
-    defer writer.Flush()
-    for key, value := range props {
-        line := fmt.Sprintf("%s=%s", strings.ToUpper(key), value)
-        _, err = fmt.Fprintln(writer, line)
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "fmt.Fprintln() write to '%s' failed: %s\n", path, err)
-            errStr := wski18n.T("Whisk properties file write failure: {{.err}}", map[string]interface{}{"err": err})
-            werr := whisk.MakeWskError(errors.New(errStr), whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return werr
-        }
-    }
-    return nil
-}

--- a/tools/cli/go-whisk-cli/commands/wsk.go
+++ b/tools/cli/go-whisk-cli/commands/wsk.go
@@ -47,7 +47,7 @@ func init() {
         propertyCmd,
         namespaceCmd,
         listCmd,
-        apiCmd,
+        apiExperimentalCmd,
     )
 
     WskCmd.PersistentFlags().BoolVarP(&flags.global.verbose, "verbose", "v", false, wski18n.T("verbose output"))

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1354,5 +1354,77 @@
   {
     "id": "display full description of each API",
     "translation": "display full description of each API"
+  },
+  {
+    "id": "User name and password were not specified",
+    "translation": "User name and password were not specified"
+  },
+  {
+    "id": "Unable to access Bluemix API host: {{.err}}",
+    "translation": "Unable to access Bluemix API host: {{.err}}"
+  },
+  {
+    "id": "Unable to access Bluemix authorization endpoint: {{.err}}",
+    "translation": "Unable to access Bluemix authorization endpoint: {{.err}}"
+  },
+  {
+    "id": "Unable to authenticate with Bluemix: {{.err}}",
+    "translation": "Unable to authenticate with Bluemix: {{.err}}"
+  },
+  {
+    "id": "Unable to retrieve namespaces: {{.err}}",
+    "translation": "Unable to retrieve namespaces: {{.err}}"
+  },
+  {
+    "id": "Bluemix user `NAME`",
+    "translation": "Bluemix user `NAME`"
+  },
+  {
+    "id": "Bluemix user `PASSWORD`",
+    "translation": "Bluemix user `PASSWORD`"
+  },
+  {
+    "id": "OpenWhisk `NAMESPACE`",
+    "translation": "OpenWhisk `NAMESPACE`"
+  },
+  {
+    "id": "bluemix integration",
+    "translation": "bluemix integration"
+  },
+  {
+    "id": "login to Bluemix",
+    "translation": "login to Bluemix"
+  },
+  {
+    "id": "Unable to save the Bluemix login access token: {{.err}}",
+    "translation": "Unable to save the Bluemix login access token: {{.err}}"
+  },
+  {
+    "id": "Internal error. OpenWhisk API {.api} is invalid: {{.err}}",
+    "translation": "Internal error. OpenWhisk API {.api} is invalid: {{.err}}"
+  },
+  {
+    "id": "Unable to initialize server connection: {{.err}}",
+    "translation": "Unable to initialize server connection: {{.err}}"
+  },
+  {
+    "id": "Internal error. Bluemix API {.api} is invalid: {{.err}}",
+    "translation": "Internal error. Bluemix API {.api} is invalid: {{.err}}"
+  },
+  {
+    "id": "Unable to initialize Bluemix server connection: {{.err}}",
+    "translation": "Unable to initialize Bluemix server connection: {{.err}}"
+  },
+  {
+    "id": "An API host must be provided.",
+    "translation": "An API host must be provided."
+  },
+  {
+    "id": "Select a namespace:",
+    "translation": "Select a namespace:"
+  },
+  {
+    "id": "There are too many namespaces to display, please type in the namespace name.",
+    "translation": "There are too many namespaces to display, please type in the namespace name."
   }
 ]

--- a/tools/cli/go-whisk/whisk/action.go
+++ b/tools/cli/go-whisk/whisk/action.go
@@ -85,9 +85,9 @@ func (s *ActionService) List(packageName string, options *ActionListOptions) ([]
     }
     Debug(DbgError, "Action list route with options: %s\n", route)
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s, nil) error: '%s'\n", routeUrl, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", routeUrl, err)
         errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": routeUrl, "err": err})
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,

--- a/tools/cli/go-whisk/whisk/activation.go
+++ b/tools/cli/go-whisk/whisk/activation.go
@@ -83,9 +83,9 @@ func (s *ActivationService) List(options *ActivationListOptions) ([]Activation, 
         return nil, nil, werr
     }
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s) error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errStr := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -141,9 +141,9 @@ func (s *ApiService) List(apiListOptions *ApiListOptions) (*RetApiArray, *http.R
     }
     Debug(DbgInfo, "Api GET/list route with api options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s, nil) error: '%s'\n", routeUrl, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", routeUrl, err)
         errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": routeUrl, "err": err})
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
@@ -202,9 +202,9 @@ func (s *ApiService) Get(api *Api, options *ApiListOptions) (*RetApiArray, *http
     }
     Debug(DbgError, "Api get route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil) error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
@@ -237,9 +237,9 @@ func (s *ApiService) Delete(api *Api, options *ApiOptions) (*http.Response, erro
     }
     Debug(DbgError, "Api DELETE route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("DELETE", routeUrl, nil, DoNotIncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("DELETE", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequestUrl(DELETE, %s, nil) error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(DELETE, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for DELETE '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,

--- a/tools/cli/go-whisk/whisk/info.go
+++ b/tools/cli/go-whisk/whisk/info.go
@@ -21,6 +21,7 @@ import (
     "net/url"
     "errors"
     "../wski18n"
+    "fmt"
 )
 
 type Info struct {
@@ -36,17 +37,15 @@ type InfoService struct {
 
 func (s *InfoService) Get() (*Info, *http.Response, error) {
     // make a request to c.BaseURL / v1
-
-    ref, err := url.Parse(s.client.Config.Version)
+    urlStr := fmt.Sprintf("%s/%s", s.client.BaseURL.String(), s.client.Config.Version)
+    u, err := url.Parse(urlStr)
     if err != nil {
-        Debug(DbgError, "url.Parse(%s) error: %s\n", s.client.Config.Version, err)
+        Debug(DbgError, "url.Parse(%s) error: %s\n", urlStr, err)
         errStr := wski18n.T("Unable to URL parse '{{.version}}': {{.err}}",
-            map[string]interface{}{"version": s.client.Config.Version, "err": err})
+            map[string]interface{}{"version": urlStr, "err": err})
         werr := MakeWskError(errors.New(errStr), EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
         return nil, nil, werr
     }
-
-    u := s.client.BaseURL.ResolveReference(ref)
 
     req, err := http.NewRequest("GET", u.String(), nil)
     if err != nil {

--- a/tools/cli/go-whisk/whisk/package.go
+++ b/tools/cli/go-whisk/whisk/package.go
@@ -93,9 +93,9 @@ func (s *PackageService) List(options *PackageListOptions) ([]Package, *http.Res
         return nil, nil, werr
     }
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson); error: '%s'\n", route, err)
         errStr := wski18n.T("Unable to create GET HTTP request for '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)

--- a/tools/cli/go-whisk/whisk/rule.go
+++ b/tools/cli/go-whisk/whisk/rule.go
@@ -57,9 +57,9 @@ func (s *RuleService) List(options *RuleListOptions) ([]Rule, *http.Response, er
         return nil, nil, werr
     }
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson); error: '%s'\n", route, err)
         errStr := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)

--- a/tools/cli/go-whisk/whisk/trigger.go
+++ b/tools/cli/go-whisk/whisk/trigger.go
@@ -57,9 +57,9 @@ func (s *TriggerService) List(options *TriggerListOptions) ([]Trigger, *http.Res
         return nil, nil, werr
     }
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(GET, %s); error: '%s'\n", route, err)
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson); error: '%s'\n", route, err)
         errStr := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)
@@ -92,9 +92,9 @@ func (s *TriggerService) Insert(trigger *Trigger, overwrite bool) (*Trigger, *ht
         return nil, nil, werr
     }
 
-    req, err := s.client.NewRequestUrl("PUT", routeUrl, trigger, IncludeNamespaceInUrl)
+    req, err := s.client.NewRequestUrl("PUT", routeUrl, trigger, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(PUT, %s); error: '%s'\n", routeUrl, err)
+        Debug(DbgError, "http.NewRequestUrl(PUT, %s, %+v, IncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson); error: '%s'\n", routeUrl, trigger, err)
         errStr := wski18n.T("Unable to create HTTP request for PUT '{{.route}}': {{.err}}",
             map[string]interface{}{"route": routeUrl, "err": err})
         werr := MakeWskErrorFromWskError(errors.New(errStr), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG, NO_DISPLAY_USAGE)


### PR DESCRIPTION
Desire is for new commands to be completely implemented in a couple command-specific files without any impact to common code (i.e. utilities, CLI framework).

At this point, the globalized content is still in a single file..