### PR TITLE
Don't use Invoker if it is UnHealthy

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compile 'commons-codec:commons-codec:1.9'
     compile 'commons-io:commons-io:2.4'
     compile 'commons-logging:commons-logging:1.2'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
     compile 'org.apache.kafka:kafka-clients:0.10.0.0'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -216,6 +216,10 @@ object LoggingMarkers {
      */
     def INVOKER_STARTUP(i: Int) = LogMarkerToken(invoker, s"startup$i", count)
 
+    // Check invoker healthy state from loadbalancer
+    val LOADBALANCER_INVOKER_OFFLINE = LogMarkerToken(loadbalancer, "invokerOffline", count)
+    val LOADBALANCER_INVOKER_UNHEALTHY = LogMarkerToken(loadbalancer, "invokerUnhealthy", count)
+
     // Time that is needed to execute the action
     val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
 

--- a/common/scala/src/main/scala/whisk/common/RingBuffer.scala
+++ b/common/scala/src/main/scala/whisk/common/RingBuffer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer
+
+object RingBuffer {
+    def apply[T](size: Int) = new RingBuffer[T](size)
+}
+
+class RingBuffer[T](size: Int) {
+    private val inner = new CircularFifoBuffer(size)
+
+    def add(el: T) = inner.add(el)
+
+    def toList() = inner.toArray().asInstanceOf[Array[T]].toList
+}

--- a/common/scala/src/main/scala/whisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/whisk/core/connector/Message.scala
@@ -88,7 +88,8 @@ object ActivationMessage extends DefaultJsonProtocol {
  */
 case class CompletionMessage(
     override val transid: TransactionId,
-    response: WhiskActivation)
+    response: WhiskActivation,
+    invoker: String)
     extends Message {
 
     override def serialize = CompletionMessage.serdes.write(this).compactPrint
@@ -100,7 +101,7 @@ case class CompletionMessage(
 
 object CompletionMessage extends DefaultJsonProtocol {
     def parse(msg: String) = Try(serdes.read(msg.parseJson))
-    implicit val serdes = jsonFormat2(CompletionMessage.apply)
+    implicit val serdes = jsonFormat3(CompletionMessage.apply)
 }
 
 case class PingMessage(name: String) extends Message {

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -95,7 +95,7 @@ class Controller(
     private implicit val activationStore = WhiskActivationStore.datastore(whiskConfig)
 
     // initialize backend services
-    private implicit val loadBalancer = new LoadBalancerService(whiskConfig)
+    private implicit val loadBalancer = new LoadBalancerService(whiskConfig, entityStore)
     private implicit val consulServer = whiskConfig.consulServer
     private implicit val entitlementProvider = new LocalEntitlementProvider(whiskConfig, loadBalancer)
     private implicit val activationIdFactory = new ActivationIdGenerator {}

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -16,9 +16,16 @@
 
 package whisk.core.loadBalancer
 
+import java.nio.charset.StandardCharsets
+
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import org.apache.kafka.clients.producer.RecordMetadata
 
 import akka.actor.Actor
 import akka.actor.ActorRef
@@ -28,25 +35,54 @@ import akka.actor.FSM.CurrentState
 import akka.actor.FSM.SubscribeTransitionCallBack
 import akka.actor.FSM.Transition
 import akka.actor.Props
+import akka.pattern.pipe
 import akka.util.Timeout
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import whisk.common.AkkaLogging
 import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.KeyValueStore
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.common.RingBuffer
 import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.connector.CompletionMessage
+import whisk.core.connector.MessageConsumer
+import whisk.core.connector.MessageProducer
 import whisk.core.connector.PingMessage
+import whisk.core.database.NoDocumentException
+import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entity.ActivationId.ActivationIdGenerator
+import whisk.core.entity.AuthKey
+import whisk.core.entity.CodeExecAsString
+import whisk.core.entity.DocRevision
+import whisk.core.entity.EntityName
+import whisk.core.entity.EntityPath
+import whisk.core.entity.ExecManifest
+import whisk.core.entity.Identity
+import whisk.core.entity.Secret
+import whisk.core.entity.Subject
+import whisk.core.entity.UUID
+import whisk.core.entity.WhiskAction
+import whisk.core.entity.types.EntityStore
 
 // Received events
 case object GetStatus
+
+case object Tick
 
 // States an Invoker can be in
 sealed trait InvokerState { val asString: String }
 case object Offline extends InvokerState { val asString = "down" }
 case object Healthy extends InvokerState { val asString = "up" }
+case object UnHealthy extends InvokerState { val asString = "unhealthy" }
+
+case class ActivationRequest(msg: ActivationMessage, invoker: String)
+case class InvocationFinishedMessage(name: String, successful: Boolean)
 
 // Data stored in the Invoker
-final case class InvokerInfo()
+final case class InvokerInfo(buffer: RingBuffer[Boolean])
 
 /**
  * Actor representing a pool of invokers
@@ -62,12 +98,16 @@ final case class InvokerInfo()
 class InvokerPool(
     childFactory: (ActorRefFactory, String) => ActorRef,
     kv: KeyValueStore,
-    invokerDownCallback: String => Unit) extends Actor {
+    invokerDownCallback: String => Unit,
+    producer: MessageProducer,
+    activeAckConsumer: MessageConsumer,
+    activeAckCallback: CompletionMessage => Unit,
+    pingConsumer: MessageConsumer) extends Actor {
 
     implicit val transid = TransactionId.invokerHealth
+    implicit val logging = new AkkaLogging(context.system.log)
     implicit val timeout = Timeout(5.seconds)
     implicit val ec = context.dispatcher
-    val logging = new AkkaLogging(context.system.log)
 
     // State of the actor. It's important not to close over these
     // references directly, so they don't escape the Actor.
@@ -85,6 +125,21 @@ class InvokerPool(
             invoker.forward(p)
 
         case GetStatus => sender() ! invokerStatus.toMap
+
+        case msg: InvocationFinishedMessage => {
+            // Forward message to invoker, if InvokerActor exists
+            invokers.get(msg.name).map(_.forward(msg))
+        }
+
+        case msg: ActivationRequest => {
+            implicit val transid = msg.msg.transid
+            val start = transid.started(this, LoggingMarkers.CONTROLLER_KAFKA, s"posting topic '${msg.invoker}' with activation id '${msg.msg.activationId}'")
+
+            producer.send(msg.invoker, msg.msg).andThen {
+                case Success(status) => transid.finished(this, start, s"Posted to ${status.topic()}[${status.partition()}][${status.offset()}]")
+                case Failure(e)      => transid.failed(this, start, s"Error on posting to topic ${msg.invoker}")
+            }.pipeTo(sender())
+        }
 
         case CurrentState(invoker, currentState: InvokerState) =>
             invokerStatus.update(invoker.path.name, currentState)
@@ -108,13 +163,63 @@ class InvokerPool(
         }.map { case (name, state) => s"$name: $state" }
         logging.info(this, s"invoker status changed to ${pretty.mkString(", ")}")
     }
+
+    /** Receive activeAcks from Invoker. */
+    activeAckConsumer.onMessage((topic, _, _, bytes) => {
+        val raw = new String(bytes, StandardCharsets.UTF_8)
+        CompletionMessage.parse(raw) match {
+            case Success(m: CompletionMessage) => {
+                self ! InvocationFinishedMessage(m.invoker, m.response.response.statusCode <= 2)
+                activeAckCallback(m)
+            }
+            case Failure(t) => logging.error(this, s"failed processing message: $raw with $t")
+        }
+    })
+
+    /** Receive Ping messages from invokers. */
+    pingConsumer.onMessage((topic, _, _, bytes) => {
+        val raw = new String(bytes, StandardCharsets.UTF_8)
+        PingMessage.parse(raw) match {
+            case Success(p: PingMessage) => self ! p
+            case Failure(t)              => logging.error(this, s"failed processing message: $raw with $t")
+        }
+    })
 }
 
 object InvokerPool {
     def props(
         f: (ActorRefFactory, String) => ActorRef,
         kv: KeyValueStore,
-        cb: String => Unit) = Props(new InvokerPool(f, kv, cb))
+        cb: String => Unit,
+        p: MessageProducer,
+        ackC: MessageConsumer,
+        acb: CompletionMessage => Unit,
+        pc: MessageConsumer) = Props(new InvokerPool(f, kv, cb, p, ackC, acb, pc))
+
+    val testAction = ExecManifest.runtimesManifest.resolveDefaultRuntime("nodejs:6").map { manifest =>
+        new WhiskAction(
+            namespace = EntityPath("whisk.system"),
+            name = EntityName("invokerHealthTestAction"),
+            exec = new CodeExecAsString(manifest, """function main(params) { return params || {}; }""", None))
+    }
+
+    /** Create an test action on startup if it is not there. */
+    def createTestActionForInvokerHealth(db: EntityStore)(implicit logging: Logging, ec: ExecutionContext): Future[WhiskAction] = {
+        implicit val tid = TransactionId.loadbalancer
+        testAction match {
+            case Some(action) =>
+                WhiskAction.get(db, action.docid).recover {
+                    case _: NoDocumentException => WhiskAction.put(db, action)
+                }.map(_ => action).andThen {
+                    case Success(_) => logging.info(this, "Testaction for invokerHealth exists now.")
+                    case Failure(e) => logging.error(this, s"Error on creating testaction for invokerHealth: $e")
+                }
+            case None => {
+                logging.error(this, "Error on creating testaction for invokerHealth: Probably there were problems with the manifest.")
+                Future.failed(new Exception("Error on creating testaction for invokerHealth: Probably there were problems with the manifest."))
+            }
+        }
+    }
 }
 
 /**
@@ -125,19 +230,38 @@ object InvokerPool {
  */
 class InvokerActor extends FSM[InvokerState, InvokerInfo] {
     implicit val transid = TransactionId.invokerHealth
-    val logging = new AkkaLogging(context.system.log)
+    implicit val logging = new AkkaLogging(context.system.log)
     def name = self.path.name
 
     val healthyTimeout = 10.seconds
 
-    startWith(Healthy, InvokerInfo())
+    // This is done at this point to not intermingle with the state-machine
+    // especially their timeouts.
+    def customReceive: Receive = {
+        case _: RecordMetadata => // The response of putting testactions to the MessageProducer. We don't have to do anything with them.
+    }
+    override def receive = customReceive.orElse(super.receive)
+
+    startWith(UnHealthy, InvokerInfo(new RingBuffer[Boolean](InvokerActor.bufferSize)))
 
     /**
      * An Offline invoker represents an existing but broken
-     * invoker.
+     * invoker. This means, that it does not send pings anymore.
      */
     when(Offline) {
-        case Event(_: PingMessage, _) => goto(Healthy)
+        case Event(_: PingMessage, _) => goto(UnHealthy)
+    }
+
+    /**
+     * An UnHealthy invoker represents an invoker, that was not able to handle actions successfully.
+     */
+    when(UnHealthy, stateTimeout = healthyTimeout) {
+        case Event(_: PingMessage, _) => stay
+        case Event(StateTimeout, _)   => goto(Offline)
+        case Event(Tick, info) => {
+            invokeTestActions()
+            stay
+        }
     }
 
     /**
@@ -150,14 +274,95 @@ class InvokerActor extends FSM[InvokerState, InvokerInfo] {
         case Event(StateTimeout, _)   => goto(Offline)
     }
 
+    whenUnhandled {
+        case Event(cm: InvocationFinishedMessage, info) => handleCompletionMessage(cm.successful, info.buffer)
+    }
+
+    /** Logging on Transition change */
     onTransition {
-        case Healthy -> Offline => logging.warn(this, s"$name is down")
-        case Offline -> Healthy => logging.info(this, s"$name is online")
+        case _ -> Offline   => transid.mark(this, LoggingMarkers.LOADBALANCER_INVOKER_OFFLINE, s"$name is offline", akka.event.Logging.WarningLevel)
+        case _ -> UnHealthy => transid.mark(this, LoggingMarkers.LOADBALANCER_INVOKER_UNHEALTHY, s"$name is unhealthy", akka.event.Logging.WarningLevel)
+        case _ -> Healthy   => logging.info(this, s"$name is healthy")
+    }
+
+    /** Scheduler to send testActivations, if the invoker is UnHealthy */
+    onTransition {
+        case _ -> UnHealthy => {
+            invokeTestActions()
+            setTimer(InvokerActor.timerName, Tick, 1.minute, true)
+        }
+        case UnHealthy -> _ => cancelTimer(InvokerActor.timerName)
     }
 
     initialize()
+
+    /**
+     * Handling for active acks. This method saves the result (successful or unsuccessful)
+     * into an RingBuffer and checks, if the InvokerActor has to be changed to UnHealthy.
+     *
+     * @param wasActivationSuccessful: result of Activation
+     * @param buffer to be used
+     */
+    private def handleCompletionMessage(wasActivationSuccessful: Boolean, buffer: RingBuffer[Boolean]) = {
+        buffer.add(wasActivationSuccessful)
+
+        // If the current state is UnHealthy, this means, that the activeAck is from an testaction.
+        // If this is successful it seems like the Invoker is Healthy again. So we execute immediately
+        // a new testaction to remove the errors out of the RingBuffer as fast as possible.
+        if (wasActivationSuccessful && stateName == UnHealthy) {
+            invokeTestActions()
+        }
+
+        if (stateName == Healthy && wasActivationSuccessful) {
+            stay
+        } else {
+            // Goto UnHealthy if there are more errors than accepted in buffer, else goto Healthy
+            if (buffer.toList.count(_ == true) >= InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance) {
+                gotoIfNotThere(Healthy)
+            } else {
+                gotoIfNotThere(UnHealthy)
+            }
+        }
+    }
+
+    /**
+     * Creates an Activationmessage with the given action and sends it to the InvokerPool.
+     * The InvokerPool redirects it to the invoker which is represented by this InvokerActor.
+     */
+    private def invokeTestActions() = {
+        InvokerPool.testAction.map { action =>
+            val activationMessage = ActivationMessage(
+                // Use the sid of the InvokerSupervisor as tid
+                transid = transid,
+                action = action.fullyQualifiedName(true),
+                // Use empty DocRevision to force the invoker to pull the action from db all the time
+                revision = DocRevision(),
+                // Authentication is not needed anymore at this point.
+                user = Identity(Subject("unhealthyInvokerCheck"), EntityName("unhealthyInvokerCheck"), AuthKey(UUID(), Secret()), Set[Privilege]()),
+                // Create a new Activation ID for this activation
+                activationId = new ActivationIdGenerator {}.make(),
+                activationNamespace = EntityPath("whisk.system"),
+                content = None)
+
+            context.parent ! ActivationRequest(activationMessage, name)
+        }
+    }
+
+    /**
+     * Only change the state if the currentState is not the newState.
+     *
+     * @param newState of the InvokerActor
+     */
+    private def gotoIfNotThere(newState: InvokerState) = {
+        if (stateName == newState) stay() else goto(newState)
+    }
 }
 
 object InvokerActor {
     def props() = Props[InvokerActor]
+
+    val bufferSize = 10
+    val bufferErrorTolerance = 3
+
+    val timerName = "testActionTimer"
 }

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -19,7 +19,6 @@ package whisk.core.loadBalancer
 import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
@@ -42,14 +41,11 @@ import spray.json.DefaultJsonProtocol._
 import whisk.common.AkkaLogging
 import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.KeyValueStore
-import whisk.common.Logging
 import whisk.common.LoggingMarkers
 import whisk.common.RingBuffer
 import whisk.common.TransactionId
 import whisk.core.connector.ActivationMessage
-import whisk.core.connector.CompletionMessage
 import whisk.core.connector.MessageConsumer
-import whisk.core.connector.MessageProducer
 import whisk.core.connector.PingMessage
 import whisk.core.entitlement.Privilege.Privilege
 import whisk.core.entity.ActivationId.ActivationIdGenerator
@@ -57,7 +53,6 @@ import whisk.core.entity.AuthKey
 import whisk.core.entity.CodeExecAsString
 import whisk.core.entity.DocRevision
 import whisk.core.entity.EntityName
-import whisk.core.entity.EntityPath
 import whisk.core.entity.ExecManifest
 import whisk.core.entity.Identity
 import whisk.core.entity.Secret
@@ -165,12 +160,12 @@ class InvokerPool(
 
 object InvokerPool {
     def props(
+        f: (ActorRefFactory, String) => ActorRef,
         kv: KeyValueStore,
         cb: String => Unit,
         p: (ActivationMessage, String) => Future[RecordMetadata],
         pc: MessageConsumer) = {
-        val invokerFactory = (f: ActorRefFactory, name: String) => f.actorOf(InvokerActor.props, name)
-        Props(new InvokerPool(invokerFactory, kv, cb, p, pc))
+        Props(new InvokerPool(f, kv, cb, p, pc))
     }
 
     /** A stub identity for invoking the test action. This does not need to be a valid identity. */

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -218,8 +218,9 @@ class LoadBalancerService(config: WhiskConfig, entityStore: EntityStore)(implici
 
         val consul = new ConsulClient(config.consulServer)
         val pingConsumer = new KafkaConsumerConnector(config.kafkaHost, "health", "health")
+        val invokerFactory = (f: ActorRefFactory, name: String) => f.actorOf(InvokerActor.props, name)
 
-        actorSystem.actorOf(InvokerPool.props(consul.kv, invoker => {
+        actorSystem.actorOf(InvokerPool.props(invokerFactory, consul.kv, invoker => {
             clearInvokerState(invoker)
             logging.info(this, s"cleared load balancer state for $invoker")(TransactionId.invokerHealth)
         }, (m, i) => sendActivationToInvoker(messageProducer, m, i), pingConsumer))

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -92,8 +92,7 @@ class LoadBalancerService(config: WhiskConfig, entityStore: EntityStore)(implici
         chooseInvoker(action, msg).flatMap { invokerName =>
             val subject = msg.user.subject.asString
             val entry = setupActivation(msg.activationId, subject, invokerName, timeout, transid)
-            val msgWithTarget = ActivationRequest(msg, invokerName)
-            invokerPool.ask(msgWithTarget)(Timeout(5.seconds)).mapTo[RecordMetadata].map { _ =>
+            InvokerPool.sendActivationToInvoker(messageProducer, msg, invokerName).mapTo[RecordMetadata].map { _ =>
                 entry.promise.future
             }
         }

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -72,7 +72,7 @@ class WhiskContainer(
     def init(args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
-        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry = true)
+        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry=true)
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"initialization result: ${result.toBriefString}", endTime = endActivation)
         result
@@ -98,7 +98,7 @@ class WhiskContainer(
      */
     def run(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to ${msg.action} $details")
-        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry = false)
+        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry=false)
         // Use start and end time of the activation
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"running result: ${result.toBriefString}", endTime = endActivation)

--- a/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/WhiskContainer.scala
@@ -72,7 +72,7 @@ class WhiskContainer(
     def init(args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to ${this.details}")
         // when invoking /init, don't wait longer than the timeout configured for this action
-        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry=true)
+        val result = sendPayload("/init", JsObject("value" -> args), timeout, retry = true)
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"initialization result: ${result.toBriefString}", endTime = endActivation)
         result
@@ -98,7 +98,7 @@ class WhiskContainer(
      */
     def run(msg: ActivationMessage, args: JsObject, timeout: FiniteDuration)(implicit system: ActorSystem, transid: TransactionId): RunResult = {
         val startMarker = transid.started("Invoker", LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to ${msg.action} $details")
-        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry=false)
+        val result = sendPayload("/run", constructActivationMetadata(msg, args, timeout), timeout, retry = false)
         // Use start and end time of the activation
         val RunResult(Interval(startActivation, endActivation), _) = result
         transid.finished("Invoker", startMarker.copy(startActivation), s"running result: ${result.toBriefString}", endTime = endActivation)

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -63,6 +63,7 @@ class Invoker(
     with ActionLogDriver {
 
     private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
+    val invokerName = s"invoker$instance"
 
     TransactionId.invoker.mark(this, LoggingMarkers.INVOKER_STARTUP(instance), s"starting invoker instance ${instance}")
 
@@ -254,7 +255,7 @@ class Invoker(
         val activationInterval = computeActivationInterval(tran)
         val activationResponse = getActivationResponse(activationInterval, action.limits.timeout.duration, result, failedInit)
         val activationResult = makeWhiskActivation(msg, EntityPath(action.fullyQualifiedName(false).toString), action.version, activationResponse, activationInterval, Some(action.limits))
-        val completeMsg = CompletionMessage(transid, activationResult)
+        val completeMsg = CompletionMessage(transid, activationResult, invokerName)
 
         producer.send("completed", completeMsg) map { status =>
             logging.info(this, s"posted completion of activation ${msg.activationId}")

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -63,7 +63,6 @@ class Invoker(
     with ActionLogDriver {
 
     private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
-    val invokerName = s"invoker$instance"
 
     TransactionId.invoker.mark(this, LoggingMarkers.INVOKER_STARTUP(instance), s"starting invoker instance ${instance}")
 
@@ -255,7 +254,7 @@ class Invoker(
         val activationInterval = computeActivationInterval(tran)
         val activationResponse = getActivationResponse(activationInterval, action.limits.timeout.duration, result, failedInit)
         val activationResult = makeWhiskActivation(msg, EntityPath(action.fullyQualifiedName(false).toString), action.version, activationResponse, activationInterval, Some(action.limits))
-        val completeMsg = CompletionMessage(transid, activationResult, invokerName)
+        val completeMsg = CompletionMessage(transid, activationResult, this.name)
 
         producer.send("completed", completeMsg) map { status =>
             logging.info(this, s"posted completion of activation ${msg.activationId}")

--- a/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/whisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -19,7 +19,10 @@ package whisk.core.loadBalancer.test
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.concurrent.Future
 
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
@@ -36,18 +39,40 @@ import akka.actor.FSM.SubscribeTransitionCallBack
 import akka.actor.FSM.Transition
 import akka.pattern.ask
 import akka.testkit.ImplicitSender
+import akka.testkit.TestFSMRef
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import akka.util.Timeout
+import common.StreamLogging
 import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.KeyValueStore
+import whisk.common.TransactionId
+import whisk.core.WhiskConfig
+import whisk.core.connector.ActivationMessage
+import whisk.core.connector.MessageConsumer
+import whisk.core.connector.MessageProducer
 import whisk.core.connector.PingMessage
+import whisk.core.entitlement.Privilege.Privilege
+import whisk.core.entity.ActivationId.ActivationIdGenerator
+import whisk.core.entity.AuthKey
+import whisk.core.entity.DocRevision
+import whisk.core.entity.EntityName
+import whisk.core.entity.EntityPath
+import whisk.core.entity.ExecManifest
+import whisk.core.entity.FullyQualifiedEntityName
+import whisk.core.entity.Identity
+import whisk.core.entity.Secret
+import whisk.core.entity.Subject
+import whisk.core.entity.UUID
+import whisk.core.loadBalancer.ActivationRequest
 import whisk.core.loadBalancer.GetStatus
 import whisk.core.loadBalancer.Healthy
+import whisk.core.loadBalancer.InvocationFinishedMessage
 import whisk.core.loadBalancer.InvokerActor
 import whisk.core.loadBalancer.InvokerPool
 import whisk.core.loadBalancer.InvokerState
 import whisk.core.loadBalancer.Offline
+import whisk.core.loadBalancer.UnHealthy
 import whisk.utils.retry
 
 @RunWith(classOf[JUnitRunner])
@@ -56,7 +81,12 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with MockFactory {
+    with MockFactory
+    with StreamLogging {
+
+    val config = new WhiskConfig(ExecManifest.requiredProperties)
+
+    ExecManifest.initialize(config)
 
     override def afterAll {
         TestKit.shutdownActorSystem(system)
@@ -82,7 +112,10 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
         val childFactory = (f: ActorRefFactory, name: String) => children.dequeue()
 
         val kv = stub[KeyValueStore]
-        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, () => _))
+        val p = stub[MessageProducer]
+        val ackC = stub[MessageConsumer]
+        val pC = stub[MessageConsumer]
+        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, () => _, p, ackC, () => _, pC))
 
         within(timeout.duration) {
             // create first invoker
@@ -122,7 +155,10 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
 
         val kv = stub[KeyValueStore]
         val callback = stubFunction[String, Unit]
-        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, callback))
+        val p = stub[MessageProducer]
+        val ackC = stub[MessageConsumer]
+        val pC = stub[MessageConsumer]
+        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, callback, p, ackC, () => _, pC))
 
         within(timeout.duration) {
             // create first invoker
@@ -145,21 +181,135 @@ class InvokerSupervisionTests extends TestKit(ActorSystem("InvokerSupervision"))
         }, N = 3, waitBeforeRetry = Some(500.milliseconds))
     }
 
+    it should "forward the ActivationResult to the appropriate invoker" in {
+        val invoker = TestProbe()
+        val invokerName = invoker.ref.path.name
+        val childFactory = (f: ActorRefFactory, name: String) => invoker.ref
+        val kv = stub[KeyValueStore]
+        val p = stub[MessageProducer]
+        val ackC = stub[MessageConsumer]
+        val pC = stub[MessageConsumer]
+
+        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, () => _, p, ackC, () => _, pC))
+
+        within(timeout.duration) {
+            // Create one invoker
+            val ping0 = PingMessage(invokerName)
+            supervisor ! ping0
+            invoker.expectMsgType[SubscribeTransitionCallBack] // subscribe to the actor
+            invoker.expectMsg(ping0)
+            invoker.send(supervisor, CurrentState(invoker.ref, Healthy))
+            allStates(supervisor) shouldBe Map(invokerName -> Healthy)
+
+            // Send message and expect receive in invoker
+            val msg = InvocationFinishedMessage(invokerName, true)
+            supervisor ! msg
+            invoker.expectMsg(msg)
+        }
+    }
+
+    it should "forward an ActivationMessage to the MessageConsumer" in {
+        val invoker = TestProbe()
+        val invokerName = invoker.ref.path.name
+        val childFactory = (f: ActorRefFactory, name: String) => invoker.ref
+
+        val kv = stub[KeyValueStore]
+        val p = stub[MessageProducer]
+        val ackC = stub[MessageConsumer]
+        val pC = stub[MessageConsumer]
+
+        val supervisor = system.actorOf(InvokerPool.props(childFactory, kv, () => _, p, ackC, () => _, pC))
+
+        // Send ActivationMessage to InvokerPool
+        val activationMessage = ActivationMessage(
+            transid = TransactionId.invokerHealth,
+            action = FullyQualifiedEntityName(EntityPath("whisk.system/utils"), EntityName("date")),
+            revision = DocRevision(),
+            user = Identity(Subject("unhealthyInvokerCheck"), EntityName("unhealthyInvokerCheck"), AuthKey(UUID(), Secret()), Set[Privilege]()),
+            activationId = new ActivationIdGenerator {}.make(),
+            activationNamespace = EntityPath("guest"),
+            content = None)
+        val msg = ActivationRequest(activationMessage, invokerName)
+
+        (p.send _).when(invokerName, activationMessage).returns(Future.successful(new RecordMetadata(new TopicPartition(invokerName, 0), 0L, 0L, 0L, 0L, 0, 0)))
+
+        supervisor ! msg
+
+        // Verify, that MessageProducer will receive a call to send the message
+        retry((p.send _).verify(invokerName, activationMessage).once, N = 3, waitBeforeRetry = Some(500.milliseconds))
+    }
+
     behavior of "InvokerActor"
 
-    it should "start healthy, go offline if the state times out and goes healthy on a successful ping again" in {
+    // unHealthy -> offline
+    // offline -> unhealthy
+    it should "start unhealthy, go offline if the state times out and goes unhealthy on a successful ping again" in {
         val pool = TestProbe()
         val invoker = pool.system.actorOf(InvokerActor.props)
 
         within(timeout.duration) {
             pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
-            pool.expectMsg(CurrentState(invoker, Healthy))
-
+            pool.expectMsg(CurrentState(invoker, UnHealthy))
             timeout(invoker)
-            pool.expectMsg(Transition(invoker, Healthy, Offline))
+            pool.expectMsg(Transition(invoker, UnHealthy, Offline))
 
             invoker ! PingMessage("testinvoker")
-            pool.expectMsg(Transition(invoker, Offline, Healthy))
+            pool.expectMsg(Transition(invoker, Offline, UnHealthy))
         }
+    }
+
+    // unhealthy -> healthy
+    it should "goto healthy again, if unhealthy and error buffer has enough successful invocations" in {
+        val pool = TestProbe()
+        val invoker = pool.system.actorOf(InvokerActor.props)
+
+        within(timeout.duration) {
+            pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
+            pool.expectMsg(CurrentState(invoker, UnHealthy))
+
+            // Fill buffer with errors
+            (1 to InvokerActor.bufferSize).foreach { _ =>
+                invoker ! InvocationFinishedMessage("testinvoker", false)
+            }
+
+            // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
+            (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
+                invoker ! InvocationFinishedMessage("testinvoker", true)
+            }
+            pool.expectMsg(Transition(invoker, UnHealthy, Healthy))
+        }
+    }
+
+    // unhealthy -> offline
+    // offline -> unhealthy
+    it should "go offline when unhealthy, if the state times out and go unhealthy on a successful ping again" in {
+        val pool = TestProbe()
+        val invoker = pool.system.actorOf(InvokerActor.props)
+
+        within(timeout.duration) {
+            pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
+            pool.expectMsg(CurrentState(invoker, UnHealthy))
+
+            timeout(invoker)
+            pool.expectMsg(Transition(invoker, UnHealthy, Offline))
+
+            invoker ! PingMessage("testinvoker")
+            pool.expectMsg(Transition(invoker, Offline, UnHealthy))
+        }
+    }
+
+    it should "start timer to send testactions when unhealthy" in {
+        val invoker = TestFSMRef(new InvokerActor)
+        invoker.stateName shouldBe UnHealthy
+
+        invoker.isTimerActive(InvokerActor.timerName) shouldBe true
+
+        // Fill buffer with successful invocations to become healthy again (one below errorTolerance)
+        (1 to InvokerActor.bufferSize - InvokerActor.bufferErrorTolerance).foreach { _ =>
+            invoker ! InvocationFinishedMessage("testinvoker", true)
+        }
+        invoker.stateName shouldBe Healthy
+
+        invoker.isTimerActive(InvokerActor.timerName) shouldBe false
     }
 }


### PR DESCRIPTION
This PR adds the state "UnHealthy" to InvokerHealth. 
If an Invoker is Unhealthy, the loadbalancer won't dispatch user actions to it.
It becomes Unhealthy, if too many activations failed with the status > 2 (WhiskError).
When it is Healthy, some test actions (`whisk.system/utils/date`) will be sent to the invoker.
If enough of these test messages pass again, the Invoker turns to Healthy again and user activations are dispatched to it.

In addition this PR moves the Handling of Kafka from the LoadBalancerService to the InvokerSupervision.