### PR TITLE
Part 2: Update all remaining Python files with ASF license

### DIFF
--- a/ansible/callbacks/logformatter.py
+++ b/ansible/callbacks/logformatter.py
@@ -1,16 +1,38 @@
+"""Python callback for highlighting Ansible logs.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 from __future__ import (absolute_import, division, print_function)
+import os
+import sys
+from ansible.plugins.callback import CallbackBase
 __metaclass__ = type
 
-from ansible.plugins.callback import CallbackBase
-import sys
-import json
 
 class CallbackModule(CallbackBase):
+    """."""
 
     def __init__(self):
+        """Initialize superclass."""
         super(CallbackModule, self).__init__()
 
     def emit(self, host, category, data):
+        """Emit colorized output based upon data contents."""
         if type(data) == dict:
             cmd = data['cmd'] if 'cmd' in data else None
             stdout = data['stdout'] if 'stdout' in data else None
@@ -43,18 +65,22 @@ class CallbackModule(CallbackBase):
 
 
 def hilite(msg, status):
-    def supportsColor():
-        if (sys.platform != 'win32' or 'ANSICON' in os.environ) and sys.stdout.isatty():
+    """Highlight message."""
+    def supports_color():
+        if ((sys.platform != 'win32' or 'ANSICON' in os.environ) and
+           sys.stdout.isatty()):
             return True
         else:
             return False
 
-    if supportsColor():
+    if supports_color():
         attr = []
         if status == 'FAILED':
-            attr.append('31') # red
+            # red
+            attr.append('31')
         else:
-            attr.append('1') # bold
+            # bold
+            attr.append('1')
         return '\x1b[%sm%s\x1b[0m' % (';'.join(attr), msg)
     else:
         return msg

--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -29,7 +29,6 @@ code when required.
 
 import sys
 import os
-import stat
 import json
 import subprocess
 import codecs
@@ -39,14 +38,16 @@ import zipfile
 import io
 import base64
 
-class ActionRunner:
 
+class ActionRunner:
+    """ActionRunner."""
     LOG_SENTINEL = 'XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX'
 
     # initializes the runner
     # @param source the path where the source code will be located (if any)
-    # @param binary the path where the binary will be located (may be the same as source code path)
-    def __init__(self, source = None, binary = None):
+    # @param binary the path where the binary will be located (may be the
+    # same as source code path)
+    def __init__(self, source=None, binary=None):
         defaultBinary = '/action/exec'
         self.source = source if source else defaultBinary
         self.binary = binary if binary else defaultBinary
@@ -78,7 +79,9 @@ class ActionRunner:
                 # build the source
                 self.build(message)
             except Exception:
-                None  # do nothing, verify will signal failure if binary not executable
+                # do nothing, verify will signal failure
+                # if binary not executable
+                None
         # verify the binary exists and is executable
         return self.verify()
 
@@ -92,33 +95,38 @@ class ActionRunner:
 
     # @return True iff binary exists and is executable, False otherwise
     def verify(self):
-        return (os.path.isfile(self.binary) and os.access(self.binary, os.X_OK))
+        return (os.path.isfile(self.binary) and
+                os.access(self.binary, os.X_OK))
 
     # constructs an environment for the action to run in
-    # @param message is a JSON object received from invoker (should contain 'value' and 'api_key' and other metadata)
+    # @param message is a JSON object received from invoker (should
+    # contain 'value' and 'api_key' and other metadata)
     # @return an environment dictionary for the action process
     def env(self, message):
         # make sure to include all the env vars passed in by the invoker
         env = os.environ
-        for p in [ 'api_key', 'namespace', 'action_name', 'activation_id', 'deadline' ]:
-             if p in message:
+        for p in ['api_key', 'namespace', 'action_name',
+                  'activation_id', 'deadline']:
+            if p in message:
                 env['__OW_%s' % p.upper()] = message[p]
         return env
 
     # runs the action, called iff self.verify() is True.
     # @param args is a JSON object representing the input to the action
-    # @param env is the environment for the action to run in (defined edge host, auth key)
-    # return JSON object result of running the action or an error dictionary if action failed
+    # @param env is the environment for the action to run in (defined edge
+    # host, auth key)
+    # return JSON object result of running the action or an error dictionary
+    # if action failed
     def run(self, args, env):
         def error(msg):
             # fall through (exception and else case are handled the same way)
             sys.stdout.write('%s\n' % msg)
-            return (502, { 'error': 'The action did not return a dictionary.'})
+            return (502, {'error': 'The action did not return a dictionary.'})
 
         try:
             input = json.dumps(args)
             p = subprocess.Popen(
-                [ self.binary, input ],
+                [self.binary, input],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=env)
@@ -164,16 +172,18 @@ class ActionRunner:
             archive.close()
             return True
         except Exception as e:
-            print('err',str(e))
+            print('err', str(e))
             return False
 
 proxy = flask.Flask(__name__)
 proxy.debug = False
 runner = None
 
+
 def setRunner(r):
     global runner
     runner = r
+
 
 @proxy.route('/init', methods=['POST'])
 def init():
@@ -194,14 +204,18 @@ def init():
     if status is True:
         return ('OK', 200)
     else:
-        response = flask.jsonify({'error': 'The action failed to generate or locate a binary. See logs for details.' })
+        response = flask.jsonify({'error':
+                                  'The action failed to generate or '
+                                  'locate a binary. See logs for details.'})
         response.status_code = 502
         return complete(response)
+
 
 @proxy.route('/run', methods=['POST'])
 def run():
     def error():
-        response = flask.jsonify({'error': 'The action did not receive a dictionary as an argument.' })
+        response = flask.jsonify({'error': 'The action did not receive '
+                                  'a dictionary as an argument.'})
         response.status_code = 404
         return complete(response)
 
@@ -215,16 +229,19 @@ def run():
 
     if runner.verify():
         try:
-            (code, result) = runner.run(args, runner.env(message if message else {}))
+            (code, result) = runner.run(args,
+                                        runner.env(message if message else {}))
             response = flask.jsonify(result)
             response.status_code = code
         except Exception as e:
-            response = flask.jsonify({'error': 'Internal error.' })
+            response = flask.jsonify({'error': 'Internal error.'})
             response.status_code = 500
     else:
-        response = flask.jsonify({'error': 'The action failed to locate a binary. See logs for details.' })
+        response = flask.jsonify({'error': 'The action failed to locate '
+                                  'a binary. See logs for details.'})
         response.status_code = 502
     return complete(response)
+
 
 def complete(response):
     # Add sentinel to stdout/stderr
@@ -233,6 +250,7 @@ def complete(response):
     sys.stderr.write('%s\n' % ActionRunner.LOG_SENTINEL)
     sys.stderr.flush()
     return response
+
 
 def main():
     port = int(os.getenv('FLASK_PROXY_PORT', 8080))

--- a/core/actionProxy/invoke.py
+++ b/core/actionProxy/invoke.py
@@ -36,7 +36,8 @@ import codecs
 DOCKER_HOST = "localhost"
 if "DOCKER_HOST" in os.environ:
     try:
-        DOCKER_HOST = re.compile("tcp://(.*):[\d]+").findall(os.environ["DOCKER_HOST"])[0]
+        DOCKER_HOST = re.compile("tcp://(.*):[\d]+").findall(
+            os.environ["DOCKER_HOST"])[0]
     except Exception:
         print("cannot determine docker host from %s" %
               os.environ["DOCKER_HOST"])

--- a/core/pythonAction/pythonrunner.py
+++ b/core/pythonAction/pythonrunner.py
@@ -20,12 +20,11 @@
 
 import os
 import sys
-import subprocess
 import codecs
+import traceback
 sys.path.append('../actionProxy')
 from actionproxy import ActionRunner, main, setRunner
-import json
-import traceback
+
 
 class PythonRunner(ActionRunner):
 
@@ -54,12 +53,12 @@ class PythonRunner(ActionRunner):
             return False
 
         try:
-            self.fn = compile(code, filename = filename, mode = 'exec')
+            self.fn = compile(code, filename=filename, mode='exec')
             if 'main' in message:
                 self.mainFn = message['main']
             return True
         except Exception:
-            traceback.print_exc(file = sys.stderr, limit = 0)
+            traceback.print_exc(file=sys.stderr, limit=0)
             return False
 
     def verify(self):
@@ -76,12 +75,12 @@ class PythonRunner(ActionRunner):
             exec('fun = %s(param)' % self.mainFn, namespace)
             result = namespace['fun']
         except Exception:
-            traceback.print_exc(file = sys.stderr)
+            traceback.print_exc(file=sys.stderr)
 
         if result and isinstance(result, dict):
             return (200, result)
         else:
-            return (502, { 'error': 'The action did not return a dictionary.'})
+            return (502, {'error': 'The action did not return a dictionary.'})
 
 if __name__ == '__main__':
     setRunner(PythonRunner())

--- a/core/swift3Action/buildandrecord.py
+++ b/core/swift3Action/buildandrecord.py
@@ -1,36 +1,41 @@
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""Python to generate build script.
 
-import os,sys
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+import os
+import sys
 from subprocess import check_output
 
-#Settings
+# Settings
 COMPILE_PREFIX = "/usr/bin/swiftc -module-name Action "
-LINKER_PREFIX = "/usr/bin/swiftc -Xlinker '-rpath=$ORIGIN' '-L/swift3Action/spm-build/.build/release' -o '/swift3Action/spm-build/.build/release/Action'\
-"
+LINKER_PREFIX = "/usr/bin/swiftc -Xlinker '-rpath=$ORIGIN' " \
+                "'-L/swift3Action/spm-build/.build/release' " \
+                "-o '/swift3Action/spm-build/.build/release/Action'"
 GENERATED_BUILD_SCRIPT = "/swift3Action/spm-build/swiftbuildandlink.sh"
 SPM_DIRECTORY = "/swift3Action/spm-build"
-BUILD_COMMAND = ["swift","build","-v","-c","release"]
+BUILD_COMMAND = ["swift", "build", "-v", "-c", "release"]
 
-## Build Swift package and capture step trace
+# Build Swift package and capture step trace
 print "Building action"
 out = check_output(BUILD_COMMAND, cwd=SPM_DIRECTORY)
 print "action built. Decoding compile and link commands"
 
-## Look for compile and link commands in step trace
+# Look for compile and link commands in step trace
 compileCommand = None
 linkCommand = None
 
@@ -40,36 +45,34 @@ for instruction in buildInstructions:
     if instruction.startswith(COMPILE_PREFIX):
         compileCommand = instruction
 
-        ## add flag to quiet warnings
+        # add flag to quiet warnings
         compileCommand += " -suppress-warnings"
 
     elif instruction.startswith(LINKER_PREFIX):
         linkCommand = instruction
 
-## if found, create build script, otherwise exit with error
-if compileCommand != None and linkCommand != None:
+# if found, create build script, otherwise exit with error
+if compileCommand is not None and linkCommand is not None:
     print "Generated OpenWhisk Compile command: %s" % compileCommand
     print "========="
     print "Generated OpenWhisk Link command: %s" % linkCommand
 
     with open(GENERATED_BUILD_SCRIPT, "a") as buildScript:
-      buildScript.write("#!/bin/bash\n")
-      buildScript.write("echo \"Compiling\"\n")
-      buildScript.write("%s\n" % compileCommand)
-      buildScript.write("swiftStatus=$?\n")
-      buildScript.write("echo swiftc status is $swiftStatus\n")
-      buildScript.write("if [[ \"$swiftStatus\" -eq \"0\" ]]; then\n")
-      buildScript.write("echo \"Linking\"\n")
-      buildScript.write("%s\n" % linkCommand)
-      buildScript.write("else\n")
-      buildScript.write(">2& echo \"Action did not compile\"\n")
-      buildScript.write("exit 1\n")
-      buildScript.write("fi")
+        buildScript.write("#!/bin/bash\n")
+        buildScript.write("echo \"Compiling\"\n")
+        buildScript.write("%s\n" % compileCommand)
+        buildScript.write("swiftStatus=$?\n")
+        buildScript.write("echo swiftc status is $swiftStatus\n")
+        buildScript.write("if [[ \"$swiftStatus\" -eq \"0\" ]]; then\n")
+        buildScript.write("echo \"Linking\"\n")
+        buildScript.write("%s\n" % linkCommand)
+        buildScript.write("else\n")
+        buildScript.write(">2& echo \"Action did not compile\"\n")
+        buildScript.write("exit 1\n")
+        buildScript.write("fi")
 
     os.chmod(GENERATED_BUILD_SCRIPT, 0777)
     sys.exit(0)
 else:
     print("Cannot generate build script: compile or link command not found")
     sys.exit(1)
-
-

--- a/core/swift3Action/swift3runner.py
+++ b/core/swift3Action/swift3runner.py
@@ -1,19 +1,22 @@
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""Python proxy to run Swift action.
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import os
 import sys
 import subprocess
@@ -27,7 +30,8 @@ DEST_SCRIPT_FILE = '/swift3Action/spm-build/main.swift'
 DEST_SCRIPT_DIR = '/swift3Action/spm-build'
 DEST_BIN_FILE = '/swift3Action/spm-build/.build/release/Action'
 
-BUILD_PROCESS = [ './swiftbuildandlink.sh' ]
+BUILD_PROCESS = ['./swiftbuildandlink.sh']
+
 
 class Swift3Runner(ActionRunner):
 

--- a/tests/dat/actions/hello.py
+++ b/tests/dat/actions/hello.py
@@ -1,9 +1,30 @@
-import sys
+"""Python Hello test.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+
 def main(dict):
+    """Main."""
     if 'name' in dict:
         name = dict['name']
     else:
         name = "stranger"
     greeting = "Hello " + name + "!"
     print(greeting)
-    return {"greeting":greeting}
+    return {"greeting": greeting}

--- a/tests/dat/actions/malformed.py
+++ b/tests/dat/actions/malformed.py
@@ -1,2 +1,21 @@
-// invalid python comment
+"""Invalid Python comment test.
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+// invalid python comment

--- a/tests/dat/actions/niam.py
+++ b/tests/dat/actions/niam.py
@@ -1,2 +1,26 @@
+"""Python Non-standard entry point test.
+
+niam = 'main'[::-1]
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+
 def niam(args):
-    return { "greetings": "Hello from a non-standard entrypoint." }
+    """Non-standard entry point."""
+    return {"greetings": "Hello from a non-standard entrypoint."}

--- a/tests/dat/actions/stdenv.py
+++ b/tests/dat/actions/stdenv.py
@@ -1,4 +1,25 @@
+"""Unify action container environments.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import os
 
+
 def main(dict):
-    return { "auth": os.environ['__OW_API_KEY'], "edge": os.environ['__OW_API_HOST'] }
+    return {"auth": os.environ['__OW_API_KEY'],
+            "edge": os.environ['__OW_API_HOST']}

--- a/tests/dat/actions/timedout.py
+++ b/tests/dat/actions/timedout.py
@@ -1,3 +1,25 @@
+"""Python timeout test.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import time
+
+
 def main(dict):
