### PR TITLE
remove intermediate shell to make shutdown hook great again.

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -54,7 +54,7 @@
         -v {{ docker_sock | default('/var/run/docker.sock') }}:/var/run/docker.sock
         -p {{invoker.port + play_hosts.index(inventory_hostname)}}:8080
         {{docker_registry}}{{ docker_image_prefix }}/invoker:{{docker_image_tag}}
-        /bin/sh -c "/invoker/bin/invoker {{play_hosts.index(inventory_hostname)}} >> /logs/invoker{{play_hosts.index(inventory_hostname)}}_logs.log 2>&1"
+        /bin/sh -c "exec /invoker/bin/invoker {{play_hosts.index(inventory_hostname)}} >> /logs/invoker{{play_hosts.index(inventory_hostname)}}_logs.log 2>&1"
 
 
 # todo: re-enable docker_container module once https://github.com/ansible/ansible-modules-core/issues/5054 is resolved


### PR DESCRIPTION
@perryibm the shutdown hook did not work because SIGTERM got sent to the shell that runs the invoker JVM instead of the JVM directly. @sven-lange-last and I replaced it with exec to make the JVM the top level process in the invoker container.

In case we need similar behavior in the controller, it can also be applied to the CMD stanza of a Dockerfile.