### PR TITLE
Bump scalatest version

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testCompile 'org.apache.httpcomponents:httpmime:4.3.6'
     testCompile 'junit:junit:4.11'
     testCompile 'com.jayway.restassured:rest-assured:2.4.1'
-    testCompile 'org.scalatest:scalatest_2.11:2.2.4'
+    testCompile 'org.scalatest:scalatest_2.11:3.0.1'
     testCompile 'org.seleniumhq.selenium:selenium-java:2.45.0'
     testCompile 'io.spray:spray-testkit_2.11:1.3.3'
     testCompile 'com.google.code.tempus-fugit:tempus-fugit:1.2-SNAPSHOT'


### PR DESCRIPTION
Several repositories need to do this to support more sophisticated testing capabilities (mocking etc.)

This is taken out of a larger PR to resolve a deadlock in our integration.