### PR TITLE
Document how to use the non-SSL apihost for Vagrant

### DIFF
--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -76,7 +76,7 @@ wsk -i action invoke /whisk.system/utils/echo -p message hello --blocking --resu
 }
 ```
 
-**Tip:** You need to use the `-i` switch as the default SSL certificate used by the Vagrant installation is self-signed. Alternatively, you can configure you __apihost__ to use the non-SSL interface:
+**Tip:** You need to use the `-i` switch as the default SSL certificate used by the Vagrant installation is self-signed. Alternatively, you can configure your __apihost__ to use the non-SSL interface:
 
 ```
 wsk -i property set --apihost http://192.168.33.13:10001 --auth `vagrant ssh -- cat openwhisk/ansible/files/auth.guest

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -75,7 +75,17 @@ wsk -i action invoke /whisk.system/utils/echo -p message hello --blocking --resu
     "message": "hello"
 }
 ```
-**Tip:** To connect to a different host API (i.e. bluemix.net) with the CLI, you will need to 
+
+**Tip:** You need to use the `-i` switch as the default SSL certificate used by the Vagrant installation is self-signed. Alternatively, you can configure you __apihost__ to use the non-SSL interface:
+
+```
+wsk -i property set --apihost http://192.168.33.13:10001 --auth `vagrant ssh -- cat openwhisk/ansible/files/auth.guest
+````
+
+You do not need to use the `-i` switch to `wsk` now.
+
+
+**Note:** To connect to a different host API (i.e. bluemix.net) with the CLI, you will need to 
 configure the CLI with new values for __apihost__, and __auth__ key.
  
 ### Use the wsk CLI inside the VM


### PR DESCRIPTION
When working locally, it’s easier to use the non-SSL `apihost` for the `wsk` tool so that you don’t have to keep remembering to use the `-I` flag.