### PR TITLE
Disable HTML Encoding of JSON Content in CLI

### DIFF
--- a/tests/dat/actions/hello.js
+++ b/tests/dat/actions/hello.js
@@ -2,5 +2,7 @@
  * Hello, world.
  */
 function main(params) {
-    console.log('hello', params.payload+'!');
+    greeting = 'hello, ' + params.payload + '!'
+    console.log(greeting);
+    return {payload: greeting}
 }

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -182,7 +182,7 @@ class WskActionTests
             withActivation(wsk.activation, run2) {
                 activation =>
                     activation.response.status shouldBe "success"
-                    activation.logs.get.mkString(" ") should include(s"hello $testString")
+                    activation.logs.get.mkString(" ") should include(s"hello, $testString")
             }
     }
 

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -291,7 +291,8 @@ class WskBasicTests
 
             wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
             wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    console.log\\('hello', params.payload\\+'!'\\);[\\\\r]*\\\\n\\}[\\\\r]*\\\\n"\n\\}""")
+            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include (s"""$successMsg""")
+            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    greeting \\= 'hello, ' \\+ params.payload \\+ '!'[\\\\r]*\\\\n    console.log\\(greeting\\);[\\\\r]*\\\\n    return \\{payload: greeting\\}[\\\\r]*\\\\n\\}""")
             wsk.action.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("annotations")).stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("limits")).stdout should include regex (s"""$successMsg limits\n\\{\\s+"timeout":\\s+60000,\\s+"memory":\\s+256,\\s+"logs":\\s+10\\s+\\}""")

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -396,13 +396,13 @@ class WskBasicTests
         (wp, assetHelper) =>
             val name = "emptyJSONAction"
 
-            val res = assetHelper.withCleaner(wsk.action, name) {
+            assetHelper.withCleaner(wsk.action, name) {
                 (action, _) =>
                     action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
-                    action.invoke(name, blocking = true, result = true)
             }
 
-            res.stdout shouldBe ("{}\n")
+            val stdout = wsk.action.invoke(name, blocking = true, result = true).stdout
+            stdout.parseJson.asJsObject shouldBe JsObject()
     }
 
     it should "create, and invoke an action that times out to ensure the proper response is received" in withAssetCleaner(wskprops) {

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -312,7 +312,7 @@ class WskRuleTests
                         _.head.response.result shouldBe Some(testResult)
                     }
                     withActivationsFromEntity(wsk.activation, actionName2, since = Some(triggerActivation.start)) {
-                        _.head.logs.get.mkString(" ") should include(s"hello $testString")
+                        _.head.logs.get.mkString(" ") should include(s"hello, $testString")
                     }
             }
     }
@@ -350,7 +350,7 @@ class WskRuleTests
                         activations =>
                             // drops the leftmost 39 characters (timestamp + streamname)
                             val logs = activations.map(_.logs.get.map(_.drop(39))).flatten
-                            val expectedLogs = testPayloads.map { payload => s"hello $payload!" }
+                            val expectedLogs = testPayloads.map { payload => s"hello, $payload!" }
 
                             logs should contain theSameElementsAs expectedLogs
                     }

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -601,6 +601,20 @@ class WskBasicUsageTests
             wsk.action.create(name, file, web = Some(invalidInput), update = true, expectedExitCode = ERROR_EXIT).stderr should include(errorMsg)
     }
 
+    it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "nonescape"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
+            val input = Map("key" -> "&<>".toJson)
+
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, file)
+            }
+
+            val stdout = wsk.action.invoke(name, parameters = input, blocking = true, result = true).stdout
+            stdout.parseJson.asJsObject shouldBe input.toJson.asJsObject
+    }
+
     behavior of "Wsk packages"
 
     it should "create, and delete a package" in {

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -37,6 +37,7 @@ import (
     "io/ioutil"
     "sort"
     "reflect"
+    "bytes"
 )
 
 type QualifiedName struct {
@@ -586,18 +587,19 @@ func printJSON(v interface{}, stream ...io.Writer) {
     printJsonNoColor(v, stream...)
 }
 
-// Same as printJSON, but with coloring disabled.
-func printJsonNoColor(v interface{}, stream ...io.Writer) {
-    output, err := json.MarshalIndent(v, "", "    ")
+func printJsonNoColor(decoded interface{}, stream ...io.Writer) {
+    var output bytes.Buffer
 
-    if err != nil {
-        whisk.Debug(whisk.DbgError, "json.MarshalIndent() failure: %s\n", err)
-    }
+    buffer := new(bytes.Buffer)
+    encoder := json.NewEncoder(buffer)
+    encoder.SetEscapeHTML(false)
+    encoder.Encode(&decoded)
+    json.Indent(&output, buffer.Bytes(), "", "    ")
 
     if len(stream) > 0 {
-        fmt.Fprintf(stream[0], "%s\n", string(output))
+        fmt.Fprintf(stream[0], "%s\n", string(output.Bytes()))
     } else {
-        fmt.Fprintf(os.Stdout, "%s\n", string(output))
+        fmt.Fprintf(os.Stdout, "%s\n", string(output.Bytes()))
     }
 }
 

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -597,9 +597,9 @@ func printJsonNoColor(decoded interface{}, stream ...io.Writer) {
     json.Indent(&output, buffer.Bytes(), "", "    ")
 
     if len(stream) > 0 {
-        fmt.Fprintf(stream[0], "%s\n", string(output.Bytes()))
+        fmt.Fprintf(stream[0], "%s", string(output.Bytes()))
     } else {
-        fmt.Fprintf(os.Stdout, "%s\n", string(output.Bytes()))
+        fmt.Fprintf(os.Stdout, "%s", string(output.Bytes()))
     }
 }
 

--- a/tools/cli/go-whisk/whisk/client.go
+++ b/tools/cli/go-whisk/whisk/client.go
@@ -160,7 +160,10 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}, includeName
     var buf io.ReadWriter
     if body != nil {
         buf = new(bytes.Buffer)
-        err := json.NewEncoder(buf).Encode(body)
+        encoder := json.NewEncoder(buf)
+        encoder.SetEscapeHTML(false)
+        err := encoder.Encode(body)
+
         if err != nil {
             Debug(DbgError, "json.Encode(%#v) error: %s\n", body, err)
             errStr := wski18n.T("Error encoding request body: {{.err}}", map[string]interface{}{"err": err})
@@ -507,7 +510,10 @@ func (c *Client) NewRequestUrl(
     if body != nil {
         if (encodeBodyAs == EncodeBodyAsJson) {
             buf = new(bytes.Buffer)
-            err := json.NewEncoder(buf).Encode(body)
+            encoder := json.NewEncoder(buf)
+            encoder.SetEscapeHTML(false)
+            err := encoder.Encode(body)
+
             if err != nil {
                 Debug(DbgError, "json.Encode(%#v) error: %s\n", body, err)
                 errStr := wski18n.T("Error encoding request body: {{.err}}",


### PR DESCRIPTION
- Do not encode &, <, and > to \u0026, \u003c, and \u003e
- Prevents mentioned characters in raw HTTP web action query parameters from being encoded in activation logs