### PR TITLE
API GW V2 - Add 'wsk api` command

### DIFF
--- a/core/routemgmt/createApi/createApi.js
+++ b/core/routemgmt/createApi/createApi.js
@@ -55,6 +55,7 @@ var utils = require('./utils.js');
 var utils2 = require('./apigw-utils.js');
 
 function main(message) {
+  //console.log('message: '+JSON.stringify(message));  // ONLY FOR TEMPORARY/LOCAL DEBUG; DON'T ENABLE PERMANENTLY
   var badArgMsg = validateArgs(message);
   if (badArgMsg) {
     return Promise.reject(utils2.makeErrorResponseObject(badArgMsg, (message.__ow_method != undefined)));

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -20,6 +20,7 @@ task testLean(type: Test) {
     exclude '**/*Python*'
     exclude '**/*ThrottleTests*'
     exclude '**/MaxActionDurationTests*'
+    exclude '**/ApiGwTests*'
 }
 
 // Add all images needed for local testing here

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -20,7 +20,7 @@ task testLean(type: Test) {
     exclude '**/*Python*'
     exclude '**/*ThrottleTests*'
     exclude '**/MaxActionDurationTests*'
-    exclude '**/ApiGwTests*'
+    exclude '**/*ApiGwTests*'
 }
 
 // Add all images needed for local testing here

--- a/tests/dat/actions/echo-web-http.js
+++ b/tests/dat/actions/echo-web-http.js
@@ -1,0 +1,10 @@
+function main(params) {
+    var bodyobj = params || {};
+    bodystr = JSON.stringify(bodyobj);
+    return {
+        statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: new Buffer(bodystr).toString('base64')
+    };
+}
+

--- a/tests/dat/apigw/testswaggerdoc1V2
+++ b/tests/dat/apigw/testswaggerdoc1V2
@@ -1,0 +1,61 @@
+{
+    "swagger": "2.0",
+    "basePath": "/CLI_APIGWTEST7_bp",
+    "info": {
+        "title": "CLI_APIGWTEST7 API Name",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/path": {
+            "get": {
+                "operationId": "get_/path",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "CLI_APIGWTEST7_action",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http"
+                }
+            }
+        }
+    },
+    "x-ibm-configuration": {
+        "assembly": {
+            "execute": [
+                {
+                    "set-variable": {
+                        "actions": [
+                            {
+                                "set": "message.headers.Authorization",
+                                "value": "Basic Nzg5YzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOmFiY3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
+                            }
+                        ]
+                    }
+                },
+                {
+                    "operation-switch": {
+                        "case": [
+                            {
+                                "execute": [
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/CLI_APIGWTEST7_action.http",
+                                            "verb": "keep"
+                                        }
+                                    }
+                                ],
+                                "operations": [
+                                    "get_/path"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/dat/apigw/testswaggerdoc2V2
+++ b/tests/dat/apigw/testswaggerdoc2V2
@@ -1,0 +1,117 @@
+{
+    "swagger": "2.0",
+    "basePath": "/test1/v1",
+    "info": {
+        "title": "CLI_APIGWTEST13 API Name",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/whisk_system/utils/echo": {
+            "get": {
+                "operationId": "get_/whisk_system/utils/echo",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "test1a",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http"
+                }
+            },
+            "post": {
+                "operationId": "post_/whisk_system/utils/echo",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "test1a",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http"
+                }
+            }
+        },
+        "/whisk_system/utils/split": {
+            "post": {
+                "operationId": "post_/whisk_system/utils/split",
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                },
+                "x-openwhisk": {
+                    "action": "test1a",
+                    "namespace": "whisk.system",
+                    "package": "",
+                    "url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http"
+                }
+            }
+        }
+    },
+    "x-ibm-configuration": {
+        "assembly": {
+            "execute": [
+                {
+                    "set-variable": {
+                        "actions": [
+                            {
+                                "set": "message.headers.Authorization",
+                                "value": "Basic Nzg5YzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOmFiY3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A="
+                            }
+                        ]
+                    }
+                },
+                {
+                    "operation-switch": {
+                        "case": [
+                            {
+                                "operations": [
+                                    "get_/whisk_system/utils/echo"
+                                ],
+                                "execute": [
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http",
+                                            "verb": "get"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "operations": [
+                                    "post_/whisk_system/utils/echo"
+                                ],
+                                "execute": [
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http",
+                                            "verb": "post"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "operations": [
+                                    "post_/whisk_system/utils/split"
+                                ],
+                                "execute": [
+                                    {
+                                        "invoke": {
+                                            "target-url": "https://172.17.0.1/api/v1/web/whisk.system/default/test1a.http",
+                                            "verb": "post"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
+++ b/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
@@ -62,8 +62,8 @@ class ApiGwEndToEndTests
     val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
 
     /*
- * Create a CLI properties file for use by the tests
- */
+     * Create a CLI properties file for use by the tests
+     */
     override def beforeAll() = {
         cliWskPropsFile.deleteOnExit()
         val wskprops = WskPropsV2(token = "SOME TOKEN")

--- a/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
+++ b/tests/src/test/scala/apigw/healthtests/ApiGwEndToEndTests.scala
@@ -23,6 +23,7 @@ import java.io.FileWriter
 import scala.concurrent.duration.DurationInt
 
 import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
@@ -35,6 +36,7 @@ import common.TestUtils._
 import common.Wsk
 import common.WskAdmin
 import common.WskProps
+import common.WskPropsV2
 import common.WskTestHelpers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -44,19 +46,40 @@ import system.rest.RestUtil
  * Basic tests of the download link for Go CLI binaries
  */
 @RunWith(classOf[JUnitRunner])
-class ApiGwEndToEndTests extends FlatSpec with Matchers with RestUtil with TestHelpers with WskTestHelpers {
+class ApiGwEndToEndTests
+    extends FlatSpec
+    with Matchers
+    with RestUtil
+    with TestHelpers
+    with WskTestHelpers
+    with BeforeAndAfterAll {
 
     implicit val wskprops = WskProps()
     val wsk = new Wsk
     val (cliuser, clinamespace) = WskAdmin.getUser(wskprops.authKey)
 
+    // Custom CLI properties file
+    val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
+
+    /*
+ * Create a CLI properties file for use by the tests
+ */
+    override def beforeAll() = {
+        cliWskPropsFile.deleteOnExit()
+        val wskprops = WskPropsV2(token = "SOME TOKEN")
+        wskprops.writeFile(cliWskPropsFile)
+        println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
+    }
+
+    behavior of "Wsk api-experimental"
+
     it should s"create an API and successfully invoke that API" in {
-        val testName = "APIGW_HEALTHTEST1"
+        val testName = "APIGWe_HEALTHTEST1"
         val testbasepath = "/" + testName + "_bp"
         val testrelpath = "/path"
         val testurlop = "get"
         val testapiname = testName + " API Name"
-        val actionName = "echo"
+        val actionName = testName + "_echo"
         val urlqueryparam = "name"
         val urlqueryvalue = "test"
 
@@ -68,7 +91,7 @@ class ApiGwEndToEndTests extends FlatSpec with Matchers with RestUtil with TestH
             wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
 
             // Create the API
-            var rr = wsk.api.create(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            var rr = wsk.apiexperimental.create(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
             val apiurl = rr.stdout.split("\n")(1)
             println(s"apiurl: '${apiurl}'")
@@ -78,13 +101,13 @@ class ApiGwEndToEndTests extends FlatSpec with Matchers with RestUtil with TestH
             // ok: APIs
             // Action                            Verb             API Name  URL
             // /_//whisk.system/utils/echo          get  APIGW_HEALTHTEST1 API Name  http://172.17.0.1:9001/api/ab9082cd-ea8e-465a-8a65-b491725cc4ef/APIGW_HEALTHTEST1_bp/path
-            rr = wsk.api.list(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr = wsk.apiexperimental.list(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
             rr.stdout should include("ok: APIs")
             rr.stdout should include regex (s"${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
             rr.stdout should include(testbasepath + testrelpath)
 
             // Recreate the API using a JSON swagger file
-            rr = wsk.api.get(basepathOrApiName = Some(testbasepath))
+            rr = wsk.apiexperimental.get(basepathOrApiName = Some(testbasepath))
             val swaggerfile = File.createTempFile("api", ".json")
             swaggerfile.deleteOnExit()
             val bw = new BufferedWriter(new FileWriter(swaggerfile))
@@ -92,10 +115,10 @@ class ApiGwEndToEndTests extends FlatSpec with Matchers with RestUtil with TestH
             bw.close()
 
             // Delete API to that it can be recreated again using the generated swagger file
-            val deleteApiResult = wsk.api.delete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            val deleteApiResult = wsk.apiexperimental.delete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
 
             // Create the API again, but use the swagger file this time
-            rr = wsk.api.create(swagger = Some(swaggerfile.getAbsolutePath()))
+            rr = wsk.apiexperimental.create(swagger = Some(swaggerfile.getAbsolutePath()))
             rr.stdout should include("ok: created API")
             val swaggerapiurl = rr.stdout.split("\n")(1)
             println(s"apiurl: '${swaggerapiurl}'")
@@ -114,7 +137,103 @@ class ApiGwEndToEndTests extends FlatSpec with Matchers with RestUtil with TestH
             println("Deleting action: " + actionName)
             val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
             println("Deleting API: " + testbasepath)
-            val finallydeleteApiResult = wsk.api.delete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            val finallydeleteApiResult = wsk.apiexperimental.delete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
+    }
+
+    behavior of "Wsk api"
+
+    it should s"create an API and successfully invoke that API" in {
+        val testName = "APIGW_HEALTHTEST1"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_echo"
+        val urlqueryparam = "name"
+        val urlqueryvalue = "test"
+
+        try {
+            println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
+
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo-web-http.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            // Create the API
+            var rr = wsk.api.create(
+                basepath = Some(testbasepath),
+                relpath = Some(testrelpath),
+                operation = Some(testurlop),
+                action = Some(actionName),
+                apiname = Some(testapiname),
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
+            rr.stdout should include("ok: created API")
+            val apiurl = rr.stdout.split("\n")(1)
+            println(s"apiurl: '${apiurl}'")
+
+            // Validate the API was successfully created
+            // List result will look like:
+            // ok: APIs
+            // Action                            Verb             API Name  URL
+            // /_//whisk.system/utils/echo          get  APIGW_HEALTHTEST1 API Name  http://172.17.0.1:9001/api/ab9082cd-ea8e-465a-8a65-b491725cc4ef/APIGW_HEALTHTEST1_bp/path
+            rr = wsk.api.list(
+                basepathOrApiName = Some(testbasepath),
+                relpath = Some(testrelpath),
+                operation = Some(testurlop),
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+
+            // Recreate the API using a JSON swagger file
+            rr = wsk.api.get(
+                basepathOrApiName = Some(testbasepath),
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
+            val swaggerfile = File.createTempFile("api", ".json")
+            swaggerfile.deleteOnExit()
+            val bw = new BufferedWriter(new FileWriter(swaggerfile))
+            bw.write(rr.stdout)
+            bw.close()
+
+            // Delete API to that it can be recreated again using the generated swagger file
+            val deleteApiResult = wsk.api.delete(
+                basepathOrApiName = testbasepath,
+                expectedExitCode = DONTCARE_EXIT,
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
+
+            // Create the API again, but use the swagger file this time
+            rr = wsk.api.create(
+                swagger = Some(swaggerfile.getAbsolutePath()),
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
+            rr.stdout should include("ok: created API")
+            val swaggerapiurl = rr.stdout.split("\n")(1)
+            println(s"apiurl: '${swaggerapiurl}'")
+
+            // Call the API URL and validate the results
+            val response = whisk.utils.retry({
+                val response = RestAssured.given().config(sslconfig).get(s"$swaggerapiurl?$urlqueryparam=$urlqueryvalue")
+                response.statusCode should be(200)
+                response
+            }, 5, Some(1.second))
+            val responseString = response.body.asString
+            println("URL invocation response: " + responseString)
+            responseString.parseJson.asJsObject.fields(urlqueryparam).convertTo[String] should be(urlqueryvalue)
+
+        } finally {
+            println("Deleting action: " + actionName)
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            println("Deleting API: " + testbasepath)
+            val finallydeleteApiResult = wsk.api.delete(
+                basepathOrApiName = testbasepath,
+                expectedExitCode = DONTCARE_EXIT,
+                cliCfgFile = Some(cliWskPropsFile.getCanonicalPath())
+            )
         }
     }
 }

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -16,7 +16,9 @@
 
 package common
 
+import java.io.BufferedWriter
 import java.io.File
+import java.io.FileWriter
 
 import scala.Left
 import scala.Right
@@ -73,6 +75,21 @@ case class WskProps(
     def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
 }
 
+case class WskPropsV2(
+    authKey: String = WhiskProperties.readAuthKey(WhiskProperties.getAuthFileForTesting),
+    namespace: String = "_",
+    apiversion: String = "v1",
+    apihost: String = WhiskProperties.getEdgeHost,
+    token: String = "") {
+    def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
+    def writeFile(propsfile: File) = {
+        val propsStr = s"NAMESPACE=${namespace}\nAPIVERSION=${apiversion}\nAUTH=${authKey}\nAPIHOST=${apihost}\nBMXTOKEN=${token}\n"
+        val bw = new BufferedWriter(new FileWriter(propsfile))
+        bw.write(propsStr)
+        bw.close()
+    }
+}
+
 class Wsk() extends RunWskCmd {
     implicit val action = new WskAction
     implicit val trigger = new WskTrigger
@@ -81,6 +98,7 @@ class Wsk() extends RunWskCmd {
     implicit val pkg = new WskPackage
     implicit val namespace = new WskNamespace
     implicit val api = new WskApi
+    implicit val apiexperimental = new WskApiExperimental
 }
 
 trait FullyQualifiedNames {
@@ -743,8 +761,7 @@ class WskPackage()
     }
 }
 
-class WskApi()
-    extends RunWskCmd {
+class WskApiExperimental extends RunWskCmd {
     protected val noun = "api-experimental"
 
     /**
@@ -831,6 +848,101 @@ class WskApi()
             { relpath map { r => Seq(r) } getOrElse Seq() } ++
             { operation map { o => Seq(o) } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode, showCmd = true)
+    }
+}
+
+class WskApi()
+    extends RunWskCmd {
+    protected val noun = "api"
+
+    /**
+     * Creates and API endpoint. Parameters mirror those available in the CLI.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def create(
+        basepath: Option[String] = None,
+        relpath: Option[String] = None,
+        operation: Option[String] = None,
+        action: Option[String] = None,
+        apiname: Option[String] = None,
+        swagger: Option[String] = None,
+        expectedExitCode: Int = SUCCESS_EXIT,
+        cliCfgFile: Option[String] = None)(
+            implicit wp: WskProps): RunResult = {
+        val params = Seq(noun, "create", "--auth", wp.authKey) ++
+            { basepath map { b => Seq(b) } getOrElse Seq() } ++
+            { relpath map { r => Seq(r) } getOrElse Seq() } ++
+            { operation map { o => Seq(o) } getOrElse Seq() } ++
+            { action map { aa => Seq(aa) } getOrElse Seq() } ++
+            { apiname map { a => Seq("--apiname", a) } getOrElse Seq() } ++
+            { swagger map { s => Seq("--config-file", s) } getOrElse Seq() }
+        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env=Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+    }
+
+    /**
+     * Retrieve a list of API endpoints. Parameters mirror those available in the CLI.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def list(
+        basepathOrApiName: Option[String] = None,
+        relpath: Option[String] = None,
+        operation: Option[String] = None,
+        limit: Option[Int] = None,
+        since: Option[Instant] = None,
+        full: Option[Boolean] = None,
+        expectedExitCode: Int = SUCCESS_EXIT,
+        cliCfgFile: Option[String] = None)(
+            implicit wp: WskProps): RunResult = {
+        val params = Seq(noun, "list", "--auth", wp.authKey) ++
+            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
+            { relpath map { r => Seq(r) } getOrElse Seq() } ++
+            { operation map { o => Seq(o) } getOrElse Seq() } ++
+            { limit map { l => Seq("--limit", l.toString) } getOrElse Seq() } ++
+            { since map { i => Seq("--since", i.toEpochMilli.toString) } getOrElse Seq() } ++
+            { full map { r => Seq("--full") } getOrElse Seq() }
+        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env=Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+    }
+
+    /**
+     * Retieves an API's configuration. Parameters mirror those available in the CLI.
+     * Runs a command wsk [params] where the arguments come in as a sequence.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def get(
+        basepathOrApiName: Option[String] = None,
+        full: Option[Boolean] = None,
+        expectedExitCode: Int = SUCCESS_EXIT,
+        cliCfgFile: Option[String] = None)(
+            implicit wp: WskProps): RunResult = {
+        val params = Seq(noun, "get", "--auth", wp.authKey) ++
+            { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
+            { full map { f => if (f) Seq("--full") else Seq() } getOrElse Seq() }
+        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env=Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
+    }
+
+    /**
+     * Delete an entire API or a subset of API endpoints. Parameters mirror those available in the CLI.
+     *
+     * @param expectedExitCode (optional) the expected exit code for the command
+     * if the code is anything but DONTCARE_EXIT, assert the code is as expected
+     */
+    def delete(
+        basepathOrApiName: String,
+        relpath: Option[String] = None,
+        operation: Option[String] = None,
+        expectedExitCode: Int = SUCCESS_EXIT,
+        cliCfgFile: Option[String] = None)(
+            implicit wp: WskProps): RunResult = {
+        val params = Seq(noun, "delete", "--auth", wp.authKey, basepathOrApiName) ++
+            { relpath map { r => Seq(r) } getOrElse Seq() } ++
+            { operation map { o => Seq(o) } getOrElse Seq() }
+        cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env=Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
     }
 }
 

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -83,7 +83,7 @@ case class WskPropsV2(
     token: String = "") {
     def overrides = Seq("-i", "--apihost", apihost, "--apiversion", apiversion)
     def writeFile(propsfile: File) = {
-        val propsStr = s"NAMESPACE=${namespace}\nAPIVERSION=${apiversion}\nAUTH=${authKey}\nAPIHOST=${apihost}\nBMXTOKEN=${token}\n"
+        val propsStr = s"NAMESPACE=${namespace}\nAPIVERSION=${apiversion}\nAUTH=${authKey}\nAPIHOST=${apihost}\nAPIGW_ACCESS_TOKEN=${token}\n"
         val bw = new BufferedWriter(new FileWriter(propsfile))
         bw.write(propsStr)
         bw.close()

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -1012,7 +1012,7 @@ class ApiGwTests
     val actionName = testName+"_action"
     try {
       var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-      rr.stderr should include("API action either does not exist or is not a web-action")
+      rr.stderr should include("API action does not exist")
     }
     finally {
       val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
@@ -1034,7 +1034,7 @@ class ApiGwTests
       wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
 
       var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-      rr.stderr should include("API action either does not exist or is not a web-action")
+      rr.stderr should include("API action is not a web-action")
     } finally {
       val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
       var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -16,8 +16,11 @@
 
 package whisk.core.cli.test
 
+import java.io.File
 import java.time.Instant
 import scala.concurrent.duration._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
@@ -28,6 +31,7 @@ import common.WhiskProperties
 import common.Wsk
 import common.WskAdmin
 import common.WskProps
+import common.WskPropsV2
 import common.WskTestHelpers
 
 /**
@@ -52,6 +56,9 @@ class ApiGwTests
     var clearedThrottleTime = Instant.now
     val maxActionsPerMin = WhiskProperties.getMaxActionInvokesPerMinute()
 
+    // Custom CLI properties file
+    val cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
+
     /**
       * Expected to be called before or after each CLI invocation
       * If number of CLI invocations in this suite have reached the throttle limit
@@ -60,8 +67,9 @@ class ApiGwTests
     def checkThrottle() = {
       // If the # CLI calls at the throttle limit, then wait enough time to avoid the CLI being blocked
       cliCallCount += 1
-      if ( cliCallCount > maxActionsPerMin ) {
-        println(s"Action invokes ${cliCallCount} exceeds per minute thottle limit of ${maxActionsPerMin}")
+      println(s"Action invokes ${cliCallCount}; per minute thottle limit ${maxActionsPerMin}")
+      if ( cliCallCount > (maxActionsPerMin - 10) ) {  // Allow for some margin...10 invocations
+        println(s"Action invokes ${cliCallCount} close to exceeding per minute thottle limit of ${maxActionsPerMin}")
         val waitedAlready = Duration.fromNanos(java.time.Duration.between(clearedThrottleTime, Instant.now).toNanos)
         settleThrottle(waitedAlready)
         cliCallCount = 0
@@ -81,6 +89,17 @@ class ApiGwTests
     }
 
     /*
+     * Create a CLI properties file for use by the tests
+     */
+    override def beforeAll() = {
+      //cliWskPropsFile = File.createTempFile("wskprops", ".tmp")
+      cliWskPropsFile.deleteOnExit()
+      val wskprops = WskPropsV2(token = "SOME TOKEN")
+      wskprops.writeFile(cliWskPropsFile)
+      println(s"wsk temporary props file created here: ${cliWskPropsFile.getCanonicalPath()}")
+    }
+
+    /*
      * Forcibly clear the throttle so that downstream tests are not affected by
      * this test suite
      */
@@ -92,7 +111,7 @@ class ApiGwTests
       }
     }
 
-    def apiCreate(
+    def apiCreateExperimental(
       basepath: Option[String] = None,
       relpath: Option[String] = None,
       operation: Option[String] = None,
@@ -101,7 +120,49 @@ class ApiGwTests
       swagger: Option[String] = None,
       expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
         checkThrottle()
-        wsk.api.create(basepath, relpath, operation, action, apiname, swagger, expectedExitCode)
+        wsk.apiexperimental.create(basepath, relpath, operation, action, apiname, swagger, expectedExitCode)
+    }
+
+    def apiListExperimental(
+      basepathOrApiName: Option[String] = None,
+      relpath: Option[String] = None,
+      operation: Option[String] = None,
+      limit: Option[Int] = None,
+      since: Option[Instant] = None,
+      full: Option[Boolean] = None,
+      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+        checkThrottle()
+        wsk.apiexperimental.list(basepathOrApiName, relpath, operation, limit, since, full, expectedExitCode)
+    }
+
+    def apiGetExperimental(
+      basepathOrApiName: Option[String] = None,
+      full: Option[Boolean] = None,
+      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+        checkThrottle()
+        wsk.apiexperimental.get(basepathOrApiName, full, expectedExitCode)
+    }
+
+    def apiDeleteExperimental(
+      basepathOrApiName: String,
+      relpath: Option[String] = None,
+      operation: Option[String] = None,
+      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+        checkThrottle()
+        wsk.apiexperimental.delete(basepathOrApiName, relpath, operation, expectedExitCode)
+    }
+
+    def apiCreate(
+      basepath: Option[String] = None,
+      relpath: Option[String] = None,
+      operation: Option[String] = None,
+      action: Option[String] = None,
+      apiname: Option[String] = None,
+      swagger: Option[String] = None,
+      expectedExitCode: Int = SUCCESS_EXIT,
+      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
+        checkThrottle()
+        wsk.api.create(basepath, relpath, operation, action, apiname, swagger, expectedExitCode, cliCfgFile)
     }
 
     def apiList(
@@ -111,40 +172,43 @@ class ApiGwTests
       limit: Option[Int] = None,
       since: Option[Instant] = None,
       full: Option[Boolean] = None,
-      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+      expectedExitCode: Int = SUCCESS_EXIT,
+      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
         checkThrottle()
-        wsk.api.list(basepathOrApiName, relpath, operation, limit, since, full, expectedExitCode)
+        wsk.api.list(basepathOrApiName, relpath, operation, limit, since, full, expectedExitCode, cliCfgFile)
     }
 
     def apiGet(
       basepathOrApiName: Option[String] = None,
       full: Option[Boolean] = None,
-      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+      expectedExitCode: Int = SUCCESS_EXIT,
+      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
         checkThrottle()
-        wsk.api.get(basepathOrApiName, full, expectedExitCode)
+        wsk.api.get(basepathOrApiName, full, expectedExitCode, cliCfgFile)
     }
 
     def apiDelete(
       basepathOrApiName: String,
       relpath: Option[String] = None,
       operation: Option[String] = None,
-      expectedExitCode: Int = SUCCESS_EXIT): RunResult = {
+      expectedExitCode: Int = SUCCESS_EXIT,
+      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
         checkThrottle()
-        wsk.api.delete(basepathOrApiName, relpath, operation, expectedExitCode)
+        wsk.api.delete(basepathOrApiName, relpath, operation, expectedExitCode, cliCfgFile)
     }
 
-    behavior of "Wsk api"
+  behavior of "Wsk api-experimental"
 
     it should "reject an api commands with an invalid path parameter" in {
         val badpath = "badpath"
 
-        var rr = apiCreate(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
+        var rr = apiCreateExperimental(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
         rr.stderr should include (s"'${badpath}' must begin with '/'")
 
-        rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+        rr = apiDeleteExperimental(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
         rr.stderr should include (s"'${badpath}' must begin with '/'")
 
-        rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+        rr = apiListExperimental(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
         rr.stderr should include (s"'${badpath}' must begin with '/'")
     }
 
@@ -159,10 +223,10 @@ class ApiGwTests
       try {
         println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
 
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         println("api create: " + rr.stdout)
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
         println("api list: " + rr.stdout)
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
@@ -174,7 +238,7 @@ class ApiGwTests
         rr.stdout should include(testbasepath + testrelpath)
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
       }
     }
 
@@ -189,17 +253,17 @@ class ApiGwTests
         try {
             println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
 
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
-            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
             rr.stdout should include("ok: APIs")
             rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
             rr.stdout should include(testbasepath + testrelpath)
-            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
             deleteresult.stdout should include("ok: deleted API")
         }
         finally {
-            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
         }
     }
 
@@ -212,14 +276,14 @@ class ApiGwTests
         val testapiname = testName+" API Name"
         val actionName = testName+"_action"
         try {
-            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
-            rr = apiGet(basepathOrApiName = Some(testapiname))
+            rr = apiGetExperimental(basepathOrApiName = Some(testapiname))
             rr.stdout should include(testbasepath)
             rr.stdout should include(s"${actionName}")
         }
         finally {
-            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
         }
     }
 
@@ -232,13 +296,13 @@ class ApiGwTests
       val testapiname = testName+" API Name"
       val actionName = testName+"_action"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiDelete(basepathOrApiName = testapiname)
+        rr = apiDeleteExperimental(basepathOrApiName = testapiname)
         rr.stdout should include("ok: deleted API")
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -251,13 +315,13 @@ class ApiGwTests
       val testapiname = testName+" API Name"
       val actionName = testName+"_action"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiDelete(basepathOrApiName = testbasepath)
+        rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
         rr.stdout should include("ok: deleted API")
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -271,18 +335,18 @@ class ApiGwTests
       val actionName = testName+"_action"
       val newEndpoint = "/newEndpoint"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
         rr.stdout should include(testbasepath + newEndpoint)
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -296,9 +360,9 @@ class ApiGwTests
       val actionName = testName+"_action"
       val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1")
       try {
-        var rr = apiCreate(swagger = Some(swaggerPath))
+        var rr = apiCreateExperimental(swagger = Some(swaggerPath))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
         println("list stdout: "+rr.stdout)
         println("list stderr: "+rr.stderr)
         rr.stdout should include("ok: APIs")
@@ -307,7 +371,7 @@ class ApiGwTests
         rr.stdout should include(testbasepath + testrelpath)
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -322,32 +386,32 @@ class ApiGwTests
       val actionName = testName+"_action"
       val newEndpoint = "/newEndpoint"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
 
         // Update both APIs - each with a new endpoint
-        rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
         rr.stdout should include("ok: created API")
-        rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
         rr.stdout should include("ok: created API")
 
-        rr = apiList(basepathOrApiName = Some(testbasepath))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
         rr.stdout should include(testbasepath + newEndpoint)
 
-        rr = apiList(basepathOrApiName = Some(testbasepath2))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath2))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath2 + testrelpath)
         rr.stdout should include(testbasepath2 + newEndpoint)
       }
       finally {
-        var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -364,17 +428,17 @@ class ApiGwTests
       try {
         println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
 
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
         deleteresult.stdout should include("ok: deleted API")
       }
       finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -388,12 +452,12 @@ class ApiGwTests
       val actionName = testName + "_action"
       val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
       try {
-        var rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+        var rr = apiCreateExperimental(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
         println("api create stdout: " + rr.stdout)
         println("api create stderr: " + rr.stderr)
         rr.stderr should include(s"Swagger file is invalid")
       } finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -406,18 +470,18 @@ class ApiGwTests
       val testapiname = testName + " API Name"
       val actionName = testName + "_action"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        var rr2 = apiCreate(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr2 = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr2.stdout should include("ok: created API")
-        rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
+        rr = apiDeleteExperimental(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
         rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
-        rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
+        rr2 = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
         rr2.stdout should include("ok: APIs")
         rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr2.stdout should include(testbasepath + testnewrelpath)
       } finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -431,20 +495,20 @@ class ApiGwTests
       val testapiname = testName + " API Name"
       val actionName = testName + "_action"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
+        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
-        rr = apiDelete(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
+        rr = apiDeleteExperimental(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
         rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
-        rr = apiList(basepathOrApiName = Some(testbasepath))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
       } finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -458,18 +522,18 @@ class ApiGwTests
       val actionName = "test1a"
       val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2")
       try {
-        var rr = apiCreate(swagger = Some(swaggerPath))
+        var rr = apiCreateExperimental(swagger = Some(swaggerPath))
         println("api create stdout: " + rr.stdout)
         println("api create stderror: " + rr.stderr)
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
         rr.stdout should include("ok: APIs")
         // Actual CLI namespace will vary from local dev to automated test environments, so don't check
         rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
         rr.stdout should include(testbasepath + testrelpath2)
       } finally {
-        val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
       }
     }
 
@@ -483,29 +547,498 @@ class ApiGwTests
       val testapiname = testName + " API Name"
       val actionName = testName + "_action"
       try {
-        var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
-        rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
         rr.stdout should include("ok: created API")
-        rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath2 + testrelpath)
-        rr = apiDelete(basepathOrApiName = testbasepath2)
+        rr = apiDeleteExperimental(basepathOrApiName = testbasepath2)
         rr.stdout should include("ok: deleted API")
-        rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
         rr.stdout should include("ok: APIs")
         rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
         rr.stdout should include(testbasepath + testrelpath)
-        rr = apiDelete(basepathOrApiName = testbasepath)
+        rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
         rr.stdout should include("ok: deleted API")
       } finally {
-        var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
       }
     }
+
+  behavior of "Wsk api"
+
+  it should "reject an api commands with an invalid path parameter" in {
+    val badpath = "badpath"
+
+    var rr = apiCreate(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include (s"'${badpath}' must begin with '/'")
+
+    rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include (s"'${badpath}' must begin with '/'")
+
+    rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+    rr.stderr should include (s"'${badpath}' must begin with '/'")
+  }
+
+  it should "verify full list output" in {
+    val testName = "CLI_APIGWTEST_RO1"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      println("api create: " + rr.stdout)
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
+      println("api list: " + rr.stdout)
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
+      rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
+      rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
+      rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
+      rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
+      rr.stdout should include regex (s"URL:\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+    }
+  }
+
+  it should "verify successful creation and deletion of a new API" in {
+    val testName = "CLI_APIGWTEST1"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    try {
+      println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
+
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+      deleteresult.stdout should include("ok: deleted API")
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify get API name " in {
+    val testName = "CLI_APIGWTEST3"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiGet(basepathOrApiName = Some(testapiname))
+      rr.stdout should include(testbasepath)
+      rr.stdout should include(s"${actionName}")
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify delete API name " in {
+    val testName = "CLI_APIGWTEST4"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testapiname)
+      rr.stdout should include("ok: deleted API")
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify delete API basepath " in {
+    val testName = "CLI_APIGWTEST5"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testbasepath)
+      rr.stdout should include("ok: deleted API")
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify adding endpoints to existing api" in {
+    val testName = "CLI_APIGWTEST6"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    val newEndpoint = "/newEndpoint"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + newEndpoint)
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify successful creation with swagger doc as input" in {
+    // NOTE: These values must match the swagger file contents
+    val testName = "CLI_APIGWTEST7"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1V2")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      println("list stdout: "+rr.stdout)
+      println("list stderr: "+rr.stderr)
+      rr.stdout should include("ok: APIs")
+      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+    }
+    finally {
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify adding endpoints to two existing apis" in {
+    val testName = "CLI_APIGWTEST8"
+    val testbasepath = "/"+testName+"_bp"
+    val testbasepath2 = "/"+testName+"_bp2"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    val newEndpoint = "/newEndpoint"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+
+      // Update both APIs - each with a new endpoint
+      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+      rr.stdout should include("ok: created API")
+
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + newEndpoint)
+
+      rr = apiList(basepathOrApiName = Some(testbasepath2))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath2 + testrelpath)
+      rr.stdout should include(testbasepath2 + newEndpoint)
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+      deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify successful creation of a new API using an action name using all allowed characters" in {
+    // Be aware: full action name is close to being truncated by the 'list' command
+    // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
+    val testName = "CLI_APIGWTEST9"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"a-c@t ion"
+    try {
+      println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+      deleteresult.stdout should include("ok: deleted API")
+    }
+    finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify failed creation with invalid swagger doc as input" in {
+    val testName = "CLI_APIGWTEST10"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+      println("api create stdout: " + rr.stdout)
+      println("api create stderr: " + rr.stderr)
+      rr.stderr should include(s"Swagger file is invalid")
+    } finally {
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify delete basepath/path " in {
+    val testName = "CLI_APIGWTEST11"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      var rr2 = apiCreate(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr2.stdout should include("ok: created API")
+      rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
+      rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
+      rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
+      rr2.stdout should include("ok: APIs")
+      rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr2.stdout should include(testbasepath + testnewrelpath)
+    } finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify delete single operation from existing API basepath/path/operation(s) " in {
+    val testName = "CLI_APIGWTEST12"
+    val testbasepath = "/" + testName + "_bp"
+    val testrelpath = "/path2"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testurlop2 = "post"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
+      rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+    } finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify successful creation with complex swagger doc as input" in {
+    val testName = "CLI_APIGWTEST13"
+    val testbasepath = "/test1/v1"
+    val testrelpath = "/whisk_system/utils/echo"
+    val testrelpath2 = "/whisk_system/utils/split"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = "test1a"
+    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2V2")
+    try {
+      var rr = apiCreate(swagger = Some(swaggerPath))
+      println("api create stdout: " + rr.stdout)
+      println("api create stderror: " + rr.stderr)
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath))
+      rr.stdout should include("ok: APIs")
+      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr.stdout should include(testbasepath + testrelpath2)
+    } finally {
+      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "verify successful creation and deletion with multiple base paths" in {
+    val testName = "CLI_APIGWTEST14"
+    val testbasepath = "/" + testName + "_bp"
+    val testbasepath2 = "/" + testName + "_bp2"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must be a "web-action" action.
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+      rr.stdout should include("ok: created API")
+      rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath2 + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath2)
+      rr.stdout should include("ok: deleted API")
+      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+      rr.stdout should include("ok: APIs")
+      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+      rr.stdout should include(testbasepath + testrelpath)
+      rr = apiDelete(basepathOrApiName = testbasepath)
+      rr.stdout should include("ok: deleted API")
+    } finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+      deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "reject an API created with a non-existent action" in {
+    val testName = "CLI_APIGWTEST15"
+    val testbasepath = "/"+testName+"_bp"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName+" API Name"
+    val actionName = testName+"_action"
+    try {
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
+      rr.stderr should include("API action either does not exist or is not a web-action")
+    }
+    finally {
+      val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
+  it should "reject an API created with an action that is not a web-action" in {
+    val testName = "CLI_APIGWTEST16"
+    val testbasepath = "/" + testName + "_bp"
+    val testbasepath2 = "/" + testName + "_bp2"
+    val testrelpath = "/path"
+    val testnewrelpath = "/path_new"
+    val testurlop = "get"
+    val testapiname = testName + " API Name"
+    val actionName = testName + "_action"
+    try {
+      // Create the action for the API.  It must NOT be a "web-action" action for this test
+      val file = TestUtils.getTestActionFilename(s"echo.js")
+      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
+
+      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
+      rr.stderr should include("API action either does not exist or is not a web-action")
+    } finally {
+      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    }
+  }
+
 }

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -835,7 +835,7 @@ func printActionDeleted(entityName string) {
 }
 
 // Check if the specified action is a web-action
-func IsWebAction(client *whisk.Client, qname *QualifiedName) bool {
+func isWebAction(client *whisk.Client, qname QualifiedName) bool {
     var isWebAction = false;
 
     savedNs := client.Namespace
@@ -845,7 +845,7 @@ func IsWebAction(client *whisk.Client, qname *QualifiedName) bool {
     action, _, err := client.Actions.Get(qname.entityName)
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", fullActionName, err)
-        whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for validation\n", fullActionName)
+        whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for web action validation\n", fullActionName)
     } else {
         weVal := getValue(action.Annotations, "web-export")
         if (reflect.TypeOf(weVal) == nil) {

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -835,8 +835,9 @@ func printActionDeleted(entityName string) {
 }
 
 // Check if the specified action is a web-action
-func isWebAction(client *whisk.Client, qname QualifiedName) bool {
+func isWebAction(client *whisk.Client, qname QualifiedName) (bool, string) {
     var isWebAction = false;
+    var errMsg string = ""
 
     savedNs := client.Namespace
     client.Namespace = qname.namespace
@@ -846,7 +847,9 @@ func isWebAction(client *whisk.Client, qname QualifiedName) bool {
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", fullActionName, err)
         whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for web action validation\n", fullActionName)
+        errMsg = wski18n.T("API action does not exist")
     } else {
+        errMsg = wski18n.T("API action is not a web-action")
         weVal := getValue(action.Annotations, "web-export")
         if (reflect.TypeOf(weVal) == nil) {
             whisk.Debug(whisk.DbgError, "getValue(annotations, web-export) for action %s found no value\n", fullActionName)
@@ -859,12 +862,13 @@ func isWebAction(client *whisk.Client, qname QualifiedName) bool {
                 whisk.Debug(whisk.DbgError, "web-export annotation value is false\n", weVal)
             } else {
                 isWebAction = true;
+                errMsg = ""
             }
         }
     }
 
     client.Namespace = savedNs
-    return isWebAction
+    return isWebAction, errMsg
 }
 
 func init() {

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -816,10 +816,10 @@ var apiCreateCmdV2 = &cobra.Command{
             }
 
             // Confirm that the specified action is a web-action
-            if ok, errMsg := isWebAction(client, *qname); !ok {
-                whisk.Debug(whisk.DbgError, "isWebAction(%v) is false\n", qname)
-                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                    whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            err = isWebAction(client, *qname)
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "isWebAction(%v) is false: %s\n", qname, err)
+                whiskErr := whisk.MakeWskError(err, whisk.EXITCODE_ERR_GENERAL, whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
             }
         }

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -778,7 +778,7 @@ var apiCreateCmdV2 = &cobra.Command{
         var qname *QualifiedName
 
         if (!hasApiGwAccessToken()) {
-            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            whisk.Debug(whisk.DbgError, "No APIGW_ACCESS_TOKEN in properties file\n")
             errMsg := wski18n.T("You must login prior to issuing this command.")
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -816,7 +816,7 @@ var apiCreateCmdV2 = &cobra.Command{
             }
 
             // Confirm that the specified action is a web-action
-            if !IsWebAction(client, qname) {
+            if !isWebAction(client, *qname) {
                 whisk.Debug(whisk.DbgError, "IsWebAction(%v) is false\n", qname)
                 errMsg := wski18n.T("API action either does not exist or is not a web-action")
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
@@ -830,7 +830,7 @@ var apiCreateCmdV2 = &cobra.Command{
 
         apiCreateReqOptions := new(whisk.ApiCreateRequestOptions)
         props, _ := readProps(Properties.PropsFile)
-        apiCreateReqOptions.AccessToken = props["BMXTOKEN"]
+        apiCreateReqOptions.AccessToken = props["APIGW_ACCESS_TOKEN"]
         apiCreateReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
         whisk.Debug(whisk.DbgInfo, "AccessToken: %s\nSpaceGuid: %s\n", apiCreateReqOptions.AccessToken, apiCreateReqOptions.SpaceGuid)
 
@@ -898,7 +898,7 @@ var apiGetCmdV2 = &cobra.Command{
         var isBasePathArg bool = true
 
         if (!hasApiGwAccessToken()) {
-            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            whisk.Debug(whisk.DbgError, "No APIGW_ACCESS_TOKEN in properties file\n")
             errMsg := wski18n.T("You must login prior to issuing this command.")
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -914,7 +914,7 @@ var apiGetCmdV2 = &cobra.Command{
         apiGetReqOptions := new(whisk.ApiGetRequestOptions)
         apiGetReqOptions.ApiBasePath = args[0]
         props, _ := readProps(Properties.PropsFile)
-        apiGetReqOptions.AccessToken = props["BMXTOKEN"]
+        apiGetReqOptions.AccessToken = props["APIGW_ACCESS_TOKEN"]
         apiGetReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
 
 
@@ -974,7 +974,7 @@ var apiDeleteCmdV2 = &cobra.Command{
     RunE: func(cmd *cobra.Command, args []string) error {
 
         if (!hasApiGwAccessToken()) {
-            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            whisk.Debug(whisk.DbgError, "No APIGW_ACCESS_TOKEN in properties file\n")
             errMsg := wski18n.T("You must login prior to issuing this command.")
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -989,7 +989,7 @@ var apiDeleteCmdV2 = &cobra.Command{
         apiDeleteReq := new(whisk.ApiDeleteRequest)
         apiDeleteReqOptions := new(whisk.ApiDeleteRequestOptions)
         props, _ := readProps(Properties.PropsFile)
-        apiDeleteReqOptions.AccessToken = props["BMXTOKEN"]
+        apiDeleteReqOptions.AccessToken = props["APIGW_ACCESS_TOKEN"]
         apiDeleteReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
 
         // Is the argument a basepath (must start with /) or an API name
@@ -1067,7 +1067,7 @@ var apiListCmdV2 = &cobra.Command{
         var retApiArray *whisk.RetApiArrayV2
 
         if (!hasApiGwAccessToken()) {
-            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            whisk.Debug(whisk.DbgError, "No APIGW_ACCESS_TOKEN in properties file\n")
             errMsg := wski18n.T("You must login prior to issuing this command.")
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
@@ -1080,7 +1080,7 @@ var apiListCmdV2 = &cobra.Command{
         }
 
         props, _ := readProps(Properties.PropsFile)
-        accesstoken := props["BMXTOKEN"]
+        accesstoken := props["APIGW_ACCESS_TOKEN"]
         spaceguid := strings.Split(props["AUTH"], ":")[0]
 
         // Get API request body
@@ -1315,7 +1315,7 @@ func getLargestApiNameSizeV2(retApiArray *whisk.RetApiArrayV2, api *whisk.ApiOpt
 
 func hasApiGwAccessToken() bool {
     props, _ := readProps(Properties.PropsFile)
-    return (len(props["BMXTOKEN"]) > 0)
+    return (len(props["APIGW_ACCESS_TOKEN"]) > 0)
 }
 
 /*

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -42,7 +42,7 @@ var apiExperimentalCmd = &cobra.Command{
 
 var apiCmd = &cobra.Command{
     Use:   "api",
-    Short: wski18n.T("work with APIs"),
+    Short: wski18n.T("COMING SOON - work with APIs"),
 }
 
 var apiCreateCmd = &cobra.Command{
@@ -767,7 +767,7 @@ func getManagedUrl(api *whisk.RetApi, relpath string, operation string) (url str
 /////////////
 var apiCreateCmdV2 = &cobra.Command{
     Use:           "create ([BASE_PATH] API_PATH API_VERB ACTION] | --config-file CFG_FILE) ",
-    Short:         wski18n.T("create a new API"),
+    Short:         wski18n.T("COMING SOON - create a new API"),
     SilenceUsage:  true,
     SilenceErrors: true,
     PreRunE:       setupClientConfig,
@@ -889,7 +889,7 @@ var apiCreateCmdV2 = &cobra.Command{
 
 var apiGetCmdV2 = &cobra.Command{
     Use:           "get BASE_PATH | API_NAME",
-    Short:         wski18n.T("get API details"),
+    Short:         wski18n.T("COMING SOON - get API details"),
     SilenceUsage:  true,
     SilenceErrors: true,
     PreRunE:       setupClientConfig,
@@ -967,7 +967,7 @@ var apiGetCmdV2 = &cobra.Command{
 
 var apiDeleteCmdV2 = &cobra.Command{
     Use:           "delete BASE_PATH | API_NAME [API_PATH [API_VERB]]",
-    Short:         wski18n.T("delete an API"),
+    Short:         wski18n.T("COMING SOON - delete an API"),
     SilenceUsage:  true,
     SilenceErrors: true,
     PreRunE:       setupClientConfig,
@@ -1056,7 +1056,7 @@ var apiDeleteCmdV2 = &cobra.Command{
 
 var apiListCmdV2 = &cobra.Command{
     Use:           "list [[BASE_PATH | API_NAME] [API_PATH [API_VERB]]",
-    Short:         wski18n.T("list APIs"),
+    Short:         wski18n.T("COMING SOON - list APIs"),
     SilenceUsage:  true,
     SilenceErrors: true,
     PreRunE:       setupClientConfig,

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -40,6 +40,11 @@ var apiExperimentalCmd = &cobra.Command{
     Short: wski18n.T("work with APIs (experimental)"),
 }
 
+var apiCmd = &cobra.Command{
+    Use:   "api",
+    Short: wski18n.T("work with APIs"),
+}
+
 var apiCreateCmd = &cobra.Command{
     Use:           "create ([BASE_PATH] API_PATH API_VERB ACTION] | --config-file CFG_FILE) ",
     Short:         wski18n.T("create a new API"),
@@ -82,10 +87,10 @@ var apiCreateCmd = &cobra.Command{
             }
         }
 
-        sendApi := new(whisk.SendApi)
-        sendApi.ApiDoc = api
-
-        retApi, _, err := client.Apis.Insert(sendApi, false)
+        apiCreateReq := new(whisk.ApiCreateRequest)
+        apiCreateReq.ApiDoc = api
+        apiCreateReqOptions := new(whisk.ApiCreateRequestOptions)
+        retApi, _, err := client.Apis.Insert(apiCreateReq, apiCreateReqOptions, whisk.DoNotOverwrite)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, false) error: %s\n", api, err)
             errMsg := wski18n.T("Unable to create API: {{.err}}", map[string]interface{}{"err": err})
@@ -111,7 +116,7 @@ var apiCreateCmd = &cobra.Command{
             for path, _ := range retApi.Swagger.Paths {
                 managedUrl := strings.TrimSuffix(baseUrl, "/")+path
                 whisk.Debug(whisk.DbgInfo, "Managed path: %s\n",managedUrl)
-                for op, _  := range retApi.Swagger.Paths[path] {
+                for op, opv  := range retApi.Swagger.Paths[path] {
                     whisk.Debug(whisk.DbgInfo, "Path operation: %s\n", op)
                     fmt.Fprintf(color.Output,
                         wski18n.T("{{.ok}} created API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
@@ -119,7 +124,7 @@ var apiCreateCmd = &cobra.Command{
                                 "ok": color.GreenString("ok:"),
                                 "path": path,
                                 "verb": op,
-                                "name": boldString(retApi.Swagger.Paths[path][op]["x-ibm-op-ext"]["actionName"]),
+                                "name": boldString(opv.XOpenWhisk.ActionName),
                                 "fullpath": managedUrl,
                             }))
                 }
@@ -131,51 +136,51 @@ var apiCreateCmd = &cobra.Command{
     },
 }
 
-var apiUpdateCmd = &cobra.Command{
-    Use:           "update API_PATH API_VERB ACTION",
-    Short:         wski18n.T("update an existing API"),
-    SilenceUsage:  true,
-    SilenceErrors: true,
-    PreRunE:       setupClientConfig,
-    RunE: func(cmd *cobra.Command, args []string) error {
-
-        if whiskErr := checkArgs(args, 3, 3, "Api update",
-            wski18n.T("An API path, an API verb, and an action name are required.")); whiskErr != nil {
-            return whiskErr
-        }
-
-        api, err := parseApi(cmd, args)
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
-            errMsg := wski18n.T("Unable to parse API command arguments: {{.err}}", map[string]interface{}{"err": err})
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
-                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
-            return whiskErr
-        }
-        sendApi := new(whisk.SendApi)
-        sendApi.ApiDoc = api
-
-        retApi, _, err := client.Apis.Insert(sendApi, true)
-        if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, %t, false) error: %s\n", api, err)
-            errMsg := wski18n.T("Unable to update API: {{.err}}", map[string]interface{}{"err": err})
-            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
-                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
-            return whiskErr
-        }
-
-        fmt.Fprintf(color.Output,
-            wski18n.T("{{.ok}} updated API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
-                map[string]interface{}{
-                    "ok": color.GreenString("ok:"),
-                    "path": api.GatewayRelPath,
-                    "verb": api.GatewayMethod,
-                    "name": boldString("/"+api.Action.Name),
-                    "fullpath": getManagedUrl(retApi, api.GatewayRelPath, api.GatewayMethod),
-                }))
-        return nil
-    },
-}
+//var apiUpdateCmd = &cobra.Command{
+//    Use:           "update API_PATH API_VERB ACTION",
+//    Short:         wski18n.T("update an existing API"),
+//    SilenceUsage:  true,
+//    SilenceErrors: true,
+//    PreRunE:       setupClientConfig,
+//    RunE: func(cmd *cobra.Command, args []string) error {
+//
+//        if whiskErr := checkArgs(args, 3, 3, "Api update",
+//            wski18n.T("An API path, an API verb, and an action name are required.")); whiskErr != nil {
+//            return whiskErr
+//        }
+//
+//        api, err := parseApi(cmd, args)
+//        if err != nil {
+//            whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
+//            errMsg := wski18n.T("Unable to parse API command arguments: {{.err}}", map[string]interface{}{"err": err})
+//            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+//                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+//            return whiskErr
+//        }
+//        sendApi := new(whisk.ApiCreateRequest)
+//        sendApi.ApiDoc = api
+//
+//        retApi, _, err := client.Apis.Insert(sendApi, true)
+//        if err != nil {
+//            whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, %t, false) error: %s\n", api, err)
+//            errMsg := wski18n.T("Unable to update API: {{.err}}", map[string]interface{}{"err": err})
+//            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
+//                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+//            return whiskErr
+//        }
+//
+//        fmt.Fprintf(color.Output,
+//            wski18n.T("{{.ok}} updated API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
+//                map[string]interface{}{
+//                    "ok": color.GreenString("ok:"),
+//                    "path": api.GatewayRelPath,
+//                    "verb": api.GatewayMethod,
+//                    "name": boldString("/"+api.Action.Name),
+//                    "fullpath": getManagedUrl(retApi, api.GatewayRelPath, api.GatewayMethod),
+//                }))
+//        return nil
+//    },
+//}
 
 var apiGetCmd = &cobra.Command{
     Use:           "get BASE_PATH | API_NAME",
@@ -192,14 +197,12 @@ var apiGetCmd = &cobra.Command{
             return whiskErr
         }
 
-        api := new(whisk.Api)
-        options := new(whisk.ApiListOptions)
-
-        options.ApiBasePath = args[0]
-
-        retApi, _, err := client.Apis.Get(api, options)
+        apiGetReq := new(whisk.ApiGetRequest)
+        apiGetReqOptions := new(whisk.ApiGetRequestOptions)
+        apiGetReqOptions.ApiBasePath = args[0]
+        retApi, _, err := client.Apis.Get(apiGetReq, apiGetReqOptions)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Get(%s) error: %s\n", api.Id, err)
+            whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
             errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -256,16 +259,14 @@ var apiDeleteCmd = &cobra.Command{
             return whiskErr
         }
 
-        api := new(whisk.Api)
-        options := new(whisk.ApiOptions)
-        options.Force = true
-
+        apiDeleteReq := new(whisk.ApiDeleteRequest)
+        apiDeleteReqOptions := new(whisk.ApiDeleteRequestOptions)
         // Is the argument a basepath (must start with /) or an API name
         if _, ok := isValidBasepath(args[0]); !ok {
             whisk.Debug(whisk.DbgInfo, "Treating '%s' as an API name; as it does not begin with '/'\n", args[0])
-            options.ApiBasePath = args[0]
+            apiDeleteReqOptions.ApiBasePath = args[0]
         } else {
-            options.ApiBasePath = args[0]
+            apiDeleteReqOptions.ApiBasePath = args[0]
         }
 
         if (len(args) > 1) {
@@ -273,20 +274,20 @@ var apiDeleteCmd = &cobra.Command{
             if whiskErr, ok := isValidRelpath(args[1]); !ok {
                 return whiskErr
             }
-            options.ApiRelPath = args[1]
+            apiDeleteReqOptions.ApiRelPath = args[1]
         }
         if (len(args) > 2) {
             // Is the API verb valid?
             if whiskErr, ok := IsValidApiVerb(args[2]); !ok {
                 return whiskErr
             }
-            options.ApiVerb = strings.ToUpper(args[2])
+            apiDeleteReqOptions.ApiVerb = strings.ToUpper(args[2])
         }
 
-        _, err := client.Apis.Delete(api, options)
+        _, err := client.Apis.Delete(apiDeleteReq, apiDeleteReqOptions)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Delete(%s) error: %s\n", api.Id, err)
-            errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
+            whisk.Debug(whisk.DbgError, "client.Apis.Delete(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
+            errMsg := wski18n.T("Unable to delete API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -297,24 +298,24 @@ var apiDeleteCmd = &cobra.Command{
                 wski18n.T("{{.ok}} deleted API {{.basepath}}\n",
                     map[string]interface{}{
                         "ok": color.GreenString("ok:"),
-                        "basepath": options.ApiBasePath,
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
                     }))
         } else if (len(args) == 2 ) {
             fmt.Fprintf(color.Output,
                 wski18n.T("{{.ok}} deleted {{.path}} from {{.basepath}}\n",
                     map[string]interface{}{
                         "ok": color.GreenString("ok:"),
-                        "path": options.ApiRelPath,
-                        "basepath": options.ApiBasePath,
+                        "path": apiDeleteReqOptions.ApiRelPath,
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
                     }))
         } else {
             fmt.Fprintf(color.Output,
                 wski18n.T("{{.ok}} deleted {{.path}} {{.verb}} from {{.basepath}}\n",
                     map[string]interface{}{
                         "ok": color.GreenString("ok:"),
-                        "path": options.ApiRelPath,
-                        "verb": options.ApiVerb,
-                        "basepath": options.ApiBasePath,
+                        "path": apiDeleteReqOptions.ApiRelPath,
+                        "verb": apiDeleteReqOptions.ApiVerb,
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
                     }))
         }
 
@@ -331,6 +332,8 @@ var apiListCmd = &cobra.Command{
     PreRunE:       setupClientConfig,
     RunE: func(cmd *cobra.Command, args []string) error {
         var err error
+        var retApiList *whisk.ApiListResponse
+        var retApi *whisk.ApiGetResponse
         var retApiArray *whisk.RetApiArray
 
         if whiskErr := checkArgs(args, 0, 3, "Api list",
@@ -338,50 +341,59 @@ var apiListCmd = &cobra.Command{
             return whiskErr
         }
 
-        api := new(whisk.Api)
-        api.Namespace = client.Config.Namespace
+        // Get API request body
+        apiGetReq := new(whisk.ApiGetRequest)
+        apiGetReq.Namespace = client.Config.Namespace
 
-        options := new(whisk.ApiListOptions)
-        options.Limit = flags.common.limit
-        options.Skip = flags.common.skip
+        // Get API request options
+        apiGetReqOptions := new(whisk.ApiGetRequestOptions)
+
+        // List API request query parameters
+        apiListReqOptions := new(whisk.ApiListRequestOptions)
+        apiListReqOptions.Limit = flags.common.limit
+        apiListReqOptions.Skip = flags.common.skip
 
         if (len(args) == 0) {
-            retApiArray, _, err = client.Apis.List(options)
+            retApiList, _, err = client.Apis.List(apiListReqOptions)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "client.Apis.List(%s) error: %s\n", options, err)
+                whisk.Debug(whisk.DbgError, "client.Apis.List(%#v) error: %s\n", apiListReqOptions, err)
                 errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
             }
-            whisk.Debug(whisk.DbgInfo, "client.Apis.List returned: %#v (%+v)\n", retApiArray, retApiArray)
+            whisk.Debug(whisk.DbgInfo, "client.Apis.List returned: %#v (%+v)\n", retApiList, retApiList)
+            // Cast to a common type to allow for code to print out apilist response or apiget response
+            retApiArray = (*whisk.RetApiArray)(retApiList)
         } else {
             // The first argument is either a basepath (must start with /) or an API name
-            options.ApiBasePath = args[0]
+            apiGetReqOptions.ApiBasePath = args[0]
             if (len(args) > 1) {
                 // Is the API path valid?
                 if whiskErr, ok := isValidRelpath(args[1]); !ok {
                     return whiskErr
                 }
-                options.ApiRelPath = args[1]
+                apiGetReqOptions.ApiRelPath = args[1]
             }
             if (len(args) > 2) {
                 // Is the API verb valid?
                 if whiskErr, ok := IsValidApiVerb(args[2]); !ok {
                     return whiskErr
                 }
-                options.ApiVerb = strings.ToUpper(args[2])
+                apiGetReqOptions.ApiVerb = strings.ToUpper(args[2])
             }
 
-            retApiArray, _, err = client.Apis.Get(api, options)
+            retApi, _, err = client.Apis.Get(apiGetReq, apiGetReqOptions)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "client.Apis.Get(%s) error: %s\n", api.Id, err)
+                whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
                 errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
             }
-            whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApiArray)
+            whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApi)
+            // Cast to a common type to allow for code to print out apilist response or apiget response
+            retApiArray = (*whisk.RetApiArray)(retApi)
         }
 
         // Display the APIs - applying any specified filtering
@@ -393,13 +405,13 @@ var apiListCmd = &cobra.Command{
                     }))
 
             for i:=0; i<len(retApiArray.Apis); i++ {
-                printFilteredListApi(retApiArray.Apis[i].ApiValue, api)
+                printFilteredListApi(retApiArray.Apis[i].ApiValue, (*whisk.ApiOptions)(apiGetReqOptions))
             }
         } else {
             // Dynamically create the output format string based on the maximum size of the
             // fully qualified action name and the API Name.
-            maxActionNameSize := min(40, max(len("Action"), getLargestActionNameSize(retApiArray, api)))
-            maxApiNameSize := min(30, max(len("API Name"), getLargestApiNameSize(retApiArray, api)))
+            maxActionNameSize := min(40, max(len("Action"), getLargestActionNameSize(retApiArray, (*whisk.ApiOptions)(apiGetReqOptions))))
+            maxApiNameSize := min(30, max(len("API Name"), getLargestApiNameSize(retApiArray, (*whisk.ApiOptions)(apiGetReqOptions))))
             fmtString = "%-"+strconv.Itoa(maxActionNameSize)+"s %7s %"+strconv.Itoa(maxApiNameSize+1)+"s  %s\n"
 
             fmt.Fprintf(color.Output,
@@ -410,7 +422,7 @@ var apiListCmd = &cobra.Command{
             fmt.Printf(fmtString, "Action", "Verb", "API Name", "URL")
 
             for i:=0; i<len(retApiArray.Apis); i++ {
-                printFilteredListRow(retApiArray.Apis[i].ApiValue, api, maxActionNameSize, maxApiNameSize)
+                printFilteredListRow(retApiArray.Apis[i].ApiValue, (*whisk.ApiOptions)(apiGetReqOptions), maxActionNameSize, maxApiNameSize)
             }
         }
 
@@ -423,20 +435,20 @@ var apiListCmd = &cobra.Command{
  * and some filtering configuration.  For each API endpoint matching the filtering criteria, display
  * each endpoint's configuration - one line per configuration property (action name, verb, api name, api gw url)
  */
-func printFilteredListApi(resultApi *whisk.RetApi, api *whisk.Api) {
+func printFilteredListApi(resultApi *whisk.RetApi, api *whisk.ApiOptions) {
     baseUrl := strings.TrimSuffix(resultApi.BaseUrl, "/")
     apiName := resultApi.Swagger.Info.Title
     basePath := resultApi.Swagger.BasePath
     if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
         for path, _ := range resultApi.Swagger.Paths {
             whisk.Debug(whisk.DbgInfo, "apiGetCmd: comparing api relpath: %s\n", path)
-            if ( len(api.GatewayRelPath) == 0 || path == api.GatewayRelPath) {
+            if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
                 whisk.Debug(whisk.DbgInfo, "apiGetCmd: relpath matches\n")
                 for op, opv  := range resultApi.Swagger.Paths[path] {
                     whisk.Debug(whisk.DbgInfo, "apiGetCmd: comparing operation: '%s'\n", op)
-                    if ( len(api.GatewayMethod) == 0 || strings.ToLower(op) == strings.ToLower(api.GatewayMethod)) {
+                    if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
                         whisk.Debug(whisk.DbgInfo, "apiGetCmd: operation matches: %#v\n", opv)
-                        var actionName = "/"+opv["x-ibm-op-ext"]["actionNamespace"].(string)+"/"+opv["x-ibm-op-ext"]["actionName"].(string)
+                        var actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
                         fmt.Printf("%s: %s\n", wski18n.T("Action"), actionName)
                         fmt.Printf("  %s: %s\n", wski18n.T("API Name"), apiName)
                         fmt.Printf("  %s: %s\n", wski18n.T("Base path"), basePath)
@@ -457,19 +469,19 @@ func printFilteredListApi(resultApi *whisk.RetApi, api *whisk.Api) {
  *
  * NOTE: Large action name and api name value will be truncated by their associated max size parameters.
  */
-func printFilteredListRow(resultApi *whisk.RetApi, api *whisk.Api, maxActionNameSize int, maxApiNameSize int) {
+func printFilteredListRow(resultApi *whisk.RetApi, api *whisk.ApiOptions, maxActionNameSize int, maxApiNameSize int) {
     baseUrl := strings.TrimSuffix(resultApi.BaseUrl, "/")
     apiName := resultApi.Swagger.Info.Title
     if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
         for path, _ := range resultApi.Swagger.Paths {
             whisk.Debug(whisk.DbgInfo, "apiGetCmd: comparing api relpath: %s\n", path)
-            if ( len(api.GatewayRelPath) == 0 || path == api.GatewayRelPath) {
+            if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
                 whisk.Debug(whisk.DbgInfo, "apiGetCmd: relpath matches\n")
                 for op, opv  := range resultApi.Swagger.Paths[path] {
                     whisk.Debug(whisk.DbgInfo, "apiGetCmd: comparing operation: '%s'\n", op)
-                    if ( len(api.GatewayMethod) == 0 || strings.ToLower(op) == strings.ToLower(api.GatewayMethod)) {
+                    if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
                         whisk.Debug(whisk.DbgInfo, "apiGetCmd: operation matches: %#v\n", opv)
-                        var actionName = "/"+opv["x-ibm-op-ext"]["actionNamespace"].(string)+"/"+opv["x-ibm-op-ext"]["actionName"].(string)
+                        var actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
                         fmt.Printf(fmtString,
                             actionName[0 : min(len(actionName), maxActionNameSize)],
                             op,
@@ -482,20 +494,20 @@ func printFilteredListRow(resultApi *whisk.RetApi, api *whisk.Api, maxActionName
     }
 }
 
-func getLargestActionNameSize(retApiArray *whisk.RetApiArray, api *whisk.Api) int {
+func getLargestActionNameSize(retApiArray *whisk.RetApiArray, api *whisk.ApiOptions) int {
     var maxNameSize = 0
     for i:=0; i<len(retApiArray.Apis); i++ {
         var resultApi = retApiArray.Apis[i].ApiValue
         if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
             for path, _ := range resultApi.Swagger.Paths {
                 whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing api relpath: %s\n", path)
-                if ( len(api.GatewayRelPath) == 0 || path == api.GatewayRelPath) {
+                if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
                     whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: relpath matches\n")
                     for op, opv  := range resultApi.Swagger.Paths[path] {
                         whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing operation: '%s'\n", op)
-                        if ( len(api.GatewayMethod) == 0 || strings.ToLower(op) == strings.ToLower(api.GatewayMethod)) {
+                        if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
                             whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: operation matches: %#v\n", opv)
-                            var fullActionName = "/"+opv["x-ibm-op-ext"]["actionNamespace"].(string)+"/"+opv["x-ibm-op-ext"]["actionName"].(string)
+                            var fullActionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
                             if (len(fullActionName) > maxNameSize) {
                                 maxNameSize = len(fullActionName)
                             }
@@ -508,7 +520,7 @@ func getLargestActionNameSize(retApiArray *whisk.RetApiArray, api *whisk.Api) in
     return maxNameSize
 }
 
-func getLargestApiNameSize(retApiArray *whisk.RetApiArray, api *whisk.Api) int {
+func getLargestApiNameSize(retApiArray *whisk.RetApiArray, api *whisk.ApiOptions) int {
     var maxNameSize = 0
     for i:=0; i<len(retApiArray.Apis); i++ {
         var resultApi = retApiArray.Apis[i].ApiValue
@@ -516,11 +528,11 @@ func getLargestApiNameSize(retApiArray *whisk.RetApiArray, api *whisk.Api) int {
         if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
             for path, _ := range resultApi.Swagger.Paths {
                 whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing api relpath: %s\n", path)
-                if ( len(api.GatewayRelPath) == 0 || path == api.GatewayRelPath) {
+                if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
                     whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: relpath matches\n")
                     for op, opv  := range resultApi.Swagger.Paths[path] {
                         whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing operation: '%s'\n", op)
-                        if ( len(api.GatewayMethod) == 0 || strings.ToLower(op) == strings.ToLower(api.GatewayMethod)) {
+                        if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
                             whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: operation matches: %#v\n", opv)
                             if (len(apiName) > maxNameSize) {
                                 maxNameSize = len(apiName)
@@ -727,6 +739,7 @@ func isValidRelpath(relpath string) (error, bool) {
     return nil, true
 }
 
+
 /*
  * Pull the managedUrl (external API URL) from the API configuration
  */
@@ -749,6 +762,665 @@ func getManagedUrl(api *whisk.RetApi, relpath string, operation string) (url str
     return url
 }
 
+/////////////
+// V2 Cmds //
+/////////////
+var apiCreateCmdV2 = &cobra.Command{
+    Use:           "create ([BASE_PATH] API_PATH API_VERB ACTION] | --config-file CFG_FILE) ",
+    Short:         wski18n.T("create a new API"),
+    SilenceUsage:  true,
+    SilenceErrors: true,
+    PreRunE:       setupClientConfig,
+    RunE: func(cmd *cobra.Command, args []string) error {
+
+        var api *whisk.Api
+        var err error
+        var qname *QualifiedName
+
+        if (!hasApiGwAccessToken()) {
+            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            errMsg := wski18n.T("You must login prior to issuing this command.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if (len(args) == 0 && flags.api.configfile == "") {
+            whisk.Debug(whisk.DbgError, "No swagger file and no arguments\n")
+            errMsg := wski18n.T("Invalid argument(s). Specify a swagger file or specify an API base path with an API path, an API verb, and an action name.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return whiskErr
+        } else if (len(args) == 0 && flags.api.configfile != "") {
+            api, err = parseSwaggerApi()
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "parseSwaggerApi() error: %s\n", err)
+                errMsg := wski18n.T("Unable to parse swagger file: {{.err}}", map[string]interface{}{"err": err})
+                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+                return whiskErr
+            }
+        } else {
+            if whiskErr := checkArgs(args, 3, 4, "Api create",
+                wski18n.T("Specify a swagger file or specify an API base path with an API path, an API verb, and an action name.")); whiskErr != nil {
+                return whiskErr
+            }
+            api, qname, err = parseApiV2(cmd, args)
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
+                errMsg := wski18n.T("Unable to parse api command arguments: {{.err}}",
+                    map[string]interface{}{"err": err})
+                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+                return whiskErr
+            }
+
+            // Confirm that the specified action is a web-action
+            if !IsWebAction(client, qname) {
+                whisk.Debug(whisk.DbgError, "IsWebAction(%v) is false\n", qname)
+                errMsg := wski18n.T("API action either does not exist or is not a web-action")
+                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+                return whiskErr
+            }
+        }
+
+        apiCreateReq := new(whisk.ApiCreateRequest)
+        apiCreateReq.ApiDoc = api
+
+        apiCreateReqOptions := new(whisk.ApiCreateRequestOptions)
+        props, _ := readProps(Properties.PropsFile)
+        apiCreateReqOptions.AccessToken = props["BMXTOKEN"]
+        apiCreateReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
+        whisk.Debug(whisk.DbgInfo, "AccessToken: %s\nSpaceGuid: %s\n", apiCreateReqOptions.AccessToken, apiCreateReqOptions.SpaceGuid)
+
+        retApi, _, err := client.Apis.InsertV2(apiCreateReq, apiCreateReqOptions, whisk.DoNotOverwrite)
+        if err != nil {
+            whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, false) error: %s\n", api, err)
+            errMsg := wski18n.T("Unable to create API: {{.err}}", map[string]interface{}{"err": err})
+            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if (api.Swagger == "") {
+            baseUrl := retApi.BaseUrl
+            fmt.Fprintf(color.Output,
+                wski18n.T("{{.ok}} created API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
+                    map[string]interface{}{
+                        "ok": color.GreenString("ok:"),
+                        "path": strings.TrimSuffix(api.GatewayBasePath, "/")+api.GatewayRelPath,
+                        "verb": api.GatewayMethod,
+                        "name": boldString("/"+api.Action.Namespace+"/"+api.Action.Name),
+                        "fullpath": strings.TrimSuffix(baseUrl, "/")+api.GatewayRelPath,
+                    }))
+        } else {
+            whisk.Debug(whisk.DbgInfo, "Processing swagger based create API response\n")
+            baseUrl := retApi.BaseUrl
+            for path, _ := range retApi.Swagger.Paths {
+                managedUrl := strings.TrimSuffix(baseUrl, "/")+path
+                whisk.Debug(whisk.DbgInfo, "Managed path: %s\n",managedUrl)
+                for op, opv  := range retApi.Swagger.Paths[path] {
+                    whisk.Debug(whisk.DbgInfo, "Path operation: %s\n", op)
+                    var fqActionName string
+                    if (len(opv.XOpenWhisk.Package) > 0) {
+                        fqActionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.Package+"/"+opv.XOpenWhisk.ActionName
+                    } else {
+                        fqActionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
+                    }
+                    whisk.Debug(whisk.DbgInfo, "baseUrl %s  Path %s  Path obj %+v\n", baseUrl, path, opv)
+                    fmt.Fprintf(color.Output,
+                        wski18n.T("{{.ok}} created API {{.path}} {{.verb}} for action {{.name}}\n{{.fullpath}}\n",
+                            map[string]interface{}{
+                                "ok": color.GreenString("ok:"),
+                                "path": strings.TrimSuffix(retApi.Swagger.BasePath, "/") + path,
+                                "verb": op,
+                                "name": boldString(fqActionName),
+                                "fullpath": managedUrl,
+                            }))
+                }
+            }
+        }
+
+
+        return nil
+    },
+}
+
+var apiGetCmdV2 = &cobra.Command{
+    Use:           "get BASE_PATH | API_NAME",
+    Short:         wski18n.T("get API details"),
+    SilenceUsage:  true,
+    SilenceErrors: true,
+    PreRunE:       setupClientConfig,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        var err error
+        var isBasePathArg bool = true
+
+        if (!hasApiGwAccessToken()) {
+            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            errMsg := wski18n.T("You must login prior to issuing this command.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if whiskErr := checkArgs(args, 1, 1, "Api get",
+            wski18n.T("An API base path or API name is required.")); whiskErr != nil {
+            return whiskErr
+        }
+
+        apiGetReq := new(whisk.ApiGetRequest)
+        apiGetReqOptions := new(whisk.ApiGetRequestOptions)
+        apiGetReqOptions.ApiBasePath = args[0]
+        props, _ := readProps(Properties.PropsFile)
+        apiGetReqOptions.AccessToken = props["BMXTOKEN"]
+        apiGetReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
+
+
+        retApi, _, err := client.Apis.GetV2(apiGetReq, apiGetReqOptions)
+        if err != nil {
+            whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
+            errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+        whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApi)
+
+        var displayResult interface{} = nil
+        if (flags.common.detail) {
+            if (retApi.Apis != nil && len(retApi.Apis) > 0 &&
+            retApi.Apis[0].ApiValue != nil) {
+                displayResult = retApi.Apis[0].ApiValue
+            } else {
+                whisk.Debug(whisk.DbgError, "No result object returned\n")
+            }
+        } else {
+            if (retApi.Apis != nil && len(retApi.Apis) > 0 &&
+            retApi.Apis[0].ApiValue != nil &&
+            retApi.Apis[0].ApiValue.Swagger != nil) {
+                displayResult = retApi.Apis[0].ApiValue.Swagger
+            } else {
+                whisk.Debug(whisk.DbgError, "No swagger returned\n")
+            }
+        }
+        if (displayResult == nil) {
+            var errMsg string
+            if (isBasePathArg) {
+                errMsg = wski18n.T("API does not exist for basepath {{.basepath}}",
+                    map[string]interface{}{"basepath": args[0]})
+            } else {
+                errMsg = wski18n.T("API does not exist for API name {{.apiname}}",
+                    map[string]interface{}{"apiname": args[0]})
+            }
+
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+        printJSON(displayResult)
+
+        return nil
+    },
+}
+
+var apiDeleteCmdV2 = &cobra.Command{
+    Use:           "delete BASE_PATH | API_NAME [API_PATH [API_VERB]]",
+    Short:         wski18n.T("delete an API"),
+    SilenceUsage:  true,
+    SilenceErrors: true,
+    PreRunE:       setupClientConfig,
+    RunE: func(cmd *cobra.Command, args []string) error {
+
+        if (!hasApiGwAccessToken()) {
+            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            errMsg := wski18n.T("You must login prior to issuing this command.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if whiskErr := checkArgs(args, 1, 3, "Api delete",
+            wski18n.T("An API base path or API name is required.  An optional API relative path and operation may also be provided.")); whiskErr != nil {
+            return whiskErr
+        }
+
+        apiDeleteReq := new(whisk.ApiDeleteRequest)
+        apiDeleteReqOptions := new(whisk.ApiDeleteRequestOptions)
+        props, _ := readProps(Properties.PropsFile)
+        apiDeleteReqOptions.AccessToken = props["BMXTOKEN"]
+        apiDeleteReqOptions.SpaceGuid = strings.Split(props["AUTH"], ":")[0]
+
+        // Is the argument a basepath (must start with /) or an API name
+        if _, ok := isValidBasepath(args[0]); !ok {
+            whisk.Debug(whisk.DbgInfo, "Treating '%s' as an API name; as it does not begin with '/'\n", args[0])
+            apiDeleteReqOptions.ApiBasePath = args[0]
+        } else {
+            apiDeleteReqOptions.ApiBasePath = args[0]
+        }
+
+        if (len(args) > 1) {
+            // Is the API path valid?
+            if whiskErr, ok := isValidRelpath(args[1]); !ok {
+                return whiskErr
+            }
+            apiDeleteReqOptions.ApiRelPath = args[1]
+        }
+        if (len(args) > 2) {
+            // Is the API verb valid?
+            if whiskErr, ok := IsValidApiVerb(args[2]); !ok {
+                return whiskErr
+            }
+            apiDeleteReqOptions.ApiVerb = strings.ToUpper(args[2])
+        }
+
+        _, err := client.Apis.DeleteV2(apiDeleteReq, apiDeleteReqOptions)
+        if err != nil {
+            whisk.Debug(whisk.DbgError, "client.Apis.Delete(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
+            errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
+            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if (len(args) == 1) {
+            fmt.Fprintf(color.Output,
+                wski18n.T("{{.ok}} deleted API {{.basepath}}\n",
+                    map[string]interface{}{
+                        "ok": color.GreenString("ok:"),
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
+                    }))
+        } else if (len(args) == 2 ) {
+            fmt.Fprintf(color.Output,
+                wski18n.T("{{.ok}} deleted {{.path}} from {{.basepath}}\n",
+                    map[string]interface{}{
+                        "ok": color.GreenString("ok:"),
+                        "path": apiDeleteReqOptions.ApiRelPath,
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
+                    }))
+        } else {
+            fmt.Fprintf(color.Output,
+                wski18n.T("{{.ok}} deleted {{.path}} {{.verb}} from {{.basepath}}\n",
+                    map[string]interface{}{
+                        "ok": color.GreenString("ok:"),
+                        "path": apiDeleteReqOptions.ApiRelPath,
+                        "verb": apiDeleteReqOptions.ApiVerb,
+                        "basepath": apiDeleteReqOptions.ApiBasePath,
+                    }))
+        }
+
+        return nil
+    },
+}
+
+var apiListCmdV2 = &cobra.Command{
+    Use:           "list [[BASE_PATH | API_NAME] [API_PATH [API_VERB]]",
+    Short:         wski18n.T("list APIs"),
+    SilenceUsage:  true,
+    SilenceErrors: true,
+    PreRunE:       setupClientConfig,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        var err error
+        var retApiList *whisk.ApiListResponseV2
+        var retApi *whisk.ApiGetResponseV2
+        var retApiArray *whisk.RetApiArrayV2
+
+        if (!hasApiGwAccessToken()) {
+            whisk.Debug(whisk.DbgError, "No BMXTOKEN in properties file\n")
+            errMsg := wski18n.T("You must login prior to issuing this command.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return whiskErr
+        }
+
+        if whiskErr := checkArgs(args, 0, 3, "Api list",
+            wski18n.T("Optional parameters are: API base path (or API name), API relative path and operation.")); whiskErr != nil {
+            return whiskErr
+        }
+
+        props, _ := readProps(Properties.PropsFile)
+        accesstoken := props["BMXTOKEN"]
+        spaceguid := strings.Split(props["AUTH"], ":")[0]
+
+        // Get API request body
+        apiGetReq := new(whisk.ApiGetRequest)
+        apiGetReq.Namespace = client.Config.Namespace
+        // Get API request options
+        apiGetReqOptions := new(whisk.ApiGetRequestOptions)
+        apiGetReqOptions.AccessToken = accesstoken
+        apiGetReqOptions.SpaceGuid = spaceguid
+
+        // List API request query parameters
+        apiListReqOptions := new(whisk.ApiListRequestOptions)
+        apiListReqOptions.Limit = flags.common.limit
+        apiListReqOptions.Skip = flags.common.skip
+        apiListReqOptions.AccessToken = accesstoken
+        apiListReqOptions.SpaceGuid = spaceguid
+
+        if (len(args) == 0) {
+            retApiList, _, err = client.Apis.ListV2(apiListReqOptions)
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "client.Apis.List(%#v) error: %s\n", apiListReqOptions, err)
+                errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                return whiskErr
+            }
+            whisk.Debug(whisk.DbgInfo, "client.Apis.List returned: %#v (%+v)\n", retApiList, retApiList)
+            // Cast to a common type to allow for code to print out apilist response or apiget response
+            retApiArray = (*whisk.RetApiArrayV2)(retApiList)
+        } else {
+            // The first argument is either a basepath (must start with /) or an API name
+            apiGetReqOptions.ApiBasePath = args[0]
+            if (len(args) > 1) {
+                // Is the API path valid?
+                if whiskErr, ok := isValidRelpath(args[1]); !ok {
+                    return whiskErr
+                }
+                apiGetReqOptions.ApiRelPath = args[1]
+            }
+            if (len(args) > 2) {
+                // Is the API verb valid?
+                if whiskErr, ok := IsValidApiVerb(args[2]); !ok {
+                    return whiskErr
+                }
+                apiGetReqOptions.ApiVerb = strings.ToUpper(args[2])
+            }
+
+            retApi, _, err = client.Apis.GetV2(apiGetReq, apiGetReqOptions)
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
+                errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
+                whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                return whiskErr
+            }
+            whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApi)
+            // Cast to a common type to allow for code to print out apilist response or apiget response
+            retApiArray = (*whisk.RetApiArrayV2)(retApi)
+        }
+
+        // Display the APIs - applying any specified filtering
+        if (flags.common.full) {
+            fmt.Fprintf(color.Output,
+                wski18n.T("{{.ok}} APIs\n",
+                    map[string]interface{}{
+                        "ok": color.GreenString("ok:"),
+                    }))
+
+            for i:=0; i<len(retApiArray.Apis); i++ {
+                printFilteredListApiV2(retApiArray.Apis[i].ApiValue, (*whisk.ApiOptions)(apiGetReqOptions))
+            }
+        } else {
+            if (len(retApiArray.Apis) > 0) {
+                // Dynamically create the output format string based on the maximum size of the
+                // fully qualified action name and the API Name.
+                maxActionNameSize := min(40, max(len("Action"), getLargestActionNameSizeV2(retApiArray, (*whisk.ApiOptions)(apiGetReqOptions))))
+                maxApiNameSize := min(30, max(len("API Name"), getLargestApiNameSizeV2(retApiArray, (*whisk.ApiOptions)(apiGetReqOptions))))
+                fmtString = "%-"+strconv.Itoa(maxActionNameSize)+"s %7s %"+strconv.Itoa(maxApiNameSize+1)+"s  %s\n"
+                fmt.Fprintf(color.Output,
+                    wski18n.T("{{.ok}} APIs\n",
+                        map[string]interface{}{
+                            "ok": color.GreenString("ok:"),
+                        }))
+                fmt.Printf(fmtString, "Action", "Verb", "API Name", "URL")
+                for i:=0; i<len(retApiArray.Apis); i++ {
+                    printFilteredListRowV2(retApiArray.Apis[i].ApiValue, (*whisk.ApiOptions)(apiGetReqOptions), maxActionNameSize, maxApiNameSize)
+                }
+            } else {
+                fmt.Fprintf(color.Output,
+                    wski18n.T("{{.ok}} APIs\n",
+                        map[string]interface{}{
+                            "ok": color.GreenString("ok:"),
+                        }))
+                fmt.Printf(fmtString, "Action", "Verb", "API Name", "URL")
+            }
+        }
+
+        return nil
+    },
+}
+
+/*
+ * Takes an API object (containing one more more single basepath/relpath/operation triplets)
+ * and some filtering configuration.  For each API endpoint matching the filtering criteria, display
+ * each endpoint's configuration - one line per configuration property (action name, verb, api name, api gw url)
+ */
+func printFilteredListApiV2(resultApi *whisk.RetApiV2, api *whisk.ApiOptions) {
+    baseUrl := strings.TrimSuffix(resultApi.BaseUrl, "/")
+    apiName := resultApi.Swagger.Info.Title
+    basePath := resultApi.Swagger.BasePath
+    if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
+        for path, _ := range resultApi.Swagger.Paths {
+            whisk.Debug(whisk.DbgInfo, "printFilteredListApiV2: comparing api relpath: %s\n", path)
+            if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
+                whisk.Debug(whisk.DbgInfo, "printFilteredListApiV2: relpath matches\n")
+                for op, opv  := range resultApi.Swagger.Paths[path] {
+                    whisk.Debug(whisk.DbgInfo, "printFilteredListApiV2: comparing operation: '%s'\n", op)
+                    if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
+                        whisk.Debug(whisk.DbgInfo, "printFilteredListApiV2: operation matches: %#v\n", opv)
+                        var actionName string
+                        if (len(opv.XOpenWhisk.Package) > 0) {
+                            actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.Package+"/"+opv.XOpenWhisk.ActionName
+                        } else {
+                            actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
+                        }
+                        fmt.Printf("%s: %s\n", wski18n.T("Action"), actionName)
+                        fmt.Printf("  %s: %s\n", wski18n.T("API Name"), apiName)
+                        fmt.Printf("  %s: %s\n", wski18n.T("Base path"), basePath)
+                        fmt.Printf("  %s: %s\n", wski18n.T("Path"), path)
+                        fmt.Printf("  %s: %s\n", wski18n.T("Verb"), op)
+                        fmt.Printf("  %s: %s\n", wski18n.T("URL"), baseUrl+path)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+ * Takes an API object (containing one more more single basepath/relpath/operation triplets)
+ * and some filtering configuration.  For each API matching the filtering criteria, display the API
+ * on a single line (action name, verb, api name, api gw url).
+ *
+ * NOTE: Large action name and api name value will be truncated by their associated max size parameters.
+ */
+func printFilteredListRowV2(resultApi *whisk.RetApiV2, api *whisk.ApiOptions, maxActionNameSize int, maxApiNameSize int) {
+    baseUrl := strings.TrimSuffix(resultApi.BaseUrl, "/")
+    apiName := resultApi.Swagger.Info.Title
+    if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
+        for path, _ := range resultApi.Swagger.Paths {
+            whisk.Debug(whisk.DbgInfo, "printFilteredListRowV2: comparing api relpath: %s\n", path)
+            if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
+                whisk.Debug(whisk.DbgInfo, "printFilteredListRowV2: relpath matches\n")
+                for op, opv  := range resultApi.Swagger.Paths[path] {
+                    whisk.Debug(whisk.DbgInfo, "printFilteredListRowV2: comparing operation: '%s'\n", op)
+                    if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
+                        whisk.Debug(whisk.DbgInfo, "printFilteredListRowV2: operation matches: %#v\n", opv)
+                        var actionName string
+                        if (len(opv.XOpenWhisk.Package) > 0) {
+                            actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.Package+"/"+opv.XOpenWhisk.ActionName
+                        } else {
+                            actionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
+                        }
+                        fmt.Printf(fmtString,
+                            actionName[0 : min(len(actionName), maxActionNameSize)],
+                            op,
+                            apiName[0 : min(len(apiName), maxApiNameSize)],
+                            baseUrl+path)
+                    }
+                }
+            }
+        }
+    }
+}
+
+func getLargestActionNameSizeV2(retApiArray *whisk.RetApiArrayV2, api *whisk.ApiOptions) int {
+    var maxNameSize = 0
+    for i:=0; i<len(retApiArray.Apis); i++ {
+        var resultApi = retApiArray.Apis[i].ApiValue
+        if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
+            for path, _ := range resultApi.Swagger.Paths {
+                whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing api relpath: %s\n", path)
+                if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
+                    whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: relpath matches\n")
+                    for op, opv  := range resultApi.Swagger.Paths[path] {
+                        whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing operation: '%s'\n", op)
+                        if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
+                            whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: operation matches: %#v\n", opv)
+                            var fullActionName string
+                            if (len(opv.XOpenWhisk.Package) > 0) {
+                                fullActionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.Package+"/"+opv.XOpenWhisk.ActionName
+                            } else {
+                                fullActionName = "/"+opv.XOpenWhisk.Namespace+"/"+opv.XOpenWhisk.ActionName
+                            }
+                            if (len(fullActionName) > maxNameSize) {
+                                maxNameSize = len(fullActionName)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return maxNameSize
+}
+
+func getLargestApiNameSizeV2(retApiArray *whisk.RetApiArrayV2, api *whisk.ApiOptions) int {
+    var maxNameSize = 0
+    for i:=0; i<len(retApiArray.Apis); i++ {
+        var resultApi = retApiArray.Apis[i].ApiValue
+        apiName := resultApi.Swagger.Info.Title
+        if (resultApi.Swagger != nil && resultApi.Swagger.Paths != nil) {
+            for path, _ := range resultApi.Swagger.Paths {
+                whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing api relpath: %s\n", path)
+                if ( len(api.ApiRelPath) == 0 || path == api.ApiRelPath) {
+                    whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: relpath matches\n")
+                    for op, opv  := range resultApi.Swagger.Paths[path] {
+                        whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: comparing operation: '%s'\n", op)
+                        if ( len(api.ApiVerb) == 0 || strings.ToLower(op) == strings.ToLower(api.ApiVerb)) {
+                            whisk.Debug(whisk.DbgInfo, "getLargestActionNameSize: operation matches: %#v\n", opv)
+                            if (len(apiName) > maxNameSize) {
+                                maxNameSize = len(apiName)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return maxNameSize
+}
+
+func hasApiGwAccessToken() bool {
+    props, _ := readProps(Properties.PropsFile)
+    return (len(props["BMXTOKEN"]) > 0)
+}
+
+/*
+ * if # args = 4
+ * args[0] = API base path
+ * args[0] = API relative path
+ * args[1] = API verb
+ * args[2] = Optional.  Action name (may or may not be qualified with namespace and package name)
+ *
+ * if # args = 3
+ * args[0] = API relative path
+ * args[1] = API verb
+ * args[2] = Optional.  Action name (may or may not be qualified with namespace and package name)
+ */
+func parseApiV2(cmd *cobra.Command, args []string) (*whisk.Api, *QualifiedName, error) {
+    var err error
+    var basepath string = "/"
+    var apiname string
+    var basepathArgIsApiName = false;
+
+    api := new(whisk.Api)
+
+    if (len(args) > 3) {
+        // Is the argument a basepath (must start with /) or an API name
+        if _, ok := isValidBasepath(args[0]); !ok {
+            whisk.Debug(whisk.DbgInfo, "Treating '%s' as an API name; as it does not begin with '/'\n", args[0])
+            basepathArgIsApiName = true;
+        }
+        basepath = args[0]
+
+        // Shift the args so the remaining code works with or without the explicit base path arg
+        args = args[1:]
+    }
+
+    // Is the API path valid?
+    if (len(args) > 0) {
+        if whiskErr, ok := isValidRelpath(args[0]); !ok {
+            return nil, nil, whiskErr
+        }
+        api.GatewayRelPath = args[0]    // Maintain case as URLs may be case-sensitive
+    }
+
+    // Is the API verb valid?
+    if (len(args) > 1) {
+        if whiskErr, ok := IsValidApiVerb(args[1]); !ok {
+            return nil, nil, whiskErr
+        }
+        api.GatewayMethod = strings.ToUpper(args[1])
+    }
+
+    // Is the specified action name valid?
+    var qName QualifiedName
+    if (len(args) == 3) {
+        qName = QualifiedName{}
+        qName, err = parseQualifiedName(args[2])
+        if err != nil {
+            whisk.Debug(whisk.DbgError, "parseQualifiedName(%s) failed: %s\n", args[2], err)
+            errMsg := wski18n.T("'{{.name}}' is not a valid action name: {{.err}}",
+                map[string]interface{}{"name": args[2], "err": err})
+            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return nil, nil, whiskErr
+        }
+        if (qName.entityName == "") {
+            whisk.Debug(whisk.DbgError, "Action name '%s' is invalid\n", args[2])
+            errMsg := wski18n.T("'{{.name}}' is not a valid action name.", map[string]interface{}{"name": args[2]})
+            whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return nil, nil, whiskErr
+        }
+    }
+
+    if ( len(flags.api.apiname) > 0 ) {
+        if (basepathArgIsApiName) {
+            // Specifying API name as argument AND as a --apiname option value is invalid
+            whisk.Debug(whisk.DbgError, "API is specified as an argument '%s' and as a flag '%s'\n", basepath, flags.api.apiname)
+            errMsg := wski18n.T("An API name can only be specified once.")
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+            return nil, nil, whiskErr
+        }
+        apiname = flags.api.apiname
+    }
+
+    api.Namespace = client.Config.Namespace
+    api.Action = new(whisk.ApiAction)
+    var urlActionPackage string
+    if (len(qName.packageName) > 0) {
+        urlActionPackage = qName.packageName
+    } else {
+        urlActionPackage = "default"
+    }
+    api.Action.BackendUrl = "https://" + client.Config.Host + "/api/v1/web/" + qName.namespace + "/" + urlActionPackage + "/" + qName.actionName + ".http"
+    api.Action.BackendMethod = api.GatewayMethod
+    api.Action.Name = qName.entityName
+    api.Action.Namespace = qName.namespace
+    api.Action.Auth = client.Config.AuthToken
+    api.ApiName = apiname
+    api.GatewayBasePath = basepath
+    if (!basepathArgIsApiName) { api.Id = "API:"+api.Namespace+":"+api.GatewayBasePath }
+
+    whisk.Debug(whisk.DbgInfo, "Parsed api struct: %#v\n", api)
+    return api, &qName, nil
+}
+
 ///////////
 // Flags //
 ///////////
@@ -756,22 +1428,31 @@ func getManagedUrl(api *whisk.RetApi, relpath string, operation string) (url str
 func init() {
     apiCreateCmd.Flags().StringVarP(&flags.api.apiname, "apiname", "n", "", wski18n.T("Friendly name of the API; ignored when CFG_FILE is specified (default BASE_PATH)"))
     apiCreateCmd.Flags().StringVarP(&flags.api.configfile, "config-file", "c", "", wski18n.T("`CFG_FILE` containing API configuration in swagger JSON format"))
-
     //apiUpdateCmd.Flags().StringVarP(&flags.api.action, "action", "a", "", wski18n.T("`ACTION` to invoke when API is called"))
     //apiUpdateCmd.Flags().StringVarP(&flags.api.path, "path", "p", "", wski18n.T("relative `PATH` of API"))
     //apiUpdateCmd.Flags().StringVarP(&flags.api.verb, "method", "m", "", wski18n.T("API `VERB`"))
-
     apiGetCmd.Flags().BoolVarP(&flags.common.detail, "full", "f", false, wski18n.T("display full API configuration details"))
-
     apiListCmd.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))
     apiListCmd.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))
     apiListCmd.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("display full description of each API"))
-
     apiExperimentalCmd.AddCommand(
         apiCreateCmd,
         //apiUpdateCmd,
         apiGetCmd,
         apiDeleteCmd,
         apiListCmd,
+    )
+
+    apiCreateCmdV2.Flags().StringVarP(&flags.api.apiname, "apiname", "n", "", wski18n.T("Friendly name of the API; ignored when CFG_FILE is specified (default BASE_PATH)"))
+    apiCreateCmdV2.Flags().StringVarP(&flags.api.configfile, "config-file", "c", "", wski18n.T("`CFG_FILE` containing API configuration in swagger JSON format"))
+    apiGetCmdV2.Flags().BoolVarP(&flags.common.detail, "full", "f", false, wski18n.T("display full API configuration details"))
+    apiListCmdV2.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))
+    apiListCmdV2.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))
+    apiListCmdV2.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("display full description of each API"))
+    apiCmd.AddCommand(
+        apiCreateCmdV2,
+        apiGetCmdV2,
+        apiDeleteCmdV2,
+        apiListCmdV2,
     )
 }

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -203,7 +203,7 @@ var apiGetCmd = &cobra.Command{
         retApi, _, err := client.Apis.Get(apiGetReq, apiGetReqOptions)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
-            errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+            errMsg := wski18n.T("Unable to get API '{{.name}}': {{.err}}", map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
@@ -357,7 +357,7 @@ var apiListCmd = &cobra.Command{
             retApiList, _, err = client.Apis.List(apiListReqOptions)
             if err != nil {
                 whisk.Debug(whisk.DbgError, "client.Apis.List(%#v) error: %s\n", apiListReqOptions, err)
-                errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+                errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
@@ -807,7 +807,7 @@ var apiCreateCmdV2 = &cobra.Command{
             }
             api, qname, err = parseApiV2(cmd, args)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "parseApi(%s, %s) error: %s\n", cmd, args, err)
+                whisk.Debug(whisk.DbgError, "parseApiV2(%s, %s) error: %s\n", cmd, args, err)
                 errMsg := wski18n.T("Unable to parse api command arguments: {{.err}}",
                     map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
@@ -816,9 +816,8 @@ var apiCreateCmdV2 = &cobra.Command{
             }
 
             // Confirm that the specified action is a web-action
-            if !isWebAction(client, *qname) {
-                whisk.Debug(whisk.DbgError, "IsWebAction(%v) is false\n", qname)
-                errMsg := wski18n.T("API action either does not exist or is not a web-action")
+            if ok, errMsg := isWebAction(client, *qname); !ok {
+                whisk.Debug(whisk.DbgError, "isWebAction(%v) is false\n", qname)
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
                 return whiskErr
@@ -836,7 +835,7 @@ var apiCreateCmdV2 = &cobra.Command{
 
         retApi, _, err := client.Apis.InsertV2(apiCreateReq, apiCreateReqOptions, whisk.DoNotOverwrite)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Insert(%#v, false) error: %s\n", api, err)
+            whisk.Debug(whisk.DbgError, "client.Apis.InsertV2(%#v, false) error: %s\n", api, err)
             errMsg := wski18n.T("Unable to create API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_NETWORK,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -920,13 +919,13 @@ var apiGetCmdV2 = &cobra.Command{
 
         retApi, _, err := client.Apis.GetV2(apiGetReq, apiGetReqOptions)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
-            errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+            whisk.Debug(whisk.DbgError, "client.Apis.GetV2(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
+            errMsg := wski18n.T("Unable to get API '{{.name}}': {{.err}}", map[string]interface{}{"name": args[0], "err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
         }
-        whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApi)
+        whisk.Debug(whisk.DbgInfo, "client.Apis.GetV2 returned: %#v\n", retApi)
 
         var displayResult interface{} = nil
         if (flags.common.detail) {
@@ -1017,7 +1016,7 @@ var apiDeleteCmdV2 = &cobra.Command{
 
         _, err := client.Apis.DeleteV2(apiDeleteReq, apiDeleteReqOptions)
         if err != nil {
-            whisk.Debug(whisk.DbgError, "client.Apis.Delete(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
+            whisk.Debug(whisk.DbgError, "client.Apis.DeleteV2(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
             errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -1101,13 +1100,13 @@ var apiListCmdV2 = &cobra.Command{
         if (len(args) == 0) {
             retApiList, _, err = client.Apis.ListV2(apiListReqOptions)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "client.Apis.List(%#v) error: %s\n", apiListReqOptions, err)
-                errMsg := wski18n.T("Unable to get API: {{.err}}", map[string]interface{}{"err": err})
+                whisk.Debug(whisk.DbgError, "client.Apis.ListV2(%#v) error: %s\n", apiListReqOptions, err)
+                errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
             }
-            whisk.Debug(whisk.DbgInfo, "client.Apis.List returned: %#v (%+v)\n", retApiList, retApiList)
+            whisk.Debug(whisk.DbgInfo, "client.Apis.ListV2 returned: %#v (%+v)\n", retApiList, retApiList)
             // Cast to a common type to allow for code to print out apilist response or apiget response
             retApiArray = (*whisk.RetApiArrayV2)(retApiList)
         } else {
@@ -1130,13 +1129,13 @@ var apiListCmdV2 = &cobra.Command{
 
             retApi, _, err = client.Apis.GetV2(apiGetReq, apiGetReqOptions)
             if err != nil {
-                whisk.Debug(whisk.DbgError, "client.Apis.Get(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
+                whisk.Debug(whisk.DbgError, "client.Apis.GetV2(%#v, %#v) error: %s\n", apiGetReq, apiGetReqOptions, err)
                 errMsg := wski18n.T("Unable to obtain the API list: {{.err}}", map[string]interface{}{"err": err})
                 whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXITCODE_ERR_GENERAL,
                     whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
                 return whiskErr
             }
-            whisk.Debug(whisk.DbgInfo, "client.Apis.Get returned: %#v\n", retApi)
+            whisk.Debug(whisk.DbgInfo, "client.Apis.GetV2 returned: %#v\n", retApi)
             // Cast to a common type to allow for code to print out apilist response or apiget response
             retApiArray = (*whisk.RetApiArrayV2)(retApi)
         }
@@ -1408,7 +1407,7 @@ func parseApiV2(cmd *cobra.Command, args []string) (*whisk.Api, *QualifiedName, 
     } else {
         urlActionPackage = "default"
     }
-    api.Action.BackendUrl = "https://" + client.Config.Host + "/api/v1/web/" + qName.namespace + "/" + urlActionPackage + "/" + qName.actionName + ".http"
+    api.Action.BackendUrl = "https://" + client.Config.Host + "/api/v1/web/" + qName.namespace + "/" + urlActionPackage + "/" + qName.entity + ".http"
     api.Action.BackendMethod = api.GatewayMethod
     api.Action.Name = qName.entityName
     api.Action.Namespace = qName.namespace

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -44,6 +44,7 @@ type QualifiedName struct {
     namespace   string
     packageName string
     entityName  string
+    actionName  string
 }
 
 func (qName QualifiedName) String() string {
@@ -99,6 +100,10 @@ func parseQualifiedName(name string) (QualifiedName, error) {
         }
 
         qualifiedName.entityName = strings.Join(parts[2:], "/")
+        if len(parts) == 4 {
+            qualifiedName.packageName = parts[2]
+        }
+        qualifiedName.actionName = parts[len(parts)-1]
     } else {
         if len(name) == 0 || name == "." {
             whisk.Debug(whisk.DbgError, "A valid qualified name was not detected\n")
@@ -107,12 +112,19 @@ func parseQualifiedName(name string) (QualifiedName, error) {
             return qualifiedName, err
         }
 
+        parts := strings.Split(name, "/")
+        qualifiedName.actionName = parts[len(parts)-1]
+        if len(parts) == 2 {
+            qualifiedName.packageName = parts[0]
+        }
         qualifiedName.entityName = name
         qualifiedName.namespace = getNamespace()
     }
 
     whisk.Debug(whisk.DbgInfo, "Qualified entityName: %s\n", qualifiedName.entityName)
-    whisk.Debug(whisk.DbgInfo, "Qaulified namespace: %s\n", qualifiedName.namespace)
+    whisk.Debug(whisk.DbgInfo, "Qualified action namespace: %s\n", qualifiedName.namespace)
+    whisk.Debug(whisk.DbgInfo, "Qualified action package: %s\n", qualifiedName.packageName)
+    whisk.Debug(whisk.DbgInfo, "Qualified action name: %s\n", qualifiedName.actionName)
 
     return qualifiedName, nil
 }

--- a/tools/cli/go-whisk-cli/commands/util.go
+++ b/tools/cli/go-whisk-cli/commands/util.go
@@ -41,10 +41,10 @@ import (
 )
 
 type QualifiedName struct {
-    namespace   string
-    packageName string
-    entityName  string
-    actionName  string
+    namespace   string  // namespace. does not include leading '/'.  may be "" (i.e. default namespace)
+    packageName string  // package.  may be "".  does not include leading/trailing '/'
+    entity      string  // entity.  should not be ""
+    entityName  string  // pkg+entity
 }
 
 func (qName QualifiedName) String() string {
@@ -103,7 +103,7 @@ func parseQualifiedName(name string) (QualifiedName, error) {
         if len(parts) == 4 {
             qualifiedName.packageName = parts[2]
         }
-        qualifiedName.actionName = parts[len(parts)-1]
+        qualifiedName.entity = parts[len(parts)-1]
     } else {
         if len(name) == 0 || name == "." {
             whisk.Debug(whisk.DbgError, "A valid qualified name was not detected\n")
@@ -113,7 +113,7 @@ func parseQualifiedName(name string) (QualifiedName, error) {
         }
 
         parts := strings.Split(name, "/")
-        qualifiedName.actionName = parts[len(parts)-1]
+        qualifiedName.entity = parts[len(parts)-1]
         if len(parts) == 2 {
             qualifiedName.packageName = parts[0]
         }
@@ -121,10 +121,10 @@ func parseQualifiedName(name string) (QualifiedName, error) {
         qualifiedName.namespace = getNamespace()
     }
 
-    whisk.Debug(whisk.DbgInfo, "Qualified entityName: %s\n", qualifiedName.entityName)
-    whisk.Debug(whisk.DbgInfo, "Qualified action namespace: %s\n", qualifiedName.namespace)
-    whisk.Debug(whisk.DbgInfo, "Qualified action package: %s\n", qualifiedName.packageName)
-    whisk.Debug(whisk.DbgInfo, "Qualified action name: %s\n", qualifiedName.actionName)
+    whisk.Debug(whisk.DbgInfo, "Qualified pkg+entity (EntityName): %s\n", qualifiedName.entityName)
+    whisk.Debug(whisk.DbgInfo, "Qualified namespace: %s\n", qualifiedName.namespace)
+    whisk.Debug(whisk.DbgInfo, "Qualified package: %s\n", qualifiedName.packageName)
+    whisk.Debug(whisk.DbgInfo, "Qualified entity: %s\n", qualifiedName.entity)
 
     return qualifiedName, nil
 }

--- a/tools/cli/go-whisk-cli/commands/wsk.go
+++ b/tools/cli/go-whisk-cli/commands/wsk.go
@@ -48,6 +48,7 @@ func init() {
         namespaceCmd,
         listCmd,
         apiExperimentalCmd,
+        apiCmd,
     )
 
     WskCmd.PersistentFlags().BoolVarP(&flags.global.verbose, "verbose", "v", false, wski18n.T("verbose output"))

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1216,8 +1216,8 @@
     "translation": "delete an API"
   },
   {
-    "id": "Unable to delete action: {{.err}}",
-    "translation": "Unable to delete action: {{.err}}"
+    "id": "Unable to delete API: {{.err}}",
+    "translation": "Unable to delete API: {{.err}}"
   },
   {
     "id": "{{.ok}} deleted API {{.basepath}}\n",
@@ -1374,5 +1374,41 @@
   {
     "id": "Invalid argument '{{.arg}}' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'.",
     "translation": "Invalid argument '{{.arg}}' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'."
+  },
+  {
+    "id": "API action either does not exist or is not a web-action",
+    "translation": "API action either does not exist or is not a web-action"
+  },
+  {
+    "id": "Invalid configuration. The x-openwhisk stanza is missing.",
+    "translation": "Invalid configuration. The x-openwhisk stanza is missing."
+  },
+  {
+    "id": "Internal error. Missing value stanza in API configuration response",
+    "translation": "Internal error. Missing value stanza in API configuration response"
+  },
+  {
+    "id": "Internal error. Missing apidoc stanza in API configuration",
+    "translation": "Internal error. Missing apidoc stanza in API configuration"
+  },
+  {
+    "id": "Missing operationId field in API configuration for operation {{.op}}",
+    "translation": "Missing operationId field in API configuration for operation {{.op}}"
+  },
+  {
+    "id": "Missing x-openwhisk stanza in API configuration for operation {{.op}}",
+    "translation": "Missing x-openwhisk stanza in API configuration for operation {{.op}}"
+  },
+  {
+    "id": "Missing x-openwhisk.namespace field in API configuration for operation {{.op}}",
+    "translation": "Missing x-openwhisk.namespace field in API configuration for operation {{.op}}"
+  },
+  {
+    "id": "Missing x-openwhisk.action field in API configuration for operation {{.op}}",
+    "translation": "Missing x-openwhisk.action field in API configuration for operation {{.op}}"
+  },
+  {
+    "id": "Missing x-openwhisk.url field in API configuration for operation {{.op}}",
+    "translation": "Missing x-openwhisk.url field in API configuration for operation {{.op}}"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1410,5 +1410,25 @@
   {
     "id": "Missing x-openwhisk.url field in API configuration for operation {{.op}}",
     "translation": "Missing x-openwhisk.url field in API configuration for operation {{.op}}"
+  },
+  {
+    "id": "COMING SOON - work with APIs",
+    "translation": "COMING SOON - work with APIs"
+  },
+  {
+    "id": "COMING SOON - create a new API",
+    "translation": "COMING SOON - create a new API"
+  },
+  {
+    "id": "COMING SOON - get API details",
+    "translation": "COMING SOON - get API details"
+  },
+  {
+    "id": "COMING SOON - delete an API",
+    "translation": "COMING SOON - delete an API"
+  },
+  {
+    "id": "COMING SOON - list APIs",
+    "translation": "COMING SOON - list APIs"
   }
 ]

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1208,8 +1208,8 @@
     "translation": "get API"
   },
   {
-    "id": "Unable to get API: {{.err}}",
-    "translation": "Unable to get API: {{.err}}"
+    "id": "Unable to get API '{{.name}}': {{.err}}",
+    "translation": "Unable to get API '{{.name}}': {{.err}}"
   },
   {
     "id": "delete an API",
@@ -1376,8 +1376,12 @@
     "translation": "Invalid argument '{{.arg}}' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'."
   },
   {
-    "id": "API action either does not exist or is not a web-action",
-    "translation": "API action either does not exist or is not a web-action"
+    "id": "API action does not exist",
+    "translation": "API action does not exist"
+  },
+  {
+    "id": "API action is not a web-action",
+    "translation": "API action is not a web-action"
   },
   {
     "id": "Invalid configuration. The x-openwhisk stanza is missing.",

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -26,9 +26,40 @@ type ApiService struct {
     client *Client
 }
 
-type SendApi struct {
-    ApiDoc         *Api       `json:"apidoc,omitempty"`
+// wsk api create : Request, Response
+type ApiCreateRequest struct {
+    ApiDoc          *Api      `json:"apidoc,omitempty"`
 }
+type ApiCreateRequestOptions ApiOptions
+type ApiCreateResponse RetApi
+type ApiCreateResponseV2 RetApiV2
+
+// wsk api list : Request, Response
+type ApiListRequest struct {
+}
+type ApiListRequestOptions struct {
+    ApiOptions
+    Limit           int       `url:"limit"`
+    Skip            int       `url:"skip"`
+    Docs            bool      `url:"docs,omitempty"`
+}
+type ApiListResponse RetApiArray
+type ApiListResponseV2 RetApiArrayV2
+
+// wsk api get : Request, Response
+type ApiGetRequest struct {
+    Api
+}
+type ApiGetRequestOptions ApiOptions
+type ApiGetResponse RetApiArray
+type ApiGetResponseV2 RetApiArrayV2
+
+// wsk api delete : Request, Response
+type ApiDeleteRequest struct {
+    Api
+}
+type ApiDeleteRequestOptions ApiOptions
+type ApiDeleteResponse struct {}
 
 type Api struct {
     Namespace       string    `json:"namespace,omitempty"`
@@ -56,30 +87,13 @@ type ApiOptions struct {
     ApiRelPath      string    `url:"relpath,omitempty"`
     ApiVerb         string    `url:"operation,omitempty"`
     ApiName         string    `url:"apiname,omitempty"`
-    Force           bool      `url:"force,omitempty"`
+    SpaceGuid       string    `url:"spaceguid,omitempty"`
+    AccessToken     string    `url:"accesstoken,omitempty"`
 }
 
-type ApiListOptions struct {
-    ApiOptions
-    Limit           int       `url:"limit"`
-    Skip            int       `url:"skip"`
-    Docs            bool      `url:"docs,omitempty"`
-}
-
-type RetApiResponse struct {
-    Response        *RetResult `json:"response"`
-}
-
-type RetResult struct {
-    Result          *RetApi   `json:"result"`
-}
-
-type RetApiReponseApiArray struct {
-    Response        *RetResultApiArray `json:"response"`
-}
-
-type RetResultApiArray struct {
-    ResultArray     *RetApiArray `json:"result"`
+type ApiUserAuth struct {
+    SpaceGuid       string    `json:"spaceguid,omitempty"`
+    AccessToken     string    `json:"accesstoken,omitempty"`
 }
 
 type RetApiArray struct {
@@ -104,7 +118,34 @@ type ApiSwagger struct {
     SwaggerName     string    `json:"swagger,omitempty"`
     BasePath        string    `json:"basePath,omitempty"`
     Info            *ApiSwaggerInfo `json:"info,omitempty"`
-    Paths           map[string]map[string]map[string]map[string]interface{} `json:"paths,omitempty"`
+    Paths           map[string]map[string]*ApiSwaggerOperationV1 `json:"paths,omitempty"`
+    XConfig         map[string]map[string][]map[string]map[string]interface{} `json:"x-ibm-configuration,omitempty"`
+}
+
+type RetApiArrayV2 struct {
+    Apis            []ApiItemV2 `json:"apis,omitempty"`
+}
+
+type ApiItemV2 struct {
+    ApiId           string    `json:"id,omitempty"`
+    QueryKey        string    `json:"key,omitempty"`
+    ApiValue        *RetApiV2 `json:"value,omitempty"`
+}
+
+type RetApiV2 struct {
+    Namespace       string    `json:"namespace"`
+    BaseUrl         string    `json:"gwApiUrl"`
+    Activated       bool      `json:"gwApiActivated"`
+    TenantId        string    `json:"tenantId"`
+    Swagger         *ApiSwaggerV2 `json:"apidoc,omitempty"`
+}
+
+type ApiSwaggerV2 struct {
+    SwaggerName     string    `json:"swagger,omitempty"`
+    BasePath        string    `json:"basePath,omitempty"`
+    Info            *ApiSwaggerInfo `json:"info,omitempty"`
+    Paths           map[string]map[string]*ApiSwaggerOperationV2 `json:"paths,omitempty"`  // Paths["/a/path"]["get"] -> a generic object
+    XConfig         map[string]map[string][]map[string]map[string]interface{} `json:"x-ibm-configuration,omitempty"`
 }
 
 type ApiSwaggerInfo struct {
@@ -112,6 +153,31 @@ type ApiSwaggerInfo struct {
     Version         string    `json:"version,omitempty"`
 }
 
+type ApiSwaggerOperationV1 struct {
+    Responses       interface{} `json:"responses"`
+    XOpenWhisk      *ApiSwaggerOpXOpenWhiskV1 `json:"x-ibm-op-ext,omitempty"`
+}
+
+type ApiSwaggerOperationV2 struct {
+    OperationId     string    `json:"operationId"`
+    Responses       interface{} `json:"responses"`
+    XOpenWhisk      *ApiSwaggerOpXOpenWhiskV2 `json:"x-openwhisk,omitempty"`
+}
+
+type ApiSwaggerOpXOpenWhiskV1 struct {
+    ActionName      string    `json:"actionName"`
+    Namespace       string    `json:"actionNamespace"`
+    ActionUrlVerb   string    `json:"backendMethod"`
+    ActionUrl       string    `json:"backendUrl"`
+    Policies        interface{} `json:"policies"`
+}
+
+type ApiSwaggerOpXOpenWhiskV2 struct {
+    ActionName      string    `json:"action"`
+    Namespace       string    `json:"namespace"`
+    Package         string    `json:"package"`
+    ApiUrl          string    `json:"url"`
+}
 
 var ApiVerbs map[string]bool = map[string]bool {
     "GET": true,
@@ -123,12 +189,18 @@ var ApiVerbs map[string]bool = map[string]bool {
     "OPTIONS": true,
 }
 
+const (
+    Overwrite = true
+    DoNotOverwrite = false
+)
+
 ////////////////////
 // Api Methods //
 ////////////////////
 
-func (s *ApiService) List(apiListOptions *ApiListOptions) (*RetApiArray, *http.Response, error) {
+func (s *ApiService) List(apiListOptions *ApiListRequestOptions) (*ApiListResponse, *http.Response, error) {
     route := "experimental/web/whisk.system/routemgmt/getApi.json"
+    Debug(DbgInfo, "Api GET/list route: %s\n", route)
 
     routeUrl, err := addRouteOptions(route, apiListOptions)
     if err != nil {
@@ -151,7 +223,7 @@ func (s *ApiService) List(apiListOptions *ApiListOptions) (*RetApiArray, *http.R
         return nil, nil, whiskErr
     }
 
-    apiArray := new(RetApiArray)
+    apiArray := new(ApiListResponse)
     resp, err := s.client.Do(req, &apiArray, ExitWithErrorOnTimeout)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
@@ -161,15 +233,24 @@ func (s *ApiService) List(apiListOptions *ApiListOptions) (*RetApiArray, *http.R
     return apiArray, resp, err
 }
 
-func (s *ApiService) Insert(api *SendApi, overwrite bool) (*RetApi, *http.Response, error) {
-    var sentAction interface{}
-
+func (s *ApiService) Insert(api *ApiCreateRequest, options *ApiCreateRequestOptions, overwrite bool) (*ApiCreateResponse, *http.Response, error) {
     route := "experimental/web/whisk.system/routemgmt/createApi.json"
     Debug(DbgInfo, "Api PUT route: %s\n", route)
 
-    req, err := s.client.NewRequest("POST", route, api, DoNotIncludeNamespaceInUrl)
+    routeUrl, err := addRouteOptions(route, options)
     if err != nil {
-        Debug(DbgError, "http.NewRequest(POST, %s, %#v) error: '%s'\n", route, err, sentAction)
+        Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
+        errMsg := wski18n.T("Unable to add route options '{{.options}}'",
+            map[string]interface{}{"options": options})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+    Debug(DbgError, "Api create route with options: %s\n", routeUrl)
+
+    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    if err != nil {
+        Debug(DbgError, "http.NewRequestUrl(POST, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for POST '{{.route}}': {{.err}}",
             map[string]interface{}{"route": route, "err": err})
         whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
@@ -177,7 +258,7 @@ func (s *ApiService) Insert(api *SendApi, overwrite bool) (*RetApi, *http.Respon
         return nil, nil, whiskErr
     }
 
-    retApi := new(RetApi)
+    retApi := new(ApiCreateResponse)
     resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
@@ -187,7 +268,7 @@ func (s *ApiService) Insert(api *SendApi, overwrite bool) (*RetApi, *http.Respon
     return retApi, resp, nil
 }
 
-func (s *ApiService) Get(api *Api, options *ApiListOptions) (*RetApiArray, *http.Response, error) {
+func (s *ApiService) Get(api *ApiGetRequest, options *ApiGetRequestOptions) (*ApiGetResponse, *http.Response, error) {
     route := "experimental/web/whisk.system/routemgmt/getApi.json"
     Debug(DbgInfo, "Api GET route: %s\n", route)
 
@@ -212,7 +293,7 @@ func (s *ApiService) Get(api *Api, options *ApiListOptions) (*RetApiArray, *http
         return nil, nil, whiskErr
     }
 
-    retApi := new(RetApiArray)
+    retApi := new(ApiGetResponse)
     resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
@@ -222,7 +303,7 @@ func (s *ApiService) Get(api *Api, options *ApiListOptions) (*RetApiArray, *http
     return retApi, resp, nil
 }
 
-func (s *ApiService) Delete(api *Api, options *ApiOptions) (*http.Response, error) {
+func (s *ApiService) Delete(api *ApiDeleteRequest, options *ApiDeleteRequestOptions) (*http.Response, error) {
     route := "experimental/web/whisk.system/routemgmt/deleteApi.json"
     Debug(DbgInfo, "Api DELETE route: %s\n", route)
 
@@ -247,7 +328,7 @@ func (s *ApiService) Delete(api *Api, options *ApiOptions) (*http.Response, erro
         return nil, whiskErr
     }
 
-    retApi := new(RetApi)
+    retApi := new(ApiDeleteResponse)
     resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
     if err != nil {
         Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
@@ -257,3 +338,245 @@ func (s *ApiService) Delete(api *Api, options *ApiOptions) (*http.Response, erro
     return nil, nil
 }
 
+/////////////
+// V2 Cmds //
+/////////////
+func (s *ApiService) ListV2(apiListOptions *ApiListRequestOptions) (*ApiListResponseV2, *http.Response, error) {
+    route := "web/whisk.system/apimgmt/getApi.http"
+
+    routeUrl, err := addRouteOptions(route, apiListOptions)
+    if err != nil {
+        Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, apiListOptions, err)
+        errMsg := wski18n.T("Unable to add route options '{{.options}}'",
+            map[string]interface{}{"options": apiListOptions})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+    Debug(DbgInfo, "Api GET/list route with api options: %s\n", routeUrl)
+
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    if err != nil {
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", routeUrl, err)
+        errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
+            map[string]interface{}{"route": routeUrl, "err": err})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+
+    apiArray := new(ApiListResponseV2)
+    resp, err := s.client.Do(req, &apiArray, ExitWithErrorOnTimeout)
+    if err != nil {
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        return nil, resp, err
+    }
+
+    err = validateApiListResponse(apiArray)
+    if err != nil {
+        Debug(DbgError, "Not a valid ApiListReponse object\n")
+        return nil, resp, err
+    }
+
+    return apiArray, resp, err
+}
+
+func (s *ApiService) InsertV2(api *ApiCreateRequest, options *ApiCreateRequestOptions, overwrite bool) (*ApiCreateResponseV2, *http.Response, error) {
+    route := "web/whisk.system/apimgmt/createApi.http"
+    Debug(DbgInfo, "Api PUT route: %s\n", route)
+
+    routeUrl, err := addRouteOptions(route, options)
+    if err != nil {
+        Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
+        errMsg := wski18n.T("Unable to add route options '{{.options}}'",
+            map[string]interface{}{"options": options})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+    Debug(DbgError, "Api create route with options: %s\n", routeUrl)
+
+    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    if err != nil {
+        Debug(DbgError, "http.NewRequestUrl(POST, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
+        errMsg := wski18n.T("Unable to create HTTP request for POST '{{.route}}': {{.err}}",
+            map[string]interface{}{"route": route, "err": err})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+
+    retApi := new(ApiCreateResponseV2)
+    resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
+    if err != nil {
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        return nil, resp, err
+    }
+
+    err = validateApiSwaggerResponse(retApi.Swagger)
+    if err != nil {
+        Debug(DbgError, "Not a valid API creation response\n")
+        return nil, resp, err
+    }
+
+    return retApi, resp, nil
+}
+
+func (s *ApiService) GetV2(api *ApiGetRequest, options *ApiGetRequestOptions) (*ApiGetResponseV2, *http.Response, error) {
+    route := "web/whisk.system/apimgmt/getApi.http"
+    Debug(DbgInfo, "Api GET route: %s\n", route)
+
+    routeUrl, err := addRouteOptions(route, options)
+    if err != nil {
+        Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
+        errMsg := wski18n.T("Unable to add route options '{{.options}}'",
+            map[string]interface{}{"options": options})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+    Debug(DbgError, "Api get route with options: %s\n", routeUrl)
+
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    if err != nil {
+        Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
+        errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
+            map[string]interface{}{"route": route, "err": err})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, nil, whiskErr
+    }
+
+    retApi := new(ApiGetResponseV2)
+    resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
+    if err != nil {
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        return nil, resp, err
+    }
+
+    return retApi, resp, nil
+}
+
+func (s *ApiService) DeleteV2(api *ApiDeleteRequest, options *ApiDeleteRequestOptions) (*http.Response, error) {
+    route := "web/whisk.system/apimgmt/deleteApi.http"
+    Debug(DbgInfo, "Api DELETE route: %s\n", route)
+
+    routeUrl, err := addRouteOptions(route, options)
+    if err != nil {
+        Debug(DbgError, "addRouteOptions(%s, %#v) error: '%s'\n", route, options, err)
+        errMsg := wski18n.T("Unable to add route options '{{.options}}'",
+            map[string]interface{}{"options": options})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_GENERAL, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, whiskErr
+    }
+    Debug(DbgError, "Api DELETE route with options: %s\n", routeUrl)
+
+    req, err := s.client.NewRequestUrl("DELETE", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    if err != nil {
+        Debug(DbgError, "http.NewRequestUrl(DELETE, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
+        errMsg := wski18n.T("Unable to create HTTP request for DELETE '{{.route}}': {{.err}}",
+            map[string]interface{}{"route": route, "err": err})
+        whiskErr := MakeWskErrorFromWskError(errors.New(errMsg), err, EXITCODE_ERR_NETWORK, DISPLAY_MSG,
+            NO_DISPLAY_USAGE)
+        return nil, whiskErr
+    }
+
+    retApi := new(ApiDeleteResponse)
+    resp, err := s.client.Do(req, &retApi, ExitWithErrorOnTimeout)
+    if err != nil {
+        Debug(DbgError, "s.client.Do() error - HTTP req %s; error '%s'\n", req.URL.String(), err)
+        return resp, err
+    }
+
+    return nil, nil
+}
+
+
+func validateApiListResponse(apiList *ApiListResponseV2) error {
+    for i:=0; i<len(apiList.Apis); i++ {
+        if apiList.Apis[i].ApiValue == nil {
+            Debug(DbgError, "validateApiResponse: No value stanza in api %v\n", apiList.Apis[i])
+            errMsg := wski18n.T("Internal error. Missing value stanza in API configuration response")
+            whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+        err := validateApiSwaggerResponse(apiList.Apis[i].ApiValue.Swagger)
+        if (err != nil) {
+            Debug(DbgError, "validateApiListResponse: Invalid Api: %v\n", apiList.Apis[i])
+            return err
+        }
+    }
+    return nil
+}
+
+func validateApiSwaggerResponse(swagger *ApiSwaggerV2) error {
+    if swagger == nil {
+        Debug(DbgError, "validateApiSwaggerResponse: No apidoc stanza in api\n")
+        errMsg := wski18n.T("Internal error. Missing apidoc stanza in API configuration")
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+    for path, _ := range swagger.Paths {
+        err := validateApiPath(swagger.Paths[path])
+        if err != nil {
+            Debug(DbgError, "validateApiResponse: Invalid Api Path object: %v\n", swagger.Paths[path])
+            return err
+        }
+    }
+
+    return nil
+}
+
+func validateApiPath(path map[string]*ApiSwaggerOperationV2) error {
+    for op, opv := range path {
+        err := validateApiOperation(op, opv)
+        if err != nil {
+            Debug(DbgError, "validateApiPath: Invalid Api operation object: %v\n", opv)
+            return err
+        }
+    }
+    return nil
+}
+
+func validateApiOperation(opName string, op *ApiSwaggerOperationV2) error {
+    if len(op.OperationId) == 0 {
+        Debug(DbgError, "validateApiResponse: No operationId field in operation %v\n", op)
+        errMsg := wski18n.T("Missing operationId field in API configuration for operation {{.op}}",
+            map[string]interface{}{"op": opName})
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+    if op.XOpenWhisk == nil {
+        Debug(DbgError, "validateApiResponse: No x-openwhisk stanza in operation %v\n", op)
+        errMsg := wski18n.T("Missing x-openwhisk stanza in API configuration for operation {{.op}}",
+            map[string]interface{}{"op": opName})
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+    if len(op.XOpenWhisk.Namespace) == 0 {
+        Debug(DbgError, "validateApiOperation: no x-openwhisk.namespace stanza in operation %v\n", op)
+        errMsg := wski18n.T("Missing x-openwhisk.namespace field in API configuration for operation {{.op}}",
+            map[string]interface{}{"op": opName})
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+
+    // Note: The op.XOpenWhisk.Package field can have a value of "", so don't enforce a value
+
+    if len(op.XOpenWhisk.ActionName) == 0 {
+        Debug(DbgError, "validateApiOperation: no x-openwhisk.action stanza in operation %v\n", op)
+        errMsg := wski18n.T("Missing x-openwhisk.action field in API configuration for operation {{.op}}",
+            map[string]interface{}{"op": opName})
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+    if len(op.XOpenWhisk.ApiUrl) == 0 {
+        Debug(DbgError, "validateApiOperation: no x-openwhisk.url stanza in operation %v\n", op)
+        errMsg := wski18n.T("Missing x-openwhisk.url field in API configuration for operation {{.op}}",
+            map[string]interface{}{"op": opName})
+        whiskErr := MakeWskError(errors.New(errMsg), EXITCODE_ERR_NETWORK, DISPLAY_MSG, NO_DISPLAY_USAGE)
+        return whiskErr
+    }
+    return nil
+}

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -248,7 +248,7 @@ func (s *ApiService) Insert(api *ApiCreateRequest, options *ApiCreateRequestOpti
     }
     Debug(DbgError, "Api create route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson, AuthRequired)
     if err != nil {
         Debug(DbgError, "http.NewRequestUrl(POST, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for POST '{{.route}}': {{.err}}",
@@ -355,7 +355,7 @@ func (s *ApiService) ListV2(apiListOptions *ApiListRequestOptions) (*ApiListResp
     }
     Debug(DbgInfo, "Api GET/list route with api options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson, AuthRequired)
     if err != nil {
         Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", routeUrl, err)
         errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
@@ -396,7 +396,7 @@ func (s *ApiService) InsertV2(api *ApiCreateRequest, options *ApiCreateRequestOp
     }
     Debug(DbgError, "Api create route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    req, err := s.client.NewRequestUrl("POST", routeUrl, api, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson, AuthRequired)
     if err != nil {
         Debug(DbgError, "http.NewRequestUrl(POST, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for POST '{{.route}}': {{.err}}",
@@ -437,7 +437,7 @@ func (s *ApiService) GetV2(api *ApiGetRequest, options *ApiGetRequestOptions) (*
     }
     Debug(DbgError, "Api get route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    req, err := s.client.NewRequestUrl("GET", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson, AuthRequired)
     if err != nil {
         Debug(DbgError, "http.NewRequestUrl(GET, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for GET '{{.route}}': {{.err}}",
@@ -472,7 +472,7 @@ func (s *ApiService) DeleteV2(api *ApiDeleteRequest, options *ApiDeleteRequestOp
     }
     Debug(DbgError, "Api DELETE route with options: %s\n", routeUrl)
 
-    req, err := s.client.NewRequestUrl("DELETE", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson)
+    req, err := s.client.NewRequestUrl("DELETE", routeUrl, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson, AuthRequired)
     if err != nil {
         Debug(DbgError, "http.NewRequestUrl(DELETE, %s, nil, DoNotIncludeNamespaceInUrl, AppendOpenWhiskPathPrefix, EncodeBodyAsJson) error: '%s'\n", route, err)
         errMsg := wski18n.T("Unable to create HTTP request for DELETE '{{.route}}': {{.err}}",


### PR DESCRIPTION
- Support both 'wsk api-experimental' and 'wsk api' commands (separate PR wil deprecate `api-experimental`)
- 'wsk api' command requires that the target action exist and that it's a web action
- Separate V1 and V2 tests for easy deprecation/removal

Together with PR #2067, replaces PR #2031 
Depends on PR #2067 (don't merge this PR until after #2067 is merged)