+    """Main."""
     time.sleep(310)

--- a/tests/dat/actions/unicode.py
+++ b/tests/dat/actions/unicode.py
@@ -1,5 +1,26 @@
+"""Python Unicode test.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+
 def main(dict):
     sep = dict['delimiter']
     str = sep + " ☃ ".decode('utf-8') + sep
     print(str.encode('utf-8'))
-    return {"winter" : str }
+    return {"winter": str}

--- a/tests/dat/blackbox/badaction/runner.py
+++ b/tests/dat/blackbox/badaction/runner.py
@@ -1,23 +1,27 @@
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""Python bad action runner (sleep forever).
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import sys
+import time
 sys.path.append('../actionProxy')
 from actionproxy import ActionRunner, main, setRunner
-import time
+
 
 class Runner(ActionRunner):
 

--- a/tools/admin/wskprop.py
+++ b/tools/admin/wskprop.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python
+"""Helper methods for whisk properties.
 
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-##
-# Helper methods for whisk properties
-##
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import os
-import pkg_resources
+
 
 def propfile(base):
     if base != '':
@@ -34,9 +32,12 @@ def propfile(base):
     else:
         return ''
 
+
 def importPropsIfAvailable(filename):
-    thefile = open(filename, 'r') if os.path.isfile(filename) and os.path.exists(filename) else []
+    thefile = (open(filename, 'r') if os.path.isfile(filename) and
+               os.path.exists(filename) else [])
     return importProps(thefile)
+
 
 def importProps(stream):
     props = {}
@@ -47,28 +48,35 @@ def importProps(stream):
         if len(parts) >= 2:
             val = parts[1].strip()
         if key != '' and val != '':
-            props[key.upper().replace('.','_')] = val
+            props[key.upper().replace('.', '_')] = val
         elif key != '':
-            props[key.upper().replace('.','_')] = ''
+            props[key.upper().replace('.', '_')] = ''
     return props
 
-#
-# Returns a triple of (length(requiredProperties), requiredProperties, deferredInfo)
-# prints a message if a required property is not found
-#
+
+# Returns a triple of (length(invalidProperties), requiredProperties,
+# deferredInfo) prints a message if a required property is not found
 def checkRequiredProperties(requiredPropertiesByName, properties):
-    requiredPropertiesByValue = [ getPropertyValue(key, properties) for key in requiredPropertiesByName ]
-    requiredProperties = dict(zip(requiredPropertiesByName, requiredPropertiesByValue))
-    invalidProperties = [ key for key in requiredPropertiesByName if requiredProperties[key] == None ]
+    """Return a tuple describing the requested required properties."""
+    requiredPropertiesByValue = [getPropertyValue(key, properties) for key
+                                 in requiredPropertiesByName]
+    requiredProperties = dict(zip(requiredPropertiesByName,
+                                  requiredPropertiesByValue))
+    invalidProperties = [key for key in requiredPropertiesByName if
+                         requiredProperties[key] is None]
     deferredInfo = ''
     for key, value in requiredProperties.items():
