### PR TITLE
Only take backups of core databases

### DIFF
--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -23,9 +23,9 @@ Detailed instructions are found in the [ansible readme](../../ansible/README.md)
 
 ## Using Cloudant
 
-As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service. 
-There are two ways to get a Cloudant account and configure OpenWhisk to use it. 
-You only need to establish an account once, either through IBM Bluemix or with Cloudant directly. 
+As an alternative to a self-managed CouchDB, you may want to try [Cloudant](https://cloudant.com) which is a cloud-based database service.
+There are two ways to get a Cloudant account and configure OpenWhisk to use it.
+You only need to establish an account once, either through IBM Bluemix or with Cloudant directly.
 
 ### Create a Cloudant account via IBM Bluemix
 Sign up for an account via [IBM Bluemix](https://bluemix.net). Bluemix offers trial accounts and its signup process is straightforward so it is not described here in detail. Using Bluemix, the most convenient way to create a Cloudant instance is via the `cf` command-line tool. See [here](https://www.ng.bluemix.net/docs/starters/install_cli.html) for instructions on how to download and configure `cf` to work with your Bluemix account.
@@ -73,7 +73,7 @@ If you are [using an ephemeral CouchDB container](#using-an-ephemeral-couchdb-co
   ```
   # Work out of your openwhisk directory
   cd /your/path/to/openwhisk/ansible
-  
+
   # Initialize data store containing authorization keys
   ansible-playbook initdb.yml
   ```
@@ -123,6 +123,8 @@ All commands for `replicateDbs.py` take two standard parameters:
 
 * `--sourceDbUrl`: Server URL of the source database, that has to be backed up. E.g. 'https://xxx:yyy@domain.couch.com:443'.
 * `--targetDbUrl`: Server URL of the target database, where the backup is stored. Like sourceDbUrl.
+
+Keep in mind, that only the core databases of OpenWhisk are considered by this backup script.
 
 ### Creating a snapshot
 

--- a/tools/db/replicateDbs.py
+++ b/tools/db/replicateDbs.py
@@ -25,6 +25,11 @@ import time
 import re
 import couchdb.client
 
+databasesToBeReplicated = ["namespaces", "subjects", "whisks"]
+
+def toBeReplicated(nameWithPrefix):
+    reduce(lambda x, y: x or y, map(lambda name: name.endsWith(nameWithPrefix), databasesToBeReplicated))
+
 
 def replicateDatabases(args):
     """Replicate databases."""
@@ -40,7 +45,7 @@ def replicateDatabases(args):
 
     # Create backup of all databases with given prefix
     print("----- Create backups -----")
-    for db in filter(lambda dbName: dbName.startswith(args.dbPrefix), sourceDb):
+    for db in filter(lambda dbName: dbName.startswith(args.dbPrefix) and toBeReplicated(dbName), sourceDb):
         backupDb = backupPrefix + db if not args.continuous else 'continuous_' + db
         print("create backup: %s" % backupDb)
         sourceDb["_replicator"].save({
@@ -62,7 +67,7 @@ def replicateDatabases(args):
 
     # Delete all backup-databases, that are older than specified
     print("----- Delete backups older than %d seconds -----" % args.expires)
-    for db in filter(lambda db: isBackupDb(db) and isExpired(extractTimestamp(db)), targetDb):
+    for db in filter(lambda db: isBackupDb(db) and isExpired(extractTimestamp(db)) and toBeReplicated(db), targetDb):
         print("deleting backup: %s" % db)
         targetDb.delete(db)
 
@@ -75,7 +80,7 @@ def replayDatabases(args):
     if "_replicator" not in sourceDb:
         sourceDb.create("_replicator")
 
-    for db in filter(lambda dbName: dbName.startswith(args.dbPrefix), sourceDb):
+    for db in filter(lambda dbName: dbName.startswith(args.dbPrefix) and toBeReplicated(dbName), sourceDb):
         plainDbName = db.replace(args.dbPrefix, "")
         (identifier, _) = sourceDb["_replicator"].save({
             "source": args.sourceDbUrl + "/" + db,


### PR DESCRIPTION
It is planned to shrink the size of the snapshots, that are taken.
Currently this is only possible for the core components.

This PR takes out all other databases from the backup process, to avoid any breaking changes of databases, that are not part of the core of OpenWhisk.