### PR TITLE
Fix log collection after unsuccessful test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ install:
 
 script:
   - ./tools/travis/build.sh
+  - ansible-playbook -i ansible/environments/local ansible/logs.yml # collect logs regardless of build exit
   - ./tools/travis/box-upload.py "/home/travis/build/openwhisk/openwhisk/logs" "$TRAVIS_BUILD_ID-$TRAVIS_BRANCH.tar.gz"


### PR DESCRIPTION
If the tests fail, we don't get logs.