### PR TITLE
Better handling for zip actions with incorrect structure

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -51,6 +51,10 @@ function NodeActionRunner() {
         if (message.binary) {
             // The code is a base64-encoded zip file.
             return unzipInTmpDir(message.code).then(function (moduleDir) {
+                if(!fs.existsSync(path.join(moduleDir, 'package.json'))) {
+                    return Promise.reject('package.json must be located at the root of a zipped action.')
+                }
+
                 try {
                     thisRunner.userScriptMain = eval('require("' + moduleDir + '").' + message.main);
                     assertMainIsFunction();

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -390,6 +390,8 @@ To create an OpenWhisk action from this package:
   $ zip -r action.zip *
   ```
 
+  > Please note: Using the Windows Explorer action for creating the zip file will result in an incorrect structure. OpenWhisk zip actions must have `package.json` at the root of the zip, while Windows Explorer will put it inside a nested folder. The safest option is to use the command line `zip` command as shown above.
+
 3. Create the action:
 
   ```

--- a/tests/src/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/actionContainers/NodeJsActionContainerTests.scala
@@ -444,7 +444,7 @@ class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSys
         checkStreams(out, err, {
             case (o, e) =>
                 (o + e).toLowerCase should include("error")
-                (o + e).toLowerCase should include("module_not_found")
+                (o + e).toLowerCase should include("package.json must be located at the root of a zipped action")
         })
     }
 


### PR DESCRIPTION
resolves #1945 

In addition to updating the doc to specifically warn against using the Windows Explorer zip action, update the Node.js runtime to fail on `/init` with a specific message telling the user what is wrong with their zip action.