### PR TITLE
Flatten Exec hiearchy

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -266,9 +266,10 @@ protected[core] object Exec
         }
     }
 
-    protected[entity] lazy val b64decoder = Base64.getDecoder()
-    protected[entity] def isBinaryCode(code: String): Boolean = {
+    def isBinaryCode(code: String): Boolean = {
         val t = code.trim
-        (t.length % 4 == 0) && Try(Exec.b64decoder.decode(t)).isSuccess
+        (t.length > 0) && (t.length % 4 == 0) && Try(b64decoder.decode(t)).isSuccess
     }
+
+    private lazy val b64decoder = Base64.getDecoder()
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskAction.scala
@@ -144,32 +144,18 @@ case class WhiskAction(
      * explicitly inside containers.
      */
     def containerInitializer: Option[JsObject] = {
-        def getNodeInitializer(code: String, binary: Boolean, main: Option[String]) = {
-            JsObject(
-                "name" -> name.toJson,
-                "binary" -> JsBoolean(binary),
-                "main" -> JsString(main.getOrElse("main")),
-                "code" -> JsString(code))
-        }
-
         exec match {
-            case n: NodeJSAbstractExec =>
-                Some(getNodeInitializer(n.code, n.binary, n.main))
-            case s: SwiftAbstractExec =>
+            case c: CodeExecAsString =>
                 Some(JsObject(
                     "name" -> name.toJson,
-                    "code" -> s.code.toJson,
-                    "main" -> s.main.getOrElse("main").toJson))
+                    "binary" -> c.binary.toJson,
+                    "code" -> c.code.toJson,
+                    "main" -> c.entryPoint.getOrElse("main").toJson))
             case JavaExec(jar, main) =>
                 Some(JsObject(
                     "name" -> name.toJson,
                     "jar" -> jar.toJson,
                     "main" -> main.toJson))
-            case PythonExec(code, main) =>
-                Some(JsObject(
-                    "name" -> name.toJson,
-                    "code" -> code.toJson,
-                    "main" -> main.getOrElse("main").toJson))
             case b @ BlackBoxExec(image, code) =>
                 Some(code map {
                     c => JsObject("code" -> c.toJson, "binary" -> JsBoolean(b.binary))

--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -423,7 +423,7 @@ class ContainerPool(
     // TODO: Generalize across language by storing image name when we generalize to other languages
     //       Better heuristic for # of containers to keep warm - make sensitive to idle capacity
     private val stemCellNodejsKey = StemCellNodeJsActionContainerId
-    private val nodejsExec = NodeJS6Exec("", main = None)
+    private val nodejsExec = NodeJS6Exec("", entryPoint = None)
     private val WARM_NODEJS_CONTAINERS = 2
 
     // This parameter controls how many outstanding un-removed containers there are before

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -29,7 +29,6 @@ function NodeActionRunner(whisk) {
     // Use this ref inside closures etc.
     var thisRunner = this;
 
-    this.userScriptName = undefined;
     this.userScriptMain = undefined;
 
     // This structure is reset for every action invocation. It contains two fields:
@@ -44,12 +43,6 @@ function NodeActionRunner(whisk) {
     this.whisk = modWhisk(whisk, callback);
 
     this.init = function(message) {
-        // Determining a sensible name for the action.
-        var name = typeof message.name === 'string' ? message.name.trim() : '';
-        name = name !== '' ? name : 'Anonymous User Action';
-
-        this.userScriptName = name;
-
         function assertMainIsFunction() {
             if (typeof thisRunner.userScriptMain !== 'function') {
                 throw "Action entrypoint '" + message.main + "' is not a function.";

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -69,7 +69,7 @@ function NodeActionService(config, logger) {
 
     /** Returns a promise of a response to the /init invocation.
      *
-     *  req.body = { main: String, code: String, name: String }
+     *  req.body = { main: String, code: String, binary: Boolean }
      */
     this.initCode = function initCode(req) {
         if (status === Status.ready) {

--- a/tests/src/actionContainers/NodeJs6ActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJs6ActionContainerTests.scala
@@ -16,8 +16,6 @@
 
 package actionContainers
 
-import whisk.core.entity.NodeJS6Exec
-
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -28,8 +26,6 @@ import spray.json.JsObject
 class NodeJs6ActionContainerTests extends NodeJsActionContainerTests {
 
     override lazy val nodejsContainerImageName = "nodejs6action"
-
-    override def exec(code: String) = NodeJS6Exec(code, None)
 
     behavior of nodejsContainerImageName
 

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -18,8 +18,6 @@ package actionContainers
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
-import whisk.core.entity.{ NodeJSAbstractExec, NodeJSExec }
-
 import ActionContainer.withContainer
 import ResourceHelpers.ZipBuilder
 
@@ -38,18 +36,6 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
     }
 
     def withNodeJsContainer(code: ActionContainer => Unit) = withActionContainer()(code)
-
-    def exec(code: String): NodeJSAbstractExec = NodeJSExec(code, None)
-
-    override def initPayload(code: String, main: String = "main") = {
-        val e = exec(code)
-        JsObject(
-            "value" -> JsObject(
-                "name" -> JsString("dummyAction"),
-                "code" -> JsString(e.code),
-                "binary" -> JsBoolean(e.binary),
-                "main" -> JsString(main)))
-    }
 
     behavior of nodejsContainerImageName
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -161,14 +161,14 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
     behavior of "EntityName"
 
     it should "accept well formed names" in {
-        val paths = Seq("a", "a b", "a@b.c", "_a", "_", "_ _", "a0", "a 0", "a.0", "a@@", "0", "0.0", "0.0.0", "0a", "0.a", "a"*EntityName.ENTITY_NAME_MAX_LENGTH)
+        val paths = Seq("a", "a b", "a@b.c", "_a", "_", "_ _", "a0", "a 0", "a.0", "a@@", "0", "0.0", "0.0.0", "0a", "0.a", "a" * EntityName.ENTITY_NAME_MAX_LENGTH)
         paths.foreach { n =>
             assert(EntityName(n).toString == n)
         }
     }
 
     it should "reject malformed names" in {
-        val paths = Seq(null, "", " ", " xxx", "xxx ", "/", " /", "/ ", "0 ", "_ ", "a  ", "a \t", "a\n", "a"*(EntityName.ENTITY_NAME_MAX_LENGTH+1))
+        val paths = Seq(null, "", " ", " xxx", "xxx ", "/", " /", "/ ", "0 ", "_ ", "a  ", "a \t", "a\n", "a" * (EntityName.ENTITY_NAME_MAX_LENGTH + 1))
         paths.foreach {
             p => an[IllegalArgumentException] should be thrownBy EntityName(p)
         }
@@ -320,6 +320,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
             JsObject("kind" -> "nodejs".toJson, "code" -> "js1".toJson, "binary" -> false.toJson),
             JsObject("kind" -> "nodejs".toJson, "code" -> "js2".toJson, "binary" -> false.toJson, "foo" -> "bar".toJson),
             JsObject("kind" -> "swift".toJson, "code" -> "swift1".toJson, "binary" -> false.toJson),
+            JsObject("kind" -> "swift:3".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson),
             JsObject("kind" -> "nodejs".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson))
 
         val execs = json.map { e => Exec.serdes.read(e) }
@@ -327,7 +328,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
         assert(execs(0) == Exec.js("js1") && json(0).compactPrint == Exec.js("js1").toString)
         assert(execs(1) == Exec.js("js2") && json(1).compactPrint != Exec.js("js2").toString) // ignores unknown properties
         assert(execs(2) == Exec.swift("swift1") && json(2).compactPrint == Exec.swift("swift1").toString)
-        assert(execs(3) == Exec.js(b64Body) && json(3).compactPrint == Exec.js(b64Body).toString)
+        assert(execs(3) == Exec.swift3(b64Body) && json(3).compactPrint == Exec.swift3(b64Body).toString)
+        assert(execs(4) == Exec.js(b64Body) && json(4).compactPrint == Exec.js(b64Body).toString)
     }
 
     it should "properly deserialize and reserialize JSON blackbox" in {
@@ -381,11 +383,11 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with Matchers {
     }
 
     it should "serialize to json" in {
-        val execs = Seq(Exec.bb("container"), Exec.js("js"), Exec.js("js"), Exec.swift("swft")).map { _.toString }
+        val execs = Seq(Exec.bb("container"), Exec.js("js"), Exec.js("js"), Exec.swift("swift")).map { _.toString }
         assert(execs(0) == JsObject("kind" -> "blackbox".toJson, "image" -> "container".toJson, "binary" -> false.toJson).compactPrint)
         assert(execs(1) == JsObject("kind" -> "nodejs".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
         assert(execs(2) == JsObject("kind" -> "nodejs".toJson, "code" -> "js".toJson, "binary" -> false.toJson).compactPrint)
-        assert(execs(3) == JsObject("kind" -> "swift".toJson, "code" -> "swft".toJson, "binary" -> false.toJson).compactPrint)
+        assert(execs(3) == JsObject("kind" -> "swift".toJson, "code" -> "swift".toJson, "binary" -> false.toJson).compactPrint)
     }
 
     behavior of "Parameter"

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -21,7 +21,6 @@ import (
   "errors"
   "fmt"
   "path/filepath"
-  "strings"
 
   "../../go-whisk/whisk"
   "../wski18n"
@@ -523,10 +522,10 @@ func parseAction(cmd *cobra.Command, args []string) (*whisk.Action, error) {
       }
     }
 
-    // For zip-encoded NodeJS action, the code needs to be base64-encoded.
+    // For zip-encoded actions, the code needs to be base64-encoded.
     // We reach this point if the kind has already be determined. Since the extension is not js,
     // this means the kind was specified explicitly.
-    if ext == ".zip" && (strings.HasPrefix(action.Exec.Kind, "nodejs") || action.Exec.Kind == "blackbox") {
+    if ext == ".zip" {
       code = base64.StdEncoding.EncodeToString([]byte(code))
       action.Exec.Code = &code
     }


### PR DESCRIPTION
This PR removes some unnecessary distinctions in the `exec` hierarchy - making the treatments of node, python, and swift actions the same.

PG3/303.