### PR TITLE
Suppress flake8's nitpicky formatting issues

### DIFF
--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -156,15 +156,8 @@ def syslogCmd(args, props):
     else:
         print('unknown command')
         return 2
-  
-def createUserCmd(args, props):
-    protocol = props[DB_PROTOCOL]
-    host     = props[DB_HOST]
-    port     = props[DB_PORT]
-    username = props[DB_USERNAME]
-    password = props[DB_PASSWORD]
-    database = props[DB_WHISK_AUTHS]
 
+def createUserCmd(args, props):
     subject = args.subject.strip()
     if len(subject) < 5:
         print('Subject name must be at least 5 characters')
@@ -503,9 +496,7 @@ def getLogsCmd(args, props):
             return output
         if error:
             sys.stderr.write(error)
-            return ''
-        else:
-            return ''
+        return ''
 
     logs = map(getComponentLogs, args.components)
     joined = ''.join(logs)

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -443,7 +443,7 @@ def getDbCmd(args, props):
         'database': database,
         'design'  : '/_design/' + designdoc +'/_view' if args.view else '',
         'index'   : viewname if args.view else '_all_docs',
-        'docs'    : 'true' if args.docs else 'false' 
+        'docs'    : 'true' if args.docs else 'false'
     }
 
     headers = {

--- a/tools/admin/wskutil.py
+++ b/tools/admin/wskutil.py
@@ -19,7 +19,6 @@
 """
 
 
-import sys
 import os
 import json
 import httplib

--- a/tools/build/checkLogs.py
+++ b/tools/build/checkLogs.py
@@ -26,7 +26,6 @@ CI/CD tool to assert that logs and databases are in certain bounds.
 ##
 
 import collections
-import fnmatch
 import itertools
 import os
 import platform

--- a/tools/build/citool
+++ b/tools/build/citool
@@ -112,10 +112,10 @@ def shell(cmd, data = None, verbose = False):
     p.wait()
     # stdout/stderr may be either text or bytes, depending on Python
     # version.   In the latter case, decode to text.
-    if isinstance(o, bytes):
-        o = o.decode('utf-8')
-    if isinstance(e, bytes):
-        e = e.decode('utf-8')
+    if isinstance(out, bytes):
+        out = out.decode('utf-8')
+    if isinstance(err, bytes):
+        err = err.decode('utf-8')
 
     end = time.time()
     delta = end - start

--- a/tools/build/redo
+++ b/tools/build/redo
@@ -119,7 +119,7 @@ def getArgs():
 
 class Playbook:
     cmd = 'ansible-playbook'
-        
+
     dir = False
     file = False
     modes = False
@@ -134,7 +134,7 @@ class Playbook:
         self.file = file
         self.modes = modes.split(',')
         self.env = env
-    
+
     def path(self, basedir):
         return basedir + '/' + self.dir
 
@@ -354,10 +354,10 @@ def runAndGetStdout(cmd):
     out, err = p.communicate()
     # stdout/stderr may be either text or bytes, depending on Python
     # version.   In the latter case, decode to text.
-    if isinstance(o, bytes):
-        o = o.decode('utf-8')
-    if isinstance(e, bytes):
-        e = e.decode('utf-8')
+    if isinstance(out, bytes):
+        out = out.decode('utf-8')
+    if isinstance(err, bytes):
+        err = err.decode('utf-8')
     if p.returncode:
         print(hilite(out))
         print(hilite(err, True))

--- a/tools/health/isAlive
+++ b/tools/health/isAlive
@@ -21,7 +21,6 @@
 
 import os
 import sys
-import subprocess
 import argparse
 import monitorUtil
 

--- a/tools/health/killComponent
+++ b/tools/health/killComponent
@@ -21,7 +21,6 @@
 
 import os
 import sys
-import subprocess
 import argparse
 
 scriptDir = sys.path[0]

--- a/tools/health/kvstore
+++ b/tools/health/kvstore
@@ -27,7 +27,6 @@
 # Start with standard imports.
 import os
 import sys
-import subprocess
 import argparse
 import time
 import json

--- a/tools/travis/flake8.sh
+++ b/tools/travis/flake8.sh
@@ -25,5 +25,5 @@ done
 echo 'Flake8: second round uses the --exit-zero flag to treat _every_ message as a warning...'
 for i in "${PYTHON_FILES[@]}"
 do
-    flake8 "$i" --count --ignore=E --max-line-length=127 --statistics --exit-zero
+    flake8 "$i" --ignore=E --max-line-length=127 --statistics --exit-zero
 done

--- a/tools/travis/flake8.sh
+++ b/tools/travis/flake8.sh
@@ -14,7 +14,7 @@ declare -a PYTHON_FILES=("."
 echo 'Flake8: first round (fast fail) stops the build if there are any Python 3 syntax errors...'
 for i in "${PYTHON_FILES[@]}"
 do
-    flake8 "$i" --count --max-line-length=127 --select=E999 --statistics
+    flake8 "$i" --select=E999 --statistics
     RETURN_CODE=$?
     if [ $RETURN_CODE != 0 ]; then
         echo 'Flake8 found Python 3 syntax errors above.  See: https://docs.python.org/3/howto/pyporting.html'
@@ -25,5 +25,5 @@ done
 echo 'Flake8: second round uses the --exit-zero flag to treat _every_ message as a warning...'
 for i in "${PYTHON_FILES[@]}"
 do
-    flake8 "$i" --count --max-line-length=127 --statistics --exit-zero
+    flake8 "$i" --count --ignore=E --max-line-length=127 --statistics --exit-zero
 done


### PR DESCRIPTION
Issue #1963 says that flake8 is too chatty so we use flake8's `--ignore=E` option to suppress its most nitpicky formatting complaints.  This lets us focus on more serious issues like the issues that it found in the five other commits of this PR.