### PR TITLE
Access HTTP Body from Web Actions

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/Meta.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Meta.scala
@@ -324,11 +324,10 @@ trait WhiskMetaApi
             }
         }
 
-        val isRawHTTPEnabled = """(?i)(true)""".r
         extract(_.request.entity.data.length) { length =>
             validateSize(isWhithinRange(length))(transid) {
                 optionalHeaderValueByName("x-ow-raw-http") {
-                    case Some(isRawHTTPEnabled(value)) =>
+                    case Some(headerValue) if Try(headerValue.toBoolean).getOrElse(false) =>
                         entity(as[String]) {
                             body => process(Some(JsObject("__ow_meta_body" -> body.toJson)))
                         }

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -115,57 +115,6 @@ class WskWebActionsTests
             authorizedResponse.body().asString() shouldBe namespace
     }
 
-    it should "fail to invoke web action with an unsupported content type when x-ow-raw-http header is not supplied" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val bodyContent = "This is the body"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
-            }
-
-            val host = getServiceURL()
-            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
-            val response = RestAssured.given().header("x-ow-raw-http", "false").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
-            response.statusCode shouldBe 401
-    }
-
-    it should "fail to invoke web action with an unsupported content type when x-ow-raw-http header is not enabled" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val bodyContent = "This is the body"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
-            }
-
-            val host = getServiceURL()
-            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
-            val response = RestAssured.given().header("x-ow-raw-http", "false").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
-            response.statusCode shouldBe 401
-    }
-
-    it should "fail to invoke web action with an unsupported content type when an non-boolean value is passed to the x-ow-raw-http header" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            val name = "webaction"
-            val file = Some(TestUtils.getTestActionFilename("echo.js"))
-            val bodyContent = "This is the body"
-
-            assetHelper.withCleaner(wsk.action, name) {
-                (action, _) =>
-                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
-            }
-
-            val host = getServiceURL()
-            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
-            val response = RestAssured.given().header("x-ow-raw-http", "not a boolean").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
-            response.statusCode shouldBe 401
-    }
-
     it should "invoke a web action using the x-ow-raw-http header to return the sent HTTP body" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "webaction"

--- a/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskWebActionsTests.scala
@@ -114,4 +114,73 @@ class WskWebActionsTests
             authorizedResponse.statusCode shouldBe 200
             authorizedResponse.body().asString() shouldBe namespace
     }
+
+    it should "fail to invoke web action with an unsupported content type when x-ow-raw-http header is not supplied" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+            val bodyContent = "This is the body"
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val host = getServiceURL()
+            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
+            val response = RestAssured.given().header("x-ow-raw-http", "false").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
+            response.statusCode shouldBe 401
+    }
+
+    it should "fail to invoke web action with an unsupported content type when x-ow-raw-http header is not enabled" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+            val bodyContent = "This is the body"
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val host = getServiceURL()
+            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
+            val response = RestAssured.given().header("x-ow-raw-http", "false").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
+            response.statusCode shouldBe 401
+    }
+
+    it should "fail to invoke web action with an unsupported content type when an non-boolean value is passed to the x-ow-raw-http header" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+            val bodyContent = "This is the body"
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val host = getServiceURL()
+            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.text"
+            val response = RestAssured.given().header("x-ow-raw-http", "not a boolean").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
+            response.statusCode shouldBe 401
+    }
+
+    it should "invoke a web action using the x-ow-raw-http header to return the sent HTTP body" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+            val bodyContent = "This is the body"
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) =>
+                    action.create(name, file, annotations = Map("web-export" -> true.toJson))
+            }
+
+            val host = getServiceURL()
+            val url = host + s"/api/v1/experimental/web/$namespace/default/webaction.json"
+            val response = RestAssured.given().header("x-ow-raw-http", "TruE").contentType("text/html").body(bodyContent).config(sslconfig).post(url)
+            response.statusCode shouldBe 200
+            response.body.asString.parseJson.asJsObject.fields("__ow_meta_body") shouldBe JsString(bodyContent)
+    }
 }


### PR DESCRIPTION
- Provide `__ow_meta_body` argument that allows access to the content of the HTTP body passed to a Web Action only when the `x-ow-raw: true` HTTP header is provided.

Close: https://github.com/openwhisk/openwhisk/issues/1947