### PR TITLE
Improve action log driver to truncate more tightly.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/LogLimit.scala
@@ -41,8 +41,6 @@ import whisk.core.entity.size.SizeInt
  */
 protected[core] class LogLimit private (val megabytes: Int) extends AnyVal {
     protected[core] def asMegaBytes: ByteSize = megabytes.megabytes
-    protected[core] def truncatedLogMessage = s"Logs were truncated because they exceeded the limit of $megabytes megabytes."
-
 }
 
 protected[core] object LogLimit extends ArgNormalizer[LogLimit] {

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -111,6 +111,10 @@ object Messages {
         s"${error.field} larger than allowed: ${error.is.toBytes} > ${error.allowed.toBytes} bytes."
     }
 
+    def truncateLogs(limit: ByteSize) = {
+        s"Logs were truncated because the total bytes size exceeds the limit of ${limit.toBytes} bytes."
+    }
+
     /** Error for meta api. */
     val propertyNotFound = "Response does not include requested property."
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker
+
+import java.nio.charset.StandardCharsets
+
+import scala.Vector
+import scala.util.{ Failure, Success, Try }
+
+import spray.json._
+import spray.json.DefaultJsonProtocol
+import whisk.common.{ Logging, TransactionId }
+import whisk.core.entity._
+import whisk.core.entity.size.{ SizeInt, SizeString }
+import scala.collection.mutable.Buffer
+
+/**
+ * Represents a single log line as read from a docker log
+ */
+protected[invoker] case class LogLine(time: String, stream: String, log: String) {
+    def toFormattedString = f"$time%-30s $stream: ${log.trim}"
+    def dropRight(maxBytes: ByteSize) = {
+        val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
+        LogLine(time, stream, new String(bytes, StandardCharsets.UTF_8))
+    }
+}
+
+protected[invoker] object LogLine extends DefaultJsonProtocol {
+    implicit val serdes = jsonFormat3(LogLine.apply)
+}
+
+protected[invoker] trait ActionLogDriver {
+
+    // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
+    protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+
+    /**
+     * Given the JSON driver's raw output of a docker container, convert it into our own
+     * JSON format. If asked, check for sentinel markers (which are not included in the output).
+     *
+     * Only parses and returns so much logs to fit into the LogLimit passed.
+     *
+     * @param logMsgs raw String read from a JSON log-driver written file
+     * @param requireSentinel determines if the processor should wait for a sentinel to appear
+     * @param limit the limit to apply to the log size
+     *
+     * @return Tuple containing (isComplete, isTruncated, logs)
+     */
+    protected def processJsonDriverLogContents(logMsgs: String, requireSentinel: Boolean, limit: ByteSize)(
+        implicit transid: TransactionId, logging: Logging): (Boolean, Boolean, Vector[LogLine]) = {
+
+        var hasOut = false
+        var hasErr = false
+        var truncated = false
+        var bytesSoFar = 0.B
+        val logLines = Buffer[LogLine]()
+        val lines = logMsgs.lines
+
+        // read whiles bytesSoFar <= limit when requireSentinel to try and grab sentinel if they exist to indicate completion
+        while (lines.hasNext && ((requireSentinel && bytesSoFar <= limit) || bytesSoFar < limit)) {
+            // if line does not parse, there's an error in the container log driver
+            Try(lines.next().parseJson.convertTo[LogLine]) match {
+                case Success(t) =>
+                    // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
+                    if (requireSentinel && t.log.trim != LOG_ACTIVATION_SENTINEL || !requireSentinel) {
+                        // ignore empty log lines
+                        if (t.log.nonEmpty) {
+                            bytesSoFar += t.log.sizeInBytes
+                            if (bytesSoFar <= limit) {
+                                logLines.append(t)
+                            } else {
+                                // chop off the right most bytes that overflow
+                                val chopped = t.dropRight(bytesSoFar - limit)
+                                if (chopped.log.nonEmpty) {
+                                    logLines.append(chopped)
+                                }
+                                truncated = true
+                            }
+                        }
+                    } else if (requireSentinel) {
+                        // there may be more than one sentinel in stdout/stderr (as logs may leak across activations
+                        // if for example there log limit was exceeded in one activation and the container was reused
+                        // to run the same action again (this is considered a feature - otherwise, must drain the logs
+                        // or destroy the container as if it errored)
+                        if (t.stream == "stdout") {
+                            hasOut = true
+                        } else if (t.stream == "stderr") {
+                            hasErr = true
+                        }
+                    }
+
+                case Failure(t) =>
+                    // Drop lines that did not parse to JSON objects.
+                    // However, should not happen since we are using the json log driver.
+                    logging.error(this, s"log line skipped/did not parse: $t")
+            }
+        }
+
+        ((hasOut && hasErr) || !requireSentinel, truncated || lines.hasNext, logLines.toVector)
+    }
+}

--- a/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
+++ b/core/javaAction/proxy/src/main/java/openwhisk/java/action/Proxy.java
@@ -52,7 +52,7 @@ public class Proxy {
     }
 
     private static void writeResponse(HttpExchange t, int code, String content) throws IOException {
-        byte[] bytes = content.getBytes("UTF-8");
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
         t.sendResponseHeaders(code, bytes.length);
         OutputStream os = t.getResponseBody();
         os.write(bytes);
@@ -119,7 +119,7 @@ public class Proxy {
             try {
                 InputStream is = t.getRequestBody();
                 JsonParser parser = new JsonParser();
-                JsonElement ie = parser.parse(new BufferedReader(new InputStreamReader(is, "UTF-8")));
+                JsonElement ie = parser.parse(new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8)));
                 JsonObject inputObject = ie.getAsJsonObject().getAsJsonObject("value");
 
                 HashMap<String, String> env = new HashMap<String, String>();

--- a/tests/dat/actions/dosLogs.js
+++ b/tests/dat/actions/dosLogs.js
@@ -1,8 +1,8 @@
 function main(msg) {
-    // Each log line with 16 characters
-    var lines = msg.payload / 16 || 0;
-    for(var i = 0; i <= lines; i++) {
-        console.log("0123456789abcdef");
+    // Each log line with 16 characters (new line character counts)
+    var lines = msg.payload / 16 || 1;
+    for(var i = 1; i <= lines; i++) {
+        console.log("123456789abcdef");
     }
-    return {msg: i};
+    return {msg: lines};
 }

--- a/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.invoker.test
+
+import java.nio.charset.StandardCharsets
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import common.StreamLogging
+import spray.json.pimpAny
+import whisk.common.TransactionId
+import whisk.core.entity.size._
+import whisk.core.invoker.ActionLogDriver
+import whisk.core.invoker.LogLine
+
+@RunWith(classOf[JUnitRunner])
+class ActionLogDriverTests
+    extends FlatSpec
+    with BeforeAndAfter
+    with Matchers
+    with ActionLogDriver
+    with StreamLogging {
+
+    private def makeLogMsgs(lines: Seq[String], stream: String = "stdout", addSentinel: Boolean = true) = {
+        val msgs = if (addSentinel) {
+            lines.map((stream, _)) :+
+                ("stdout", s"$LOG_ACTIVATION_SENTINEL\n") :+
+                ("stderr", s"$LOG_ACTIVATION_SENTINEL\n")
+        } else {
+            lines.map((stream, _))
+        }
+
+        msgs.map(p => LogLine("", p._1, p._2).toJson.compactPrint)
+            .mkString("\n")
+    }
+
+    private def makeLogLines(lines: Seq[String], stream: String = "stdout") = {
+        lines.map(LogLine("", stream, _)).filter(_.log.nonEmpty).toVector
+    }
+
+    behavior of "LogLine"
+
+    it should "truncate log line" in {
+        "❄".sizeInBytes shouldBe 3.B
+
+        Seq("abcdef", "❄ ☃ ❄").foreach { logline =>
+            val bytes = logline.sizeInBytes
+            LogLine("", "", logline).dropRight(0.B).log shouldBe logline
+            LogLine("", "", logline).dropRight(1.B).log shouldBe {
+                val truncated = logline.getBytes(StandardCharsets.UTF_8).dropRight(1)
+                new String(truncated, StandardCharsets.UTF_8)
+            }
+        }
+    }
+
+    behavior of "ActionLogDriver"
+
+    it should "mock container log drain" in {
+        makeLogMsgs(Seq("a", "b", "c")) shouldBe {
+            raw"""|{"time":"","stream":"stdout","log":"a"}
+                  |{"time":"","stream":"stdout","log":"b"}
+                  |{"time":"","stream":"stdout","log":"c"}
+                  |{"time":"","stream":"stdout","log":"$LOG_ACTIVATION_SENTINEL\n"}
+                  |{"time":"","stream":"stderr","log":"$LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
+        }
+    }
+
+    it should "handle empty logs" in {
+        implicit val tid = TransactionId.testing
+        processJsonDriverLogContents("", true, 0.B) shouldBe {
+            (false, false, Vector())
+        }
+
+        processJsonDriverLogContents("", false, 0.B) shouldBe {
+            (true, false, Vector())
+        }
+    }
+
+    it should "not truncate logs within limit" in {
+        implicit val tid = TransactionId.testing
+
+        Seq(
+            (Seq("\n"), 1),
+            (Seq("a"), 1),
+            (Seq("❄"), 3),
+            (Seq("", "a", "❄"), 4),
+            (Seq("abc\n", "abc\n"), 8))
+            .foreach {
+                case (msgs, l) =>
+                    Seq(false).foreach { sentinel =>
+                        processJsonDriverLogContents(makeLogMsgs(msgs, addSentinel = sentinel), sentinel, l.B) shouldBe {
+                            (true, false, makeLogLines(msgs))
+                        }
+                    }
+            }
+    }
+
+    it should "account for sentinels when logs are not form a sentinelled action runtime" in {
+        implicit val tid = TransactionId.testing
+
+        Seq(
+            (Seq(""), 0),
+            (Seq("\n"), 1),
+            (Seq("a"), 1),
+            (Seq("❄"), 3),
+            (Seq("", "a", "❄"), 4),
+            (Seq("abc\n", "abc\n"), 8))
+            .foreach {
+                case (msgs, l) =>
+                    processJsonDriverLogContents(makeLogMsgs(msgs, addSentinel = true), false, l.B) shouldBe {
+                        (true, true, makeLogLines(msgs))
+                    }
+            }
+    }
+
+    it should "truncate logs exceeding limit" in {
+        implicit val tid = TransactionId.testing
+
+        Seq(
+            (Seq("\n"), Seq(), 0),
+            (Seq("a"), Seq(), 0),
+            (Seq("ab"), Seq("a"), 1),
+            (Seq("❄"), Seq("�"), 1),
+            (Seq("❄"), Seq("�"), 2),
+            (Seq("abc\n", "abc\n", "abc\n"), Seq("abc\n", "abc\n"), 8))
+            .foreach {
+                case (msgs, exp, l) =>
+                    Seq(true, false).foreach { sentinel =>
+                        processJsonDriverLogContents(makeLogMsgs(msgs, addSentinel = sentinel), sentinel, l.B) shouldBe {
+                            (!sentinel, true, makeLogLines(exp))
+                        }
+                    }
+            }
+    }
+}


### PR DESCRIPTION
When truncating, read all bytes up to the limit.
Separate log processors into its own trait - add unit tests.
Fix/tighten pre-existing test.