### PR TITLE
Make nginx ssl configurable

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -104,6 +104,12 @@ nginx:
     http: 80
     api: 443
     adminportal: 8443
+  ssl:
+    path: "{{ openwhisk_home }}/ansible/roles/nginx/files"
+    cert: "openwhisk-cert.pem"
+    key: "openwhisk-key.pem"
+    password_enabled: false
+    password_file: "ssl.pass"
 
 db:
   authkeys:

--- a/ansible/roles/nginx/tasks/deploy.yml
+++ b/ansible/roles/nginx/tasks/deploy.yml
@@ -16,8 +16,14 @@
     src: "files/{{ item }}"
     dest: "{{ nginx_conf_dir }}"
   with_items:
-    - openwhisk-cert.pem
-    - openwhisk-key.pem
+        - "{{ nginx.ssl.cert }}"
+        - "{{ nginx.ssl.key }}"
+
+- name: copy password files for cert from local to remote in nginx config directory
+  copy:
+    src: "files/{{ nginx.ssl.password_file }}"
+    dest: "{{ nginx_conf_dir }}"
+  when: "{{ nginx.ssl.password_enabled == true }}"
 
 - name: ensure nginx log directory is created with permissions
   file:

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -26,8 +26,11 @@ http {
 
         ssl_session_cache    shared:SSL:1m;
         ssl_session_timeout  10m;
-        ssl_certificate      /etc/nginx/openwhisk-cert.pem;
-        ssl_certificate_key  /etc/nginx/openwhisk-key.pem;
+        ssl_certificate      /etc/nginx/{{ nginx.ssl.cert }};
+        ssl_certificate_key  /etc/nginx/{{ nginx.ssl.key }};
+        {% if nginx.ssl.password_enabled %}
+        ssl_password_file   "/etc/nginx/{{ nginx.ssl.password_file }}";
+        {% endif %}
         ssl_verify_client off;
         ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers RC4:HIGH:!aNULL:!MD5;

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -32,4 +32,5 @@
 
   - name: gen untrusted certificate for host
     local_action: shell "{{ playbook_dir }}/roles/nginx/files/genssl.sh" "*.{{ whisk_api_localhost_name | default(whisk_api_host_name) | default(whisk_api_localhost_name_default) }}"
+    when: nginx.ssl.cert == "openwhisk-cert.pem"
     

--- a/ansible/templates/whisk.properties.j2
+++ b/ansible/templates/whisk.properties.j2
@@ -10,8 +10,8 @@ whisk.logs.dir={{ whisk_logs_dir }}
 whisk.version.name={{ whisk_version_name }}
 whisk.version.date={{ whisk.version.date }}
 whisk.version.buildno={{ docker_image_tag }}
-whisk.ssl.cert={{ openwhisk_home }}/ansible/roles/nginx/files/openwhisk-cert.pem
-whisk.ssl.key={{ openwhisk_home }}/ansible/roles/nginx/files/openwhisk-key.pem
+whisk.ssl.cert={{ nginx.ssl.path }}/{{ nginx.ssl.cert }}
+whisk.ssl.key={{ nginx.ssl.path }}/{{ nginx.ssl.key }}
 whisk.ssl.challenge=openwhisk
 
 {#


### PR DESCRIPTION
This pr is to make trusted ssl cert configurable.
With this, user can configure ssl certificate, private key and pass phrase for key in `ansible/group_vars/all`

If user configured its own certificate, untrusted certificate generation step is skipped.

This closes #2106