### PR TITLE
Refactor InvokerPool for better decoupling

### DIFF
--- a/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/InvokerSupervision.scala
@@ -39,7 +39,6 @@ import whisk.core.connector.PingMessage
 
 // Received events
 case object GetStatus
-case object StatusChange
 
 // States an Invoker can be in
 sealed trait InvokerState { val asString: String }
@@ -66,10 +65,12 @@ class InvokerPool(
     invokerDownCallback: String => Unit) extends Actor {
 
     implicit val transid = TransactionId.invokerHealth
-    val logging = new AkkaLogging(context.system.log)
     implicit val timeout = Timeout(5.seconds)
     implicit val ec = context.dispatcher
+    val logging = new AkkaLogging(context.system.log)
 
+    // State of the actor. It's important not to close over these
+    // references directly, so they don't escape the Actor.
     val invokers = mutable.HashMap.empty[String, ActorRef]
     val invokerStatus = mutable.HashMap.empty[String, InvokerState]
 

--- a/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
+++ b/core/controller/src/main/scala/whisk/core/loadBalancer/LoadBalancerService.scala
@@ -43,6 +43,7 @@ import whisk.core.connector.{ ActivationMessage, CompletionMessage }
 import whisk.core.entity.{ ActivationId, CodeExec, WhiskAction, WhiskActivation }
 import whisk.core.connector.PingMessage
 import akka.util.Timeout
+import akka.actor.ActorRefFactory
 
 trait LoadBalancer {
 
@@ -194,7 +195,8 @@ class LoadBalancerService(config: WhiskConfig)(implicit val actorSystem: ActorSy
     })
 
     private val consul = new ConsulClient(config.consulServer)
-    private val invokerPool = actorSystem.actorOf(InvokerPool.props(consul.kv, invoker => {
+    private val invokerFactory = (f: ActorRefFactory, name: String) => f.actorOf(InvokerActor.props, name)
+    private val invokerPool = actorSystem.actorOf(InvokerPool.props(invokerFactory, consul.kv, invoker => {
         clearInvokerState(invoker)
         logging.info(this, s"cleared loadbalancer state of $invoker")(TransactionId.invokerHealth)
     }))


### PR DESCRIPTION
According to akka-standards, synchronous testing is discouraged. Refactored the whole pool to reflect common patterns and make tests much better.