### PR TITLE
Fix imagename for pre-warm container creation

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/ContainerPool.scala
@@ -538,7 +538,7 @@ class ContainerPool(
      * If container creation fails, the container will not be entered into the pool.
      */
     private def addStemCellNodejsContainer()(implicit transid: TransactionId) = Future {
-        val imageName = ExecImageName.localImageName(config.dockerRegistry, config.dockerImagePrefix, "nodejs:6", config.dockerImageTag)
+        val imageName = ExecImageName.localImageName(config.dockerRegistry, config.dockerImagePrefix, Exec.imagename(Exec.NODEJS6), config.dockerImageTag)
         val limits = ActionLimits(TimeLimit(), defaultMemoryLimit, LogLimit())
         val containerName = makeContainerName("warmJsContainer")
         logging.info(this, "Starting warm nodejs container")
@@ -566,7 +566,7 @@ class ContainerPool(
     private def makeWhiskContainer(action: WhiskAction, auth: AuthKey)(implicit transid: TransactionId): WhiskContainer = {
         val imageName = getDockerImageName(action)
         val limits = action.limits
-        val nodeImageName = ExecImageName.localImageName(config.dockerRegistry, config.dockerImagePrefix, "nodejs:6", config.dockerImageTag)
+        val nodeImageName = ExecImageName.localImageName(config.dockerRegistry, config.dockerImagePrefix, Exec.imagename(Exec.NODEJS6), config.dockerImageTag)
         val key = ActionContainerId(auth.uuid, action.fullyQualifiedName(true).toString, action.rev)
         val warmedContainer = if (limits.memory == defaultMemoryLimit && imageName == nodeImageName) getStemCellNodejsContainer(key) else None
         val containerName = makeContainerName(action)


### PR DESCRIPTION
Invoker wasn't able to spawn new pre-warm containers due to a naming issue.