### PR TITLE
only docker pull apigateway from dockerhub in normal mode deploy

### DIFF
--- a/ansible/roles/apigateway/tasks/deploy.yml
+++ b/ansible/roles/apigateway/tasks/deploy.yml
@@ -3,6 +3,7 @@
 
 - name: "pull the openwhisk/apigateway image"
   shell: "docker pull openwhisk/apigateway"
+  when: apigateway_local_build is undefined
 
 - name: (re)start apigateway
   docker_container:


### PR DESCRIPTION
the env var apigateway_local_build it's used to skip the pull
This is required when building the image from outside ansible
like the Travis integration in the openwhisk-apigateway repository