### PR TITLE
Add explicit defaults for all exec kinds

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -16,6 +16,7 @@ runtimesManifest:
     default: true
   python:
   - kind: "python"
+    default: true
   swift:
   - kind: "swift"
     deprecated: true
@@ -28,6 +29,7 @@ runtimesManifest:
       attachmentType: "application/java-archive"
     sentinelledLogs: false
     requireMain: true
+    default: true
 
 defaultLimits:
   actions:

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -116,7 +116,7 @@ protected[core] object ExecManifest {
 
         def resolveDefaultRuntime(kind: String): Option[RuntimeManifest] = {
             kind match {
-                case defaultSplitter(family) => defaultRuntimes.get(family).flatten.flatMap(manifests.get(_))
+                case defaultSplitter(family) => defaultRuntimes.get(family).flatMap(manifests.get(_))
                 case _                       => manifests.get(kind)
             }
         }
@@ -129,12 +129,13 @@ protected[core] object ExecManifest {
             }.toMap
         }
 
-        private val defaultRuntimes: Map[String, Option[String]] = {
+        private val defaultRuntimes: Map[String, String] = {
             runtimes.map { family =>
                 family.versions.filter(_.default.exists(identity)).toList match {
-                    case Nil      => family.name -> None
-                    case d :: Nil => family.name -> Some(d.kind)
-                    case ds       => throw new IllegalArgumentException(s"found more than one default for ${family.name}: ${ds.mkString(",")}")
+                    case Nil if family.versions.size == 1  => family.name -> family.versions.toSeq(0).kind
+                    case Nil                               => throw new IllegalArgumentException(s"${family.name} has multiple versions, but no default")
+                    case d :: Nil                          => family.name -> d.kind
+                    case ds                                => throw new IllegalArgumentException(s"found more than one default for ${family.name}: ${ds.mkString(",")}")
                 }
             }.toMap
         }

--- a/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/whisk/core/entity/test/ExecManifestTests.scala
@@ -51,6 +51,22 @@ class ExecManifestTests
         runtimes.resolveDefaultRuntime("p1") shouldBe Some(p1)
 
         runtimes.resolveDefaultRuntime("ks:default") shouldBe Some(k2)
-        runtimes.resolveDefaultRuntime("p1:default") shouldBe None
+        runtimes.resolveDefaultRuntime("p1:default") shouldBe Some(p1)
+    }
+
+    it should "reject runtimes with multiple defaults" in {
+        val k1 = RuntimeManifest("k1", default = Some(true))
+        val k2 = RuntimeManifest("k2", default = Some(true))
+        val mf = JsObject("ks" -> Set(k1, k2).toJson)
+
+        an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
+    }
+
+    it should "reject finding a default when none is specified for multiple versions" in {
+        val k1 = RuntimeManifest("k1")
+        val k2 = RuntimeManifest("k2")
+        val mf = JsObject("ks" -> Set(k1, k2).toJson)
+
+        an[IllegalArgumentException] should be thrownBy ExecManifest.runtimes(mf).get
     }
 }


### PR DESCRIPTION
This allows the `:default` designation to work for all kinds, as well as reinforces the idea that all kinds should explicitly state which is the default.