### PR TITLE
Fix CN host name when generating certificate.

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -31,4 +31,4 @@
     when: not db.stat.exists
 
   - name: gen untrusted certificate for host
-    local_action: shell "{{ playbook_dir }}/roles/nginx/files/genssl.sh" "lookup('env', 'OPENWHISK_APIHOST') || {{ groups["edge"]|first }}"
+    local_action: shell "{{ playbook_dir }}/roles/nginx/files/genssl.sh" "{{ lookup('env', 'OPENWHISK_API_HOST') | default("localhost", true) }}"


### PR DESCRIPTION
If the API host name is not defined, default to "localhost". Fix lookup of API host from the environment.