### PR TITLE
Include zip in swift3Action

### DIFF
--- a/core/swift3Action/Dockerfile
+++ b/core/swift3Action/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get -y purge \
 # Upgrade and install Swift dependencies
  && apt-get -y install --fix-missing build-essential curl wget libicu-dev \
 \
+# Install zip for compiling Swift actions
+ && apt-get -y install zip \
+\
 # Clean up
  && apt-get clean
 


### PR DESCRIPTION
This makes it easier to compile Swift actions locally for upload to OpenWhisk as zip files containing the Action binary. 

In terms of space, this makes very little difference as the image is based on Ubuntu 14.04. Looking at `docker images` locally, the current image is 1.45GB and one with zip included is 1.46GB.

Closes #1991