### PR TITLE
Return Appropriate Error Message when a Web Action is Invoked with an Unsupported Content-type

### DIFF
--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -117,6 +117,7 @@ object Messages {
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
     val contentTypeExtentionNotSupported = """Extension must be specified and one of [".json", ".html", ".http", ".text"]."""
     val contentTypeNotSupported = s"Content-type must be ${MediaTypes.`application/json`} or ${MediaTypes.`application/x-www-form-urlencoded`}."
+    def invalidAcceptType(m: MediaType) = s"Response of ${m.value} does not correspond with accept header."
 
     val responseNotReady = "Response not yet ready."
     val httpUnknownContentType = "Response did not specify a known content-type."

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -114,8 +114,8 @@ object Messages {
     /** Error for meta api. */
     val propertyNotFound = "Response does not include requested property."
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
-    val contentTypeNotSupported = """Content type must be specified and one of ["json", "html", "http", "text"]."""
-
+    val contentTypeExtentionNotSupported = """Content type must be specified and one of ["json", "html", "http", "text"]."""
+    val contentTypeNotSupported = "Content type must be appication/json or application/x-www-form-urlencoded."
     val responseNotReady = "Response not yet ready."
     val httpUnknownContentType = "Response did not specify a known content-type."
     val httpContentTypeError = "Response type in header did not match generated content type."

--- a/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/whisk/http/ErrorResponse.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 import spray.http.MediaType
+import spray.http.MediaTypes
 import spray.http.StatusCode
 import spray.http.StatusCodes.Forbidden
 import spray.http.StatusCodes.NotFound
@@ -114,8 +115,9 @@ object Messages {
     /** Error for meta api. */
     val propertyNotFound = "Response does not include requested property."
     def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."
-    val contentTypeExtentionNotSupported = """Content type must be specified and one of ["json", "html", "http", "text"]."""
-    val contentTypeNotSupported = "Content type must be appication/json or application/x-www-form-urlencoded."
+    val contentTypeExtentionNotSupported = """Extension must be specified and one of [".json", ".html", ".http", ".text"]."""
+    val contentTypeNotSupported = s"Content-type must be ${MediaTypes.`application/json`} or ${MediaTypes.`application/x-www-form-urlencoded`}."
+
     val responseNotReady = "Response not yet ready."
     val httpUnknownContentType = "Response did not specify a known content-type."
     val httpContentTypeError = "Response type in header did not match generated content type."

--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -192,7 +192,7 @@ protected[core] object WhiskMetaApi extends Directives {
                 respondWithHeaders(headers) {
                     respondWithMediaType(mediaType) {
                         complete(code, data)
-                    }
+                    } ~ terminate(BadRequest, Messages.invalidAcceptType(mediaType))(transid)
                 }
 
             case Failure(RejectRequest(code, message)) =>

--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -273,9 +273,9 @@ trait WhiskMetaApi
                                     val pkgName = if (pkg == "default") None else Some(EntityName(pkg))
                                     handleMatch(EntityName(namespace), pkgName, EntityName(action), extension, user)
                                 } else {
-                                    terminate(NotAcceptable, Messages.contentTypeNotSupported)
+                                    terminate(NotAcceptable, Messages.contentTypeExtentionNotSupported)
                                 }
-                            case _ => terminate(NotAcceptable, Messages.contentTypeNotSupported)
+                            case _ => terminate(NotAcceptable, Messages.contentTypeExtentionNotSupported)
                         }
                     }
                 }
@@ -330,7 +330,7 @@ trait WhiskMetaApi
                     body => process(body)
                 } ~ entity(as[FormData]) {
                     form => process(Some(form.fields.toMap.toJson.asJsObject))
-                }
+                } ~ terminate(BadRequest, Messages.contentTypeNotSupported)
             }
         }
     }

--- a/tests/dat/actions/textBody.js
+++ b/tests/dat/actions/textBody.js
@@ -1,0 +1,8 @@
+function main() {
+  return {
+    headers: {
+      'Content-Type': 'text/html'
+    },
+    body: 'plain text'
+  };
+}

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -133,4 +133,21 @@ class WskWebActionsTests
             response.statusCode shouldBe 400
             response.body().asString() should include(Messages.contentTypeNotSupported)
     }
+
+    it should "reject invocation of web action with invalid accept header" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("textBody.js"))
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val host = getServiceURL()
+            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.http"
+            val response = RestAssured.given().header("accept", "application/json").config(sslconfig).get(url)
+            response.statusCode shouldBe 400
+            response.body().asString() should include(Messages.contentTypeNotSupported)
+    }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -29,6 +29,7 @@ import common.WskProps
 import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
+import spray.http.MediaTypes
 import system.rest.RestUtil
 import whisk.http.Messages
 
@@ -148,6 +149,6 @@ class WskWebActionsTests
             val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.http"
             val response = RestAssured.given().header("accept", "application/json").config(sslconfig).get(url)
             response.statusCode shouldBe 400
-            response.body().asString() should include(Messages.contentTypeNotSupported)
+            response.body().asString() should include(Messages.invalidAcceptType(MediaTypes.`text/html`))
     }
 }

--- a/tests/src/test/scala/whisk/core/controller/test/MetaApiTests.scala
+++ b/tests/src/test/scala/whisk/core/controller/test/MetaApiTests.scala
@@ -289,7 +289,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
 
                     Get(s"$testRoutePath/$path") ~> sealRoute(routes(creds)) ~> check {
                         status should be(NotAcceptable)
-                        confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeNotSupported))
+                        confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeExtentionNotSupported))
                     }
                 }
         }
@@ -706,7 +706,7 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
                 foreach { path =>
                     Get(s"$testRoutePath/$path") ~> sealRoute(routes(creds)) ~> check {
                         status should be(NotAcceptable)
-                        confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeNotSupported))
+                        confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeExtentionNotSupported))
                     }
                 }
         }
@@ -772,8 +772,8 @@ class MetaApiTests extends ControllerTestCommon with WhiskMetaApi with BeforeAnd
             implicit val tid = transid()
 
             Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d", "1,2,3") ~> sealRoute(routes(creds)) ~> check {
-                status should be(UnsupportedMediaType)
-                responseAs[String] should include("application/json")
+                status should be(BadRequest)
+                confirmErrorWithTid(responseAs[JsObject], Some(Messages.contentTypeNotSupported))
             }
 
             Post(s"$testRoutePath/$systemId/proxy/export_c.json?a=b&c=d") ~> sealRoute(routes(creds)) ~> check {


### PR DESCRIPTION
- Inform user's when an unsupported content-type is passed to a Web Action

Closes: https://github.com/openwhisk/openwhisk/issues/1886