### PR TITLE
Provide reactive Docker and Runc client

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -142,13 +142,10 @@ object LogMarker {
     val keyword = "marker"
 
     /** Convenience method for parsing log markers in unit tests. */
-    def unapply(s: String) = {
+    def parse(s: String) = {
         val logmarker = raw"\[${keyword}:([^\s:]+):(\d+)(?::(\d+))?\]".r.unanchored
-        s match {
-            case logmarker(token, deltaToTransactionStart, deltaToMarkerStart) =>
-                Some(LogMarkerToken.parse(token), deltaToTransactionStart.toLong, Option(deltaToMarkerStart).map(_.toLong))
-            case _ => None
-        }
+        val logmarker(token, deltaToTransactionStart, deltaToMarkerStart) = s
+        LogMarker(LogMarkerToken.parse(token), deltaToTransactionStart.toLong, Option(deltaToMarkerStart).map(_.toLong))
     }
 }
 

--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -178,6 +178,8 @@ case class LogMarkerToken(component: String, action: String, state: String) {
 
 object LogMarkerToken {
     def parse(s: String) = {
+        // Per convention the components are guaranteed to not contain '_'
+        // thus it's safe to split at '_' to get the components
         val Array(component, action, state) = s.split("_")
         LogMarkerToken(component, action, state)
     }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import scala.util.Try
+import java.io.FileNotFoundException
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import whisk.common.Logging
+import whisk.common.TransactionId
+import whisk.common.LoggingMarkers
+import akka.event.Logging.ErrorLevel
+import scala.util.Failure
+import scala.util.Success
+
+/**
+ * Serves as interface to the docker CLI tool.
+ *
+ * Be cautious with the ExecutionContext passed to this, as the
+ * calls to the CLI are blocking.
+ *
+ * You only need one instance (and you shouldn't get more).
+ */
+class DockerClient(dockerHost: Option[String] = None)(executionContext: ExecutionContext)(implicit log: Logging)
+    extends DockerApi with ProcessRunner {
+    implicit private val ec = executionContext
+
+    // Determines how to run docker. Failure to find a Docker binary implies
+    // a failure to initialize this instance of DockerClient.
+    protected val dockerCmd: Seq[String] = {
+        val alternatives = List("/usr/bin/docker", "/usr/local/bin/docker")
+
+        val dockerBin = Try {
+            alternatives.find(a => Files.isExecutable(Paths.get(a))).get
+        } getOrElse {
+            throw new FileNotFoundException(s"Couldn't locate docker binary (tried: ${alternatives.mkString(", ")}).")
+        }
+
+        val host = dockerHost.map(host => Seq("--host", s"tcp://$host")).getOrElse(Seq.empty[String])
+        Seq(dockerBin) ++ host
+    }
+
+    def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] =
+        runCmd((Seq("run", "-d") ++ args ++ Seq(image)): _*).map(ContainerId.apply)
+
+    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] =
+        runCmd("inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString).map(ContainerIp.apply)
+
+    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+        runCmd("pause", id.asString).map(_ => ())
+
+    def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+        runCmd("unpause", id.asString).map(_ => ())
+
+    def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
+        runCmd("rm", "-f", id.asString).map(_ => ())
+
+    def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]] = {
+        val filterArgs = filters.map { case (attr, value) => Seq("--filter", s"$attr=$value") }.flatten
+        val allArg = if (all) Seq("--all") else Seq.empty[String]
+        val cmd = Seq("ps", "--quiet", "--no-trunc") ++ allArg ++ filterArgs
+        runCmd(cmd: _*).map(_.lines.toSeq.map(ContainerId.apply))
+    }
+
+    def pull(image: String)(implicit transid: TransactionId): Future[Unit] =
+        runCmd("pull", image).map(_ => ())
+
+    private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
+        val cmd = dockerCmd ++ args
+        val start = transid.started(this, LoggingMarkers.INVOKER_DOCKER_CMD(args.head), s"running ${cmd.mkString(" ")}")
+        executeProcess(cmd: _*).andThen {
+            case Success(_) => transid.finished(this, start)
+            case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
+        }
+    }
+}
+
+case class ContainerId(val asString: String) {
+    require(asString.nonEmpty, "ContainerId must not be empty")
+}
+case class ContainerIp(val asString: String) {
+    require(asString.nonEmpty, "ContainerIp must not be empty")
+}
+
+trait DockerApi {
+    /**
+     * Spawns a container in detached mode.
+     *
+     * @param image the image to start the container with
+     * @param args arguments for the docker run command
+     * @param cmd the command to start the container with
+     * @param name an optional name for the container
+     * @return id of the started container
+     */
+    def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
+
+    /**
+     * Gets the IP adress of a given container.
+     *
+     * @param id the id of the container to get the IP address from
+     * @return ip of the container
+     */
+    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp]
+
+    /**
+     * Pauses the container with the given id.
+     *
+     * @param id the id of the container to pause
+     * @return a Future completing according to the command's exit-code
+     */
+    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Unpauses the container with the given id.
+     *
+     * @param id the id of the container to unpause
+     * @return a Future completing according to the command's exit-code
+     */
+    def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Removes the container with the given id.
+     *
+     * @param id the id of the container to remove
+     * @return a Future completing according to the command's exit-code
+     */
+    def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Returns a list of ContainerIds in the system.
+     *
+     * @param all Whether or not to return stopped containers as well
+     * @return A list of ContainerIds
+     */
+    def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]]
+
+    /**
+     * Pulls the given image.
+     *
+     * @param image the image to pull
+     * @return a Future completing once the pull is complete
+     */
+    def pull(image: String)(implicit transid: TransactionId): Future[Unit]
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -104,8 +104,6 @@ trait DockerApi {
      *
      * @param image the image to start the container with
      * @param args arguments for the docker run command
-     * @param cmd the command to start the container with
-     * @param name an optional name for the container
      * @return id of the started container
      */
     def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
@@ -145,6 +143,7 @@ trait DockerApi {
     /**
      * Returns a list of ContainerIds in the system.
      *
+     * @param filters Filters to apply to the 'ps' command
      * @param all Whether or not to return stopped containers as well
      * @return A list of ContainerIds
      */

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
@@ -25,7 +25,7 @@ import scala.sys.process._
 trait ProcessRunner {
 
     /**
-     * Run the specified command with arguments asynchronously and
+     * Runs the specified command with arguments asynchronously and
      * capture stdout as well as stderr.
      *
      * Be cautious with the execution context you pass because the command

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/ProcessRunner.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.blocking
+import scala.sys.process._
+
+trait ProcessRunner {
+
+    /**
+     * Run the specified command with arguments asynchronously and
+     * capture stdout as well as stderr.
+     *
+     * Be cautious with the execution context you pass because the command
+     * is blocking.
+     *
+     * @param args command to be run including arguments
+     * @return a future completing according to the command's exit code
+     */
+    protected def executeProcess(args: String*)(implicit ec: ExecutionContext) =
+        Future(blocking {
+            val out = new mutable.ListBuffer[String]
+            val err = new mutable.ListBuffer[String]
+            val exitCode = args ! ProcessLogger(o => out += o, e => err += e)
+
+            (exitCode, out.mkString("\n"), err.mkString("\n"))
+        }).flatMap {
+            case (0, stdout, _) =>
+                Future.successful(stdout)
+            case (code, stdout, stderr) =>
+                Future.failed(ProcessRunningException(code, stdout, stderr))
+        }
+}
+
+case class ProcessRunningException(exitCode: Int, stdout: String, stderr: String) extends Exception(s"code: $exitCode, stdout: $stdout, stderr: $stderr")

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/RuncClient.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.util.Failure
+import whisk.common.TransactionId
+import scala.util.Success
+import whisk.common.LoggingMarkers
+import whisk.common.Logging
+import akka.event.Logging.ErrorLevel
+
+/**
+ * Serves as interface to the docker CLI tool.
+ *
+ * Be cautious with the ExecutionContext passed to this, as the
+ * calls to the CLI are blocking.
+ *
+ * You only need one instance (and you shouldn't get more).
+ */
+class RuncClient(executionContext: ExecutionContext)(implicit log: Logging) extends RuncApi with ProcessRunner {
+    implicit private val ec = executionContext
+
+    // Determines how to run docker. Failure to find a Docker binary implies
+    // a failure to initialize this instance of DockerClient.
+    protected val runcCmd: Seq[String] = Seq("/usr/bin/docker-runc")
+
+    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = runCmd("pause", id.asString).map(_ => ())
+
+    def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = runCmd("resume", id.asString).map(_ => ())
+
+    private def runCmd(args: String*)(implicit transid: TransactionId): Future[String] = {
+        val cmd = runcCmd ++ args
+        val start = transid.started(this, LoggingMarkers.INVOKER_RUNC_CMD(args.head), s"running ${cmd.mkString(" ")}")
+        executeProcess(cmd: _*).andThen {
+            case Success(_) => transid.finished(this, start)
+            case Failure(t) => transid.failed(this, start, t.getMessage, ErrorLevel)
+        }
+    }
+}
+
+trait RuncApi {
+    /**
+     * Pauses the container with the given id.
+     *
+     * @param id the id of the container to pause
+     * @return a Future completing according to the command's exit-code
+     */
+    def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+
+    /**
+     * Unpauses the container with the given id.
+     *
+     * @param id the id of the container to unpause
+     * @return a Future completing according to the command's exit-code
+     */
+    def resume(id: ContainerId)(implicit transid: TransactionId): Future[Unit]
+}

--- a/tests/src/test/scala/common/StreamLogging.scala
+++ b/tests/src/test/scala/common/StreamLogging.scala
@@ -21,6 +21,7 @@ import java.io.PrintStream
 
 import whisk.common.Logging
 import whisk.common.PrintStreamLogging
+import java.nio.charset.StandardCharsets
 
 /**
  * Logging facility, that can be used by tests.
@@ -32,4 +33,6 @@ trait StreamLogging {
     val stream = new ByteArrayOutputStream
     val printstream = new PrintStream(stream)
     implicit val logging: Logging = new PrintStreamLogging(printstream)
+
+    def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).lines.toList
 }

--- a/tests/src/test/scala/common/StreamLogging.scala
+++ b/tests/src/test/scala/common/StreamLogging.scala
@@ -30,9 +30,9 @@ import java.nio.charset.StandardCharsets
  * the logger logs to the stream, that can be accessed from your test, to check if a specific message has been written.
  */
 trait StreamLogging {
-    val stream = new ByteArrayOutputStream
-    val printstream = new PrintStream(stream)
-    implicit val logging: Logging = new PrintStreamLogging(printstream)
+    lazy val stream = new ByteArrayOutputStream
+    lazy val printstream = new PrintStream(stream)
+    implicit lazy val logging: Logging = new PrintStreamLogging(printstream)
 
     def logLines = new String(stream.toByteArray, StandardCharsets.UTF_8).lines.toList
 }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -85,11 +85,11 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
 
             logLines.head should include((Seq(dockerCommand, cmd) ++ args).mkString(" "))
 
-            val LogMarker(start, _, _) = logLines.head
-            start shouldBe INVOKER_DOCKER_CMD(cmd)
+            val start = LogMarker.parse(logLines.head)
+            start.token shouldBe INVOKER_DOCKER_CMD(cmd)
 
-            val LogMarker(end, _, _) = logLines.last
-            end shouldBe INVOKER_DOCKER_CMD(cmd).asFinish
+            val end = LogMarker.parse(logLines.last)
+            end.token shouldBe INVOKER_DOCKER_CMD(cmd).asFinish
 
             stream.reset()
             result
@@ -116,11 +116,11 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         def runAndVerify(f: Future[_], cmd: String) = {
             a[RuntimeException] should be thrownBy await(f)
 
-            val LogMarker(start, _, _) = logLines.head
-            start shouldBe INVOKER_DOCKER_CMD(cmd)
+            val start = LogMarker.parse(logLines.head)
+            start.token shouldBe INVOKER_DOCKER_CMD(cmd)
 
-            val LogMarker(end, _, _) = logLines.last
-            end shouldBe INVOKER_DOCKER_CMD(cmd).asError
+            val end = LogMarker.parse(logLines.last)
+            end.token shouldBe INVOKER_DOCKER_CMD(cmd).asError
 
             stream.reset()
         }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import scala.concurrent.Future
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalatest.Matchers
+import common.StreamLogging
+import whisk.core.containerpool.docker.ContainerId
+import whisk.common.TransactionId
+import org.scalatest.BeforeAndAfterEach
+import whisk.common.LogMarker
+import whisk.common.LoggingMarkers.INVOKER_DOCKER_CMD
+import whisk.core.containerpool.docker.DockerClient
+import whisk.core.containerpool.docker.ContainerIp
+
+@RunWith(classOf[JUnitRunner])
+class DockerClientTests extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+    val id = ContainerId("Id")
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    val dockerCommand = "docker"
+
+    /** Returns a DockerClient with a mocked result for 'executeProcess' */
+    def dockerClient(result: Future[String]) = new DockerClient()(global) {
+        override val dockerCmd = Seq(dockerCommand)
+        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = result
+    }
+
+    behavior of "DockerClient"
+
+    it should "return a list of containers and pass down the correct arguments when using 'ps'" in {
+        val containers = Seq("1", "2", "3")
+        val dc = dockerClient { Future.successful(containers.mkString("\n")) }
+
+        val filters = Seq("name" -> "wsk", "label" -> "docker")
+        await(dc.ps(filters, all = true)) shouldBe containers.map(ContainerId.apply)
+
+        val firstLine = logLines.head
+        firstLine should include(s"${dockerCommand} ps")
+        firstLine should include("--quiet")
+        firstLine should include("--no-trunc")
+        firstLine should include("--all")
+        filters.foreach {
+            case (k, v) => firstLine should include(s"--filter $k=$v")
+        }
+    }
+
+    it should "write proper log markers on a successful command" in {
+        // a dummy string works here as we do not assert any output
+        // from the methods below
+        val stdout = "stdout"
+        val dc = dockerClient { Future.successful(stdout) }
+
+        /** Awaits the command and checks for proper logging. */
+        def runAndVerify(f: Future[_], cmd: String, args: Seq[String] = Seq.empty[String]) = {
+            val result = await(f)
+
+            logLines.head should include((Seq(dockerCommand, cmd) ++ args).mkString(" "))
+
+            val LogMarker(start, _, _) = logLines.head
+            start shouldBe INVOKER_DOCKER_CMD(cmd)
+
+            val LogMarker(end, _, _) = logLines.last
+            end shouldBe INVOKER_DOCKER_CMD(cmd).asFinish
+
+            stream.reset()
+            result
+        }
+
+        runAndVerify(dc.pause(id), "pause", Seq(id.asString))
+        runAndVerify(dc.unpause(id), "unpause", Seq(id.asString))
+        runAndVerify(dc.rm(id), "rm", Seq("-f", id.asString))
+        runAndVerify(dc.ps(), "ps")
+
+        val inspectArgs = Seq("--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString)
+        runAndVerify(dc.inspectIPAddress(id), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
+
+        val image = "image"
+        val runArgs = Seq("--memory", "256m", "--cpushares", "1024")
+        runAndVerify(dc.run(image, runArgs), "run", Seq("-d") ++ runArgs ++ Seq(image)) shouldBe ContainerId(stdout)
+        runAndVerify(dc.pull(image), "pull", Seq(image))
+    }
+
+    it should "write proper log markers on a failing command" in {
+        val dc = dockerClient { Future.failed(new RuntimeException()) }
+
+        /** Awaits the command, asserts the exception and checks for proper logging. */
+        def runAndVerify(f: Future[_], cmd: String) = {
+            a[RuntimeException] should be thrownBy await(f)
+
+            val LogMarker(start, _, _) = logLines.head
+            start shouldBe INVOKER_DOCKER_CMD(cmd)
+
+            val LogMarker(end, _, _) = logLines.last
+            end shouldBe INVOKER_DOCKER_CMD(cmd).asError
+
+            stream.reset()
+        }
+
+        runAndVerify(dc.pause(id), "pause")
+        runAndVerify(dc.unpause(id), "unpause")
+        runAndVerify(dc.rm(id), "rm")
+        runAndVerify(dc.ps(), "ps")
+        runAndVerify(dc.inspectIPAddress(id), "inspect")
+        runAndVerify(dc.run("image"), "run")
+        runAndVerify(dc.pull("image"), "pull")
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/ProcessRunnerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/ProcessRunnerTests.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import scala.concurrent.Future
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import whisk.core.containerpool.docker.ProcessRunner
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalatest.Matchers
+import whisk.core.containerpool.docker.ProcessRunningException
+import scala.language.reflectiveCalls // Needed to invoke run() method of structural ProcessRunner extension
+
+@RunWith(classOf[JUnitRunner])
+class ProcessRunnerTests extends FlatSpec with Matchers {
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    val processRunner = new ProcessRunner {
+        def run(args: String*)(implicit ec: ExecutionContext) = executeProcess(args: _*)
+    }
+
+    behavior of "ProcessRunner"
+
+    it should "run an external command successfully and capture its output" in {
+        val stdout = "Output"
+        await(processRunner.run("echo", stdout)) shouldBe stdout
+    }
+
+    it should "run an external command unsuccessfully and capture its output" in {
+        val exitCode = 1
+        val stdout = "Output"
+        val stderr = "Error"
+
+        val future = processRunner.run("/bin/sh", "-c", s"echo ${stdout}; echo ${stderr} 1>&2; exit ${exitCode}")
+
+        the[ProcessRunningException] thrownBy await(future) shouldBe ProcessRunningException(exitCode, stdout, stderr)
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
@@ -66,12 +66,13 @@ class RuncClientTests extends FlatSpec with Matchers with StreamLogging with Bef
         logLines.head should include(s"${runcCommand} ${cmd} ${id.asString}")
 
         // start log maker must be found
-        val LogMarker(start, _, _) = logLines.head
-        start should be(INVOKER_RUNC_CMD(cmd))
+        val start = LogMarker.parse(logLines.head)
+        start.token should be(INVOKER_RUNC_CMD(cmd))
 
         // end log marker must be found
-        val LogMarker(end, _, _) = logLines.last
-        end should be(if (failed) INVOKER_RUNC_CMD(cmd).asError else INVOKER_RUNC_CMD(cmd).asFinish)
+        val expectedEnd = if (failed) INVOKER_RUNC_CMD(cmd).asError else INVOKER_RUNC_CMD(cmd).asFinish
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe expectedEnd
     }
 
     behavior of "RuncClient"

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/RuncClientTests.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import scala.concurrent.Future
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalatest.Matchers
+import whisk.core.containerpool.docker.RuncClient
+import common.StreamLogging
+import whisk.core.containerpool.docker.ContainerId
+import whisk.common.TransactionId
+import org.scalatest.BeforeAndAfterEach
+import whisk.common.LogMarker
+import whisk.common.LoggingMarkers.INVOKER_RUNC_CMD
+
+@RunWith(classOf[JUnitRunner])
+class RuncClientTests extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+    val id = ContainerId("Id")
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    val runcCommand = "docker-runc"
+
+    /** Returns a RuncClient with a mocked result for 'executeProcess' */
+    def runcClient(result: Future[String]) = new RuncClient(global) {
+        override val runcCmd = Seq(runcCommand)
+        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = result
+    }
+
+    /** Calls a runc method based on the name of the method. */
+    def runcProxy(runc: RuncClient, method: String) = {
+        method match {
+            case "pause"  => runc.pause(id)
+            case "resume" => runc.resume(id)
+        }
+    }
+
+    /** Verifies start and end logs are written correctly. */
+    def verifyLogs(cmd: String, failed: Boolean = false) = {
+        logLines.head should include(s"${runcCommand} ${cmd} ${id.asString}")
+
+        // start log maker must be found
+        val LogMarker(start, _, _) = logLines.head
+        start should be(INVOKER_RUNC_CMD(cmd))
+
+        // end log marker must be found
+        val LogMarker(end, _, _) = logLines.last
+        end should be(if (failed) INVOKER_RUNC_CMD(cmd).asError else INVOKER_RUNC_CMD(cmd).asFinish)
+    }
+
+    behavior of "RuncClient"
+
+    Seq("pause", "resume").foreach { cmd =>
+        it should s"$cmd a container successfully and create log entries" in {
+            val rc = runcClient { Future.successful("") }
+            await(runcProxy(rc, cmd))
+            verifyLogs(cmd)
+        }
+
+        it should s"write error markers when $cmd fails" in {
+            val rc = runcClient { Future.failed(new RuntimeException()) }
+            a[RuntimeException] should be thrownBy await(runcProxy(rc, cmd))
+            verifyLogs(cmd, failed = true)
+        }
+
+    }
+}


### PR DESCRIPTION
Provide reactive Docker and Runc client in preparation for reactive container pool implementation.

Closes #2087 
Closes #2088

Signed-off-by: Markus Thoemmes <markus.thoemmes@de.ibm.com>