### PR TITLE
Don't fail the entire playbook if topic already exists

### DIFF
--- a/ansible/roles/kafka/tasks/deploy.yml
+++ b/ansible/roles/kafka/tasks/deploy.yml
@@ -50,7 +50,13 @@
   with_items:
     - completed
     - health
+  register: command_result
+  failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
+  changed_when: "'Created topic' in command_result.stdout"
 
 - name: create the invoker topics
   shell: "docker exec kafka bash -c 'unset JMX_PORT; kafka-topics.sh --create --topic invoke{{ item.0 }} --replication-factor 1 --partitions 1 --zookeeper {{ inventory_hostname }}:{{ zookeeper.port }}'"
   with_indexed_items: "{{ groups['invokers'] }}"
+  register: command_result
+  failed_when: "not ('Created topic' in command_result.stdout or 'already exists' in command_result.stdout)"
+  changed_when: "'Created topic' in command_result.stdout"


### PR DESCRIPTION
I've been playing around with Ansible playbooks (awesome way to get started quickly !), and found myself replaying the top-level openwhisk.yml playbook many times to set up my environment properly.

This PR prevents the entire playbook from failing if the Kafka topics already exist. It considers topic creation task as successful if the topic is indeed created, or if it already exists.

It also marks the task as changed only if the topic has been created (that's just nice to have).