### PR TITLE
Utilities to read Exec runtimes from manifest.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -7,6 +7,27 @@ whisk:
   version:
     date: "{{ansible_date_time.iso8601}}"
 
+# list of supported runtimes (see whisk.core.entity.ExecManifest for schema)
+runtimesManifest:
+  nodejs:
+  - kind: "nodejs"
+  - kind: "nodejs:6"
+    default: true
+  python:
+  - kind: "python"
+  swift:
+  - kind: "swift"
+    deprecated: true
+  - kind: "swift:3"
+    default: true
+  java:
+  - kind: "java"
+    attached:
+      attachmentName: "jarfile"
+      attachmentType: "application/java-archive"
+    sentinelledLogs: false
+    requireMain: true
+
 defaultLimits:
   actions:
     invokes:
@@ -18,7 +39,6 @@ defaultLimits:
   triggers:
     fires:
       perMinute: 60
-
 
 # port means outer port
 controller:

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -15,6 +15,7 @@ whisk.ssl.key={{ openwhisk_home }}/ansible/roles/nginx/files/openwhisk-key.pem
 whisk.ssl.challenge=openwhisk
 whisk.api.host={{ whisk_api_host | default('https://' + (groups['edge'] | first)) }}
 
+runtimes.manifest={{ runtimesManifest | to_json }}
 defaultLimits.actions.invokes.perMinute={{ defaultLimits.actions.invokes.perMinute }}
 defaultLimits.actions.invokes.concurrent={{ defaultLimits.actions.invokes.concurrent }}
 defaultLimits.triggers.fires.perMinute={{ defaultLimits.triggers.fires.perMinute }}

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -107,6 +107,8 @@ class WhiskConfig(
     val kafkaDockerEndpoint = this(WhiskConfig.kafkaDockerEndpoint)
     val mainDockerEndpoint = this(WhiskConfig.mainDockerEndpoint)
 
+    val runtimesManifest = this(WhiskConfig.runtimesManifest)
+
     val actionInvokePerMinuteLimit = this(WhiskConfig.actionInvokePerMinuteDefaultLimit, WhiskConfig.actionInvokePerMinuteLimit)
     val actionInvokeConcurrentLimit = this(WhiskConfig.actionInvokeConcurrentDefaultLimit, WhiskConfig.actionInvokeConcurrentLimit)
     val triggerFirePerMinuteLimit = this(WhiskConfig.triggerFirePerMinuteDefaultLimit, WhiskConfig.triggerFirePerMinuteLimit)
@@ -262,6 +264,8 @@ object WhiskConfig {
     val kafkaHost = Map(kafkaHostName -> null, kafkaHostPort -> null)
     val controllerHost = Map(controllerHostName -> null, controllerHostPort -> null)
     val loadbalancerHost = Map(loadbalancerHostName -> null, loadbalancerHostPort -> null)
+
+    val runtimesManifest = "runtimes.manifest"
 
     val actionInvokePerMinuteDefaultLimit = "defaultLimits.actions.invokes.perMinute"
     val actionInvokeConcurrentDefaultLimit = "defaultLimits.actions.invokes.concurrent"

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity
+
+import scala.util.Try
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.core.WhiskConfig
+import whisk.core.entity.Attachments._
+import whisk.core.entity.Attachments.Attached._
+
+/**
+ * Reads manifest of supported runtimes from configuration file and stores
+ * a representation of each runtime which is used for serialization and
+ * deserialization. This singleton must be initialized.
+ */
+protected[core] object ExecManifest {
+
+    /**
+     * Required properties to initialize this singleton via WhiskConfig.
+     */
+    protected[core] def requiredProperties = Map(WhiskConfig.runtimesManifest -> null)
+
+    /**
+     * Reads runtimes manifest from WhiskConfig and initializes the
+     * singleton.
+     *
+     * @param config a valid configuration
+     * @return true iff initialized successfully
+     */
+    protected[core] def initialize(config: WhiskConfig): Boolean = {
+        Try(config.runtimesManifest.parseJson.asJsObject)
+            .flatMap(runtimes(_))
+            .map(m => manifest = Some(m))
+            .isSuccess
+    }
+
+    /**
+     * Gets existing runtime manifests.
+     *
+     * @return Some(Runtimes) or None if manifest is not yet initialized
+     */
+    protected[core] def runtimesManifest: Option[Runtimes] = manifest
+
+    private var manifest: Option[Runtimes] = None
+
+    /**
+     * @param config a configuration object as JSON
+     * @return Runtimes instance
+     */
+    protected[entity] def runtimes(config: JsObject): Try[Runtimes] = Try {
+        Runtimes(config.convertTo[Map[String, Set[RuntimeManifest]]].map {
+            case (name, versions) => RuntimeFamily(name, versions)
+        }.toSet)
+    }
+
+    /**
+     * A runtime manifest describes the "exec" runtime support.
+     *
+     * @param kind the name of the kind e.g., nodejs:6
+     * @param deprecated true iff the runtime is deprecated (allows get/delete but not create/update/invoke)
+     * @param default true iff the runtime is the default kind for its family (nodejs:default -> nodejs:6)
+     * @param attached true iff the source is an attachments (not inlined source)
+     * @param requireMain true iff main entry point is not optional
+     * @param sentinelledLogs true iff the runtime generates stdout/stderr log sentinels after an activation
+     * @param image optional image name, otherwise inferred via fixed mapping (remove colons and append 'action')
+     */
+    protected[entity] case class RuntimeManifest(
+        kind: String,
+        deprecated: Option[Boolean] = None,
+        default: Option[Boolean] = None,
+        attached: Option[Attached] = None,
+        requireMain: Option[Boolean] = None,
+        sentinelledLogs: Option[Boolean] = None,
+        image: Option[String] = None)
+
+    /**
+     * A runtime family manifest is a collection of runtimes grouped by a family (e.g., swift with versions swift:2 and swift:3).
+     * @param family runtime family
+     * @version set of runtime manifests
+     */
+    protected[entity] case class RuntimeFamily(name: String, versions: Set[RuntimeManifest])
+
+    /**
+     * A collection of runtime families.
+     *
+     * @param set of supported runtime families
+     */
+    protected[entity] case class Runtimes(runtimes: Set[RuntimeFamily]) {
+        val knownContainerRuntimes: Set[String] = runtimes.flatMap(_.versions.map(_.kind))
+
+        def resolveDefaultRuntime(kind: String): Option[RuntimeManifest] = {
+            kind match {
+                case defaultSplitter(family) => defaultRuntimes.get(family).flatten.flatMap(manifests.get(_))
+                case _                       => manifests.get(kind)
+            }
+        }
+
+        private val manifests: Map[String, RuntimeManifest] = {
+            runtimes.flatMap {
+                _.versions.map {
+                    m => m.kind -> m
+                }
+            }.toMap
+        }
+
+        private val defaultRuntimes: Map[String, Option[String]] = {
+            runtimes.map { family =>
+                family.versions.filter(_.default.exists(identity)).toList match {
+                    case Nil      => family.name -> None
+                    case d :: Nil => family.name -> Some(d.kind)
+                    case ds       => throw new IllegalArgumentException(s"found more than one default for ${family.name}: ${ds.mkString(",")}")
+                }
+            }.toMap
+        }
+
+        private val defaultSplitter = "([a-z0-9]):default".r
+    }
+
+    protected[entity] implicit val runtimeManifestSerdes = jsonFormat7(RuntimeManifest)
+}

--- a/tests/src/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/whisk/core/entity/test/ExecManifestTests.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.entity.test
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.core.entity.ExecManifest
+import whisk.core.entity.ExecManifest._
+
+@RunWith(classOf[JUnitRunner])
+class ExecManifestTests
+    extends FlatSpec
+    with Matchers {
+
+    behavior of "ExecManifest"
+
+    it should "read a valid configuration" in {
+        val k1 = RuntimeManifest("k1")
+        val k2 = RuntimeManifest("k2", default = Some(true))
+        val p1 = RuntimeManifest("p1")
+        val mf = JsObject("k" -> Set(k1, k2).toJson, "p1" -> Set(p1).toJson)
+        val runtimes = ExecManifest.runtimes(mf).get
+
+        Seq("k1", "k2", "p1").foreach {
+            runtimes.knownContainerRuntimes.contains(_) shouldBe true
+        }
+
+        runtimes.knownContainerRuntimes.contains("k3") shouldBe false
+
+        runtimes.resolveDefaultRuntime("k1") shouldBe Some(k1)
+        runtimes.resolveDefaultRuntime("k2") shouldBe Some(k2)
+        runtimes.resolveDefaultRuntime("p1") shouldBe Some(p1)
+
+        runtimes.resolveDefaultRuntime("k:default") shouldBe Some(k2)
+        runtimes.resolveDefaultRuntime("p1:default") shouldBe None
+    }
+
+}


### PR DESCRIPTION
Add runtimes manifest to ansible group vars.
Write out manifest to whisk.properties and make available through WhiskConfig.