-        if value == None or value == '':
-            print 'property "%s" not found in environment or property file' % key
+        if value is None or value is '':
+            print 'property "%s" not found in environment or ' \
+                  'property file' % key
         else:
-            deferredInfo += 'using %(key)s = %(value)s\n' % {'key': key, 'value': value}
+            deferredInfo += 'using %(key)s = %(value)s\n' % {'key': key,
+                                                             'value': value}
     return (len(invalidProperties) == 0, requiredProperties, deferredInfo)
+
 
 def getPropertyValue(key, properties):
     evalue = os.environ.get(key)
-    value  = evalue if evalue != None and evalue != '' else properties[key] if key in properties else None
+    value = (evalue if evalue is not None and evalue is not ''
+             else properties[key] if key in properties else None)
     return value

--- a/tools/admin/wskutil.py
+++ b/tools/admin/wskutil.py
@@ -1,18 +1,23 @@
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+"""Whisk Utility methods.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 
 import sys
 import os
@@ -22,8 +27,9 @@ import ssl
 import base64
 from urlparse import urlparse
 
-# global configurations, can control whether to allow untrusted certificates on HTTPS connections
-httpRequestProps = { 'secure': True }
+# global configurations, can control whether to allow untrusted certificates
+# on HTTPS connections
+httpRequestProps = {'secure': True}
 
 def request(method, urlString, body = '', headers = {}, auth = None, verbose = False, https_proxy = os.getenv('https_proxy', None)):
     url = urlparse(urlString)
@@ -37,7 +43,7 @@ def request(method, urlString, body = '', headers = {}, auth = None, verbose = F
         if https_proxy:
             conn.set_tunnel(url.netloc)
 
-    if auth != None:
+    if auth is not None:
         auth = base64.encodestring(auth).replace('\n', '')
         headers['Authorization'] = 'Basic %s' % auth
 
@@ -76,8 +82,10 @@ def request(method, urlString, body = '', headers = {}, auth = None, verbose = F
         res = dict2obj({ 'status' : 500, 'error': str(e) })
         return res
 
+
 def getPrettyJson(obj):
     return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
+
 
 # class to convert dictionary to objects
 class dict2obj(dict):

--- a/tools/build/checkLogs.py
+++ b/tools/build/checkLogs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Executable Python script for checking log (entries) sizes.
 
-CI/CD tool to assert that logs and databases are in certain bounds
+CI/CD tool to assert that logs and databases are in certain bounds.
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -1,30 +1,33 @@
 #!/usr/bin/env python
+"""Python script to replicate and replay databases.
 
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
 
 import argparse
 import time
 import re
 import couchdb.client
 
-#
-# Replicates databases
-#
+
 def replicateDatabases(args):
+    """Replicate databases."""
     sourceDb = couchdb.client.Server(args.sourceDbUrl)
     targetDb = couchdb.client.Server(args.targetDbUrl)
 
@@ -48,9 +51,14 @@ def replicateDatabases(args):
             "continuous": args.continuous
         })
 
-    def isBackupDb(dbName): return re.match("^backup_\d+_" + args.dbPrefix, dbName)
-    def extractTimestamp(dbName): return int(dbName.split("_")[1])
-    def isExpired(timestamp): return now - args.expires > timestamp
+    def isBackupDb(dbName):
+        return re.match("^backup_\d+_" + args.dbPrefix, dbName)
+
+    def extractTimestamp(dbName):
+        return int(dbName.split("_")[1])
+
+    def isExpired(timestamp):
+        return now - args.expires > timestamp
 
     # Delete all backup-databases, that are older than specified
     print "----- Delete backups older than %d seconds -----" % args.expires
@@ -58,10 +66,9 @@ def replicateDatabases(args):
         print "deleting backup: %s" % db
         targetDb.delete(db)
 
-#
-# Replays databases
-#
+
 def replayDatabases(args):
+    """Replays databases."""
     sourceDb = couchdb.client.Server(args.sourceDbUrl)
 
     # Create _replicator DB if it does not exist yet.

--- a/tools/health/monitorUtil.py
+++ b/tools/health/monitorUtil.py
@@ -1,38 +1,39 @@
-# Utility for health/RAS
+#!/usr/bin/env python
+"""Utility for health/RAS.
 
-#
-# Copyright 2015-2016 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-import os
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
 import sys
 import subprocess
-import argparse
 import datetime
 import time
 
+
 # Repeatedly run the check for delay seconds until it responds with a 0.
 # If it never does, exit with the last failing code rather than 0.
-def checkLoop(name, checker, delay) :
+def checkLoop(name, checker, delay):
     now = datetime.datetime.now()
-    end = now + datetime.timedelta(0,delay)
+    end = now + datetime.timedelta(0, delay)
     while (now <= end):
         now = datetime.datetime.now()
         alive = checker()
         if (alive == 0):
-            break;
+            break
         if (delay != 0):
             time.sleep(3)
     print "%s %s" % (name, "is alive" if alive == 0 else "is not responding")
@@ -40,16 +41,19 @@ def checkLoop(name, checker, delay) :
 
 
 # Runs the given command with optional input.
-# The command is run in a blocking fashion and the return code and output (both stdout/stderr combined) returned as a pair.
-def run(cmd, inData="") :
+# The command is run in a blocking fashion and the return code
+# and output (both stdout/stderr combined) returned as a pair.
+def run(cmd, inData=""):
     try:
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stdin=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
         if (inData != ""):
             p.stdin.write(inData)
         p.wait()
         output = p.stdout.read()
         rc = p.returncode
-    except Exception as e: # catch *all* exceptions
+    except Exception as e:
         print "exec: died with exception ",
         print e
         print "    : ", cmd
@@ -58,11 +62,12 @@ def run(cmd, inData="") :
 
 
 # Run a given command and check its output - return 0 if it matches.
-def outputChecker(cmd,expected,substring=0) :
-    (rc,output) = run(cmd);
+def outputChecker(cmd, expected, substring=0):
+    (rc, output) = run(cmd)
     if (rc != 0):
         return rc
-    match = (output == expected) if (substring == 0) else (output.find(expected) != -1)
+    match = ((output == expected) if (substring == 0) else
+             (output.find(expected) != -1))
     if (match):
         return rc
     else:

--- a/tools/json/validate.py
+++ b/tools/json/validate.py
@@ -22,25 +22,22 @@
  * limitations under the License.
  */
 """
-
 import sys
 import json
 from jsonschema import validate
 
-#print len(sys.argv)
-#print sys.argv
 
 if len(sys.argv) != 3:
     print 'usage: validate.py obj schema'
     sys.exit(-1)
 
-a1=sys.argv[1].replace('\n','');
-a2=sys.argv[2].replace('\n','');
-obj=json.loads(a1)
-schema=json.loads(a2)
+a1 = sys.argv[1].replace('\n', '')
+a2 = sys.argv[2].replace('\n', '')
+obj = json.loads(a1)
+schema = json.loads(a2)
 
 try:
-    validate(obj,schema)
+    validate(obj, schema)
     print 'true'
 except:
     print 'false'


### PR DESCRIPTION
This is "part 2" of the Python license header update.  In most cases, I also brought each file into PEP8 compliance.  The files include:
Part 2:
./openwhisk/ansible/callbacks/logformatter.py
./openwhisk/core/actionProxy/actionproxy.py (updated to PEP8)
./openwhisk/core/actionProxy/invoke.py (updated to PEP8)
./openwhisk/core/pythonAction/pythonrunner.py (updated to PEP8)
./openwhisk/core/swift3Action/buildandrecord.py
./openwhisk/core/swift3Action/swift3runner.py
./openwhisk/tests/dat/actions/hello.py
./openwhisk/tests/dat/actions/malformed.py
./openwhisk/tests/dat/actions/niam.py
./openwhisk/tests/dat/actions/stdenv.py
./openwhisk/tests/dat/actions/timedout.py
./openwhisk/tests/dat/actions/unicode.py
./openwhisk/tests/dat/blackbox/badaction/runner.py
./openwhisk/tools/admin/wskprop.py
./openwhisk/tools/admin/wskutil.py
./openwhisk/tools/db/replicateDbs.py
./openwhisk/tools/build/checkLogs.py (already in PR)
./openwhisk/tools/health/monitorUtil.py
./openwhisk/tools/json/validate.py
