### PR TITLE
Doc Fix: Highlight use of default package identifier

### DIFF
--- a/docs/webactions.md
+++ b/docs/webactions.md
@@ -22,7 +22,11 @@ $ wsk package create demo
 $ wsk action create /guest/demo/hello hello.js -a web-export true
 ```
 
-The `web-export` annotation allows the action to be accessible as a web action via a new REST interface. The URL that is structured as follows: `https://{APIHOST}/api/v1/experimental/web/{QUALIFIED ACTION NAME}.{EXT}`. The fully qualified name of an action consists of three parts: the namespace, the package name, and the action name. An example is `guest/demo/hello`. The last part of the URI called the `extension` which is typically `.http` although other values are permitted as described later. The web action API path may be used with `curl` or `wget` without an API key. It may even be entered directly in your browser.
+The `web-export` annotation allows the action to be accessible as a web action via a new REST interface. The URL that is structured as follows: `https://{APIHOST}/api/v1/experimental/web/{QUALIFIED ACTION NAME}.{EXT}`. The fully qualified name of an action consists of three parts: the namespace, the package name, and the action name. 
+
+*The fully qualified name of the action must include its package name, which is `default` if the action is not in a named package.*
+
+An example is `guest/demo/hello`. The last part of the URI called the `extension` which is typically `.http` although other values are permitted as described later. The web action API path may be used with `curl` or `wget` without an API key. It may even be entered directly in your browser.
 
 Try opening [https://${APIHOST}/api/v1/experimental/web/guest/demo/hello.http?name=Jane](https://${APIHOST}/api/v1/experimental/web/guest/demo/hello.http?name=Jane) in your web browser. Or try invoking the action via `curl`:
 ```


### PR DESCRIPTION
I got caught out trying to work out what the package identifier should be for actions without an explicit package. 

This will be a common usecase for people trying out this feature. 

There's a note about using `default` much later in this file that people might not read at first. I've copied this reference and added it to the initial example to highlight this with users.