### PR TITLE
ContainerPool should gracefully handle a failed unpause

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/Container.scala
@@ -59,18 +59,18 @@ class Container(
         s"container [$name] [$id] [$ip]"
     }
 
-    def pause(): Unit =
+    def pause(): Boolean =
         if (useRunc) {
-            RuncUtils.pause(containerId)
+            RuncUtils.isSuccessful(RuncUtils.pause(containerId))
         } else {
-            pauseContainer(containerId)
+            DockerOutput.isSuccessful(pauseContainer(containerId))
         }
 
-    def unpause(): Unit =
+    def unpause(): Boolean =
         if (useRunc) {
-            RuncUtils.resume(containerId)
+            RuncUtils.isSuccessful(RuncUtils.resume(containerId))
         } else {
-            unpauseContainer(containerId)
+            DockerOutput.isSuccessful(unpauseContainer(containerId))
         }
 
     /**

--- a/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/RuncUtils.scala
@@ -62,6 +62,12 @@ object RuncUtils {
         }
     }
 
+    def isSuccessful(result : (Int, String)) : Boolean =
+        result match {
+            case (0, _) => true
+            case _ => false
+        }
+
     /*
      *  Any global flags are added here.
      */

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -127,6 +127,12 @@ package object container {
     object DockerOutput {
         def apply(content: String) = new DockerOutput(Some(content))
         def unavailable = new DockerOutput(None)
+
+        def isSuccessful(output : DockerOutput) : Boolean =
+            output match {
+                case output if output == DockerOutput.unavailable => false
+                case _ => true
+            }
     }
 
     sealed class ContainerError(val msg: String) extends Throwable(msg)


### PR DESCRIPTION
In certain scenarios, a container can crash which will result in a failed pause and potentially later unpause. However, the ContainerPool does not recognize these failures and proceeds as normal, even though (most importantly) when the unpause fails, the container is not present to handle an action invocation.

This PR is to detect the failed unpause and to treat this the same as a cache miss. The result is that a new container will be created instead of attempting to reuse the crashed container.