### PR TITLE
Implement a proxy for a container to implement concurrent behavior.

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -57,7 +57,7 @@ sealed abstract class Exec extends ByteSizeable {
  * A common super class for all action exec types that contain their executable
  * code explicitly (i.e., any action other than a sequence).
  */
-sealed abstract class CodeExec[T <% SizeConversion] extends Exec {
+sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
     /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
     val entryPoint: Option[String]
 

--- a/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/ExecManifest.scala
@@ -104,7 +104,7 @@ protected[core] object ExecManifest {
      * @param sentinelledLogs true iff the runtime generates stdout/stderr log sentinels after an activation
      * @param image optional image name, otherwise inferred via fixed mapping (remove colons and append 'action')
      */
-    protected[entity] case class RuntimeManifest(
+    protected[core] case class RuntimeManifest(
         kind: String,
         image: ImageName,
         deprecated: Option[Boolean] = None,
@@ -128,7 +128,7 @@ protected[core] object ExecManifest {
      * An image name for an action refers to the container image canonically as
      * "prefix/name[:tag]" e.g., "openwhisk/python3action:latest".
      */
-    protected[entity] case class ImageName(
+    protected[core] case class ImageName(
         name: String,
         prefix: Option[String] = None,
         tag: Option[String] = None) {
@@ -170,7 +170,7 @@ protected[core] object ExecManifest {
         }
     }
 
-    protected[entity] object ImageName {
+    protected[core] object ImageName {
         protected val defaultImageTag = "latest"
         private val componentRegex = """([a-z0-9._-]+)""".r
         private val tagRegex = """([\w.-]{0,128})""".r

--- a/core/invoker/src/main/scala/whisk/core/container/package.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/package.scala
@@ -53,6 +53,14 @@ package object container {
         def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)
     }
 
+    object Interval {
+        /** An interval starting now with zero duration. */
+        def zero = {
+            val now = Instant.now
+            Interval(now, now)
+        }
+    }
+
     /**
      * Represents the result of accessing an endpoint in a container:
      * Start time, End time, Some(response) from container consisting of status code and payload
@@ -128,7 +136,7 @@ package object container {
         def apply(content: String) = new DockerOutput(Some(content))
         def unavailable = new DockerOutput(None)
 
-        def isSuccessful(output : DockerOutput) : Boolean =
+        def isSuccessful(output: DockerOutput): Boolean =
             output match {
                 case output if output == DockerOutput.unavailable => false
                 case _ => true

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+import spray.json.JsObject
+import whisk.common.TransactionId
+import whisk.core.container.Interval
+import whisk.core.entity.ActivationResponse
+import whisk.core.entity.ByteSize
+
+/**
+ * An OpenWhisk biased container abstraction. This is **not only** an abstraction
+ * for different container providers, but the implementation also needs to include
+ * OpenWhisk specific behavior, especially for initialize and run.
+ */
+trait Container {
+    /** Stops the container from consuming CPU cycles. */
+    def suspend()(implicit transid: TransactionId): Future[Unit]
+
+    /** Dual of halt. */
+    def resume()(implicit transid: TransactionId): Future[Unit]
+
+    /** Completely destroys this instance of the container. */
+    def destroy()(implicit transid: TransactionId): Future[Unit]
+
+    /** Initializes code in the container. */
+    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval]
+
+    /** Runs code in the container. */
+    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
+
+    /** Obtains logs up to a given threshold from the container. Optionally waits for a sentinel to appear. */
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]]
+}
+
+/** Indicates a general error with the container */
+sealed abstract class ContainerError(msg: String) extends Exception(msg)
+
+/** Indicates an error while starting a container */
+sealed abstract class ContainerStartupError(msg: String) extends ContainerError(msg)
+
+/** Indicates an error while starting a container of a managed runtime */
+case class WhiskContainerStartupError(msg: String) extends ContainerStartupError(msg)
+
+/** Indicates an error while starting a blackbox container */
+case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
+
+/** Indicates an error while initializing a container */
+case class InitializationError(interval: Interval, response: ActivationResponse) extends Exception(response.toString)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import java.time.Instant
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Success
+import scala.util.Failure
+
+import akka.actor.FSM
+import akka.actor.Props
+import akka.actor.Stash
+import akka.actor.Status.{ Failure => FailureMessage }
+import akka.pattern.pipe
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.container.Interval
+import whisk.core.entity._
+import whisk.core.entity.size._
+import whisk.common.Counter
+import whisk.core.entity.ExecManifest.ImageName
+
+// States
+sealed trait ContainerState
+case object Uninitialized extends ContainerState
+case object Starting extends ContainerState
+case object Started extends ContainerState
+case object Running extends ContainerState
+case object Ready extends ContainerState
+case object Pausing extends ContainerState
+case object Paused extends ContainerState
+case object Removing extends ContainerState
+
+// Data
+sealed abstract class ContainerData(val lastUsed: Instant)
+case class NoData() extends ContainerData(Instant.EPOCH)
+case class PreWarmedData(container: Container, kind: String) extends ContainerData(Instant.EPOCH)
+case class WarmedData(container: Container, namespace: EntityName, action: ExecutableWhiskAction, override val lastUsed: Instant) extends ContainerData(lastUsed)
+
+// Events received by the actor
+case class Start(exec: CodeExec[_], memoryLimit: ByteSize)
+case class Run(action: ExecutableWhiskAction, msg: ActivationMessage)
+case object Remove
+
+// Events sent by the actor
+case class NeedWork(data: ContainerData)
+case object ContainerPaused
+case object ContainerRemoved
+
+/**
+ * A proxy that wraps a Container. It is used to keep track of the lifecycle
+ * of a container and to guarantee a contract between the client of the container
+ * and the container itself.
+ *
+ * The contract is as follows:
+ * 1. Only one job is to be sent to the ContainerProxy at one time. ContainerProxy
+ *    will delay all further jobs until a previous job has finished.
+ * 2. The next job can be sent to the ContainerProxy after it indicates available
+ *    capacity by sending NeedWork to its parent.
+ * 3. A Remove message can be sent at any point in time. Like multiple jobs though,
+ *    it will be delayed until the currently running job finishes.
+ *
+ * @constructor
+ * @param factory a function generating a Container
+ * @param sendActiveAck a function sending the activation via active ack
+ * @param storeActivation a function storing the activation in a persistent store
+ */
+class ContainerProxy(
+    factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
+    sendActiveAck: (TransactionId, WhiskActivation) => Future[Any],
+    storeActivation: (TransactionId, WhiskActivation) => Future[Any]) extends FSM[ContainerState, ContainerData] with Stash {
+    implicit val ec = context.system.dispatcher
+
+    // The container is destroyed after this period of time
+    val unusedTimeout = 30.seconds
+
+    // The container is not paused for this period of time
+    // after an activation has finished successfully
+    val pauseGrace = 1.second
+
+    startWith(Uninitialized, NoData())
+
+    when(Uninitialized) {
+        // pre warm a container
+        case Event(job: Start, _) =>
+            factory(
+                TransactionId.invokerWarmup,
+                ContainerProxy.containerName("prewarm", job.exec.kind),
+                job.exec.image,
+                job.exec.pull,
+                job.memoryLimit)
+                .map(container => PreWarmedData(container, job.exec.kind))
+                .pipeTo(self)
+
+            goto(Starting)
+
+        // cold start
+        case Event(job: Run, _) =>
+            implicit val transid = job.msg.transid
+            factory(
+                job.msg.transid,
+                ContainerProxy.containerName(job.msg.user.namespace.name, job.action.name.name),
+                job.action.exec.image,
+                job.action.exec.pull,
+                job.action.limits.memory.megabytes.MB)
+                .andThen {
+                    case Success(container) => self ! PreWarmedData(container, job.action.exec.kind)
+                    case Failure(t) =>
+                        val response = t match {
+                            case WhiskContainerStartupError(msg) => ActivationResponse.whiskError(msg)
+                            case BlackboxStartupError(msg)       => ActivationResponse.applicationError(msg)
+                            case _                               => ActivationResponse.whiskError(t.getMessage)
+                        }
+                        val activation = ContainerProxy.constructWhiskActivation(job, Interval.zero, response)
+                        sendActiveAck(transid, activation)
+                        storeActivation(transid, activation)
+                }
+                .flatMap {
+                    container =>
+                        initializeAndRun(container, job)
+                            .map(_ => WarmedData(container, job.msg.user.namespace, job.action, Instant.now))
+                }.pipeTo(self)
+
+            goto(Running)
+    }
+
+    when(Starting) {
+        // container was successfully obtained
+        case Event(data: PreWarmedData, _) =>
+            context.parent ! NeedWork(data)
+            goto(Started) using data
+
+        // container creation failed
+        case Event(_: FailureMessage, _) =>
+            context.parent ! ContainerRemoved
+            stop()
+
+        case _ => delay
+    }
+
+    when(Started) {
+        case Event(job: Run, data: PreWarmedData) =>
+            implicit val transid = job.msg.transid
+            initializeAndRun(data.container, job)
+                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+                .pipeTo(self)
+
+            goto(Running)
+
+        case Event(Remove, data: PreWarmedData) => destroyContainer(data.container)
+    }
+
+    when(Running) {
+        // Intermediate state, we were able to start a container
+        // and we keep it in case we need to destroy it.
+        case Event(data: PreWarmedData, _) => stay using data
+
+        // Run was successful
+        case Event(data: WarmedData, _) =>
+            context.parent ! NeedWork(data)
+            goto(Ready) using data
+
+        // Failed after /init (the first run failed)
+        case Event(_: FailureMessage, data: PreWarmedData) => destroyContainer(data.container)
+
+        // Failed for a subsequent /run
+        case Event(_: FailureMessage, data: WarmedData)    => destroyContainer(data.container)
+
+        // Failed at getting a container for a cold-start run
+        case Event(_: FailureMessage, _) =>
+            context.parent ! ContainerRemoved
+            stop()
+
+        case _ => delay
+    }
+
+    when(Ready, stateTimeout = pauseGrace) {
+        case Event(job: Run, data: WarmedData) =>
+            implicit val transid = job.msg.transid
+            initializeAndRun(data.container, job)
+                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+                .pipeTo(self)
+
+            goto(Running)
+
+        // pause grace timed out
+        case Event(StateTimeout, data: WarmedData) =>
+            data.container.suspend()(TransactionId.invokerNanny).map(_ => ContainerPaused).pipeTo(self)
+            goto(Pausing)
+
+        case Event(Remove, data: WarmedData) => destroyContainer(data.container)
+    }
+
+    when(Pausing) {
+        case Event(ContainerPaused, data: WarmedData) =>
+            context.parent ! NeedWork(data)
+            goto(Paused)
+
+        case Event(_: FailureMessage, data: WarmedData) => destroyContainer(data.container)
+        case _ => delay
+    }
+
+    when(Paused, stateTimeout = unusedTimeout) {
+        case Event(job: Run, data: WarmedData) =>
+            implicit val transid = job.msg.transid
+            data.container.resume().andThen {
+                // Sending the message to self on a failure will cause the message
+                // to ultimately be sent back to the parent (which will retry it)
+                // when container removal is done.
+                case Failure(_) => self ! job
+            }.flatMap(_ => initializeAndRun(data.container, job))
+                .map(_ => WarmedData(data.container, job.msg.user.namespace, job.action, Instant.now))
+                .pipeTo(self)
+
+            goto(Running)
+
+        // timeout or removing
+        case Event(StateTimeout | Remove, data: WarmedData) => destroyContainer(data.container)
+    }
+
+    when(Removing) {
+        case Event(job: Run, _) =>
+            // Send the job back to the pool to be rescheduled
+            context.parent ! job
+            stay
+        case Event(ContainerRemoved, _) => stop()
+    }
+
+    // Unstash all messages stashed while in intermediate state
+    onTransition {
+        case _ -> Started  => unstashAll()
+        case _ -> Ready    => unstashAll()
+        case _ -> Paused   => unstashAll()
+        case _ -> Removing => unstashAll()
+    }
+
+    initialize()
+
+    /** Delays all incoming messages until unstashAll() is called */
+    def delay = {
+        stash()
+        stay
+    }
+
+    /**
+     * Destroys the container after unpausing it if needed. Can be used
+     * as a state progression as it goes to Removing.
+     *
+     * @param container the container to destroy
+     */
+    def destroyContainer(container: Container) = {
+        context.parent ! ContainerRemoved
+
+        val unpause = stateName match {
+            case Paused => container.resume()(TransactionId.invokerNanny)
+            case _      => Future.successful(())
+        }
+
+        unpause
+            .flatMap(_ => container.destroy()(TransactionId.invokerNanny))
+            .map(_ => ContainerRemoved).pipeTo(self)
+
+        goto(Removing)
+    }
+
+    /**
+     * Runs the job, initialize first if necessary.
+     *
+     * @param container the container to run the job on
+     * @param job the job to run
+     * @return a future completing after logs have been collected and
+     *         added to the WhiskActivation
+     */
+    def initializeAndRun(container: Container, job: Run)(implicit tid: TransactionId): Future[WhiskActivation] = {
+        val actionTimeout = job.action.limits.timeout.duration
+
+        // Only initialize iff we haven't yet warmed the container
+        val initialize = stateData match {
+            case data: WarmedData => Future.successful(Interval.zero)
+            case _                => container.initialize(job.action.containerInitializer, actionTimeout)
+        }
+
+        val activation: Future[WhiskActivation] = initialize.flatMap { initInterval =>
+            val parameters = job.msg.content getOrElse JsObject()
+
+            val environment = JsObject(
+                "api_key" -> job.msg.user.authkey.compact.toJson,
+                "namespace" -> job.msg.user.namespace.toJson,
+                "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
+                "activation_id" -> job.msg.activationId.toString.toJson,
+                // compute deadline on invoker side avoids discrepancies inside container
+                // but potentially under-estimates actual deadline
+                "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)
+
+            container.run(parameters, environment, actionTimeout)(job.msg.transid).map {
+                case (runInterval, response) =>
+                    val initRunInterval = Interval(runInterval.start.minusMillis(initInterval.duration.toMillis), runInterval.end)
+                    ContainerProxy.constructWhiskActivation(job, initRunInterval, response)
+            }
+        }.recover {
+            case InitializationError(interval, response) =>
+                ContainerProxy.constructWhiskActivation(job, interval, response)
+        }
+
+        // Sending active ack and storing the activation are concurrent side-effects
+        // and do not block further execution of the future. They are completely
+        // asynchronous.
+        activation.andThen {
+            case Success(activation) => sendActiveAck(tid, activation)
+        }.flatMap { activation =>
+            container.logs(job.action.limits.logs.asMegaBytes, job.action.exec.sentinelledLogs).map { logs =>
+                activation.withLogs(ActivationLogs(logs.toVector))
+            }
+        }.andThen {
+            case Success(activation) => storeActivation(tid, activation)
+        }.flatMap { activation =>
+            // Fail the future iff the activation was unsuccessful to facilitate
+            // better cleanup logic.
+            if (activation.response.isSuccess) Future.successful(activation)
+            else Future.failed(ActivationUnsuccessfulError(activation))
+        }
+    }
+}
+
+object ContainerProxy {
+    def props(factory: (TransactionId, String, ImageName, Boolean, ByteSize) => Future[Container],
+              ack: (TransactionId, WhiskActivation) => Future[Any],
+              store: (TransactionId, WhiskActivation) => Future[Any]) = Props(new ContainerProxy(factory, ack, store))
+
+    // Needs to be thread-safe as it's used by multiple proxies concurrently.
+    private val containerCount = new Counter
+
+    /**
+     * Generates a unique container name.
+     *
+     * @param prefix the container name's prefix
+     * @param suffic the container name's suffix
+     * @return a unique container name
+     */
+    def containerName(prefix: String, suffix: String) =
+        s"wsk_${containerCount.next()}_${prefix}_${suffix}".replaceAll("[^a-zA-Z0-9_]", "")
+
+    /**
+     * Creates a WhiskActivation ready to be sent via active ack.
+     *
+     * @param job the job that was executed
+     * @param interval the time it took to execute the job
+     * @param response the response to return to the user
+     * @return a WhiskActivation to be sent to the user
+     */
+    def constructWhiskActivation(job: Run, interval: Interval, response: ActivationResponse) = {
+        val causedBy = if (job.msg.causedBySequence) Parameters("causedBy", "sequence".toJson) else Parameters()
+        WhiskActivation(
+            activationId = job.msg.activationId,
+            namespace = job.msg.activationNamespace,
+            subject = job.msg.user.subject,
+            cause = job.msg.cause,
+            name = job.action.name,
+            version = job.action.version,
+            start = interval.start,
+            end = interval.end,
+            duration = Some(interval.duration.toMillis),
+            response = response,
+            annotations = {
+                Parameters("limits", job.action.limits.toJson) ++
+                    Parameters("path", job.action.fullyQualifiedName(false).toString.toJson) ++ causedBy
+            })
+    }
+}
+
+/** Indicates an activation with a non-successful response */
+case class ActivationUnsuccessfulError(activation: WhiskActivation) extends Exception(s"activation ${activation.activationId} failed")

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile 'com.jayway.restassured:rest-assured:2.6.0'
     compile 'org.scalatest:scalatest_2.11:3.0.1'
     compile 'io.spray:spray-testkit_2.11:1.3.3'
+    compile 'com.typesafe.akka:akka-testkit_2.11:2.4.16'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.scalamock:scalamock-scalatest-support_2.11:3.4.2'
 

--- a/tests/src/test/scala/common/LoggedFunction.scala
+++ b/tests/src/test/scala/common/LoggedFunction.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import scala.collection.mutable
+
+/**
+ * Extensions for Functions to provide introspection of their respective calls.
+ *
+ * Use like:
+ *     val func = LoggedFunction { (a, b) => a + b }
+ *     func(1, 2)
+ *     func.calls should have size 1
+ *     func.calls.head shouldBe (1, 2)
+ */
+
+class LoggedFunction2[A1, A2, B](body: (A1, A2) => B) extends Function2[A1, A2, B] {
+    val calls = mutable.Buffer[(A1, A2)]()
+
+    override def apply(v1: A1, v2: A2): B = {
+        calls += ((v1, v2))
+        body(v1, v2)
+    }
+}
+
+class LoggedFunction5[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) extends Function5[A1, A2, A3, A4, A5, B] {
+    val calls = mutable.Buffer[(A1, A2, A3, A4, A5)]()
+
+    override def apply(v1: A1, v2: A2, v3: A3, v4: A4, v5: A5): B = {
+        calls += ((v1, v2, v3, v4, v5))
+        body(v1, v2, v3, v4, v5)
+    }
+}
+
+object LoggedFunction {
+    def apply[A1, A2, B](body: (A1, A2) => B) = new LoggedFunction2(body)
+    def apply[A1, A2, A3, A4, A5, B](body: (A1, A2, A3, A4, A5) => B) = new LoggedFunction5(body)
+}

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1,0 +1,543 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.test
+
+import java.time.Instant
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpecLike
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.FSM
+import akka.actor.FSM.CurrentState
+import akka.actor.FSM.SubscribeTransitionCallBack
+import akka.actor.FSM.Transition
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import common.LoggedFunction
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.container.Interval
+import whisk.core.containerpool._
+import whisk.core.entity._
+import whisk.core.entity.ExecManifest.RuntimeManifest
+import whisk.core.entity.ExecManifest.ImageName
+import whisk.core.entity.size._
+
+@RunWith(classOf[JUnitRunner])
+class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
+    with ImplicitSender
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockFactory {
+
+    override def afterAll = TestKit.shutdownActorSystem(system)
+
+    val timeout = 5.seconds
+
+    // Common entities to pass to the tests. We don't really care what's inside
+    // those for the behavior testing here, as none of the contents will really
+    // reach a container anyway. We merely assert that passing and extraction of
+    // the values is done properly.
+    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+    val memoryLimit = 256.MB
+
+    val invocationNamespace = EntityName("invocationSpace")
+    val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+
+    val message = ActivationMessage(
+        TransactionId.testing,
+        action.fullyQualifiedName(true),
+        action.rev,
+        Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+        ActivationId(),
+        invocationNamespace.toPath,
+        None)
+
+    /*
+     * Helpers for assertions and actor lifecycles
+     */
+    /** Imitates a StateTimeout in the FSM */
+    def timeout(actor: ActorRef) = actor ! FSM.StateTimeout
+
+    /** Registers the transition callback and expects the first message */
+    def registerCallback(c: ActorRef) = {
+        c ! SubscribeTransitionCallBack(testActor)
+        expectMsg(CurrentState(c, Uninitialized))
+    }
+
+    /** Pre-warms the given state-machine, assumes good cases */
+    def preWarm(machine: ActorRef) = {
+        machine ! Start(exec, memoryLimit)
+        expectMsg(Transition(machine, Uninitialized, Starting))
+        expectPreWarmed(exec.kind)
+        expectMsg(Transition(machine, Starting, Started))
+    }
+
+    /** Run the common action on the state-machine, assumes good cases */
+    def run(machine: ActorRef, currentState: ContainerState) = {
+        machine ! Run(action, message)
+        expectMsg(Transition(machine, currentState, Running))
+        expectWarmed(invocationNamespace.name, action)
+        expectMsg(Transition(machine, Running, Ready))
+    }
+
+    /** Expect a NeedWork message with prewarmed data */
+    def expectPreWarmed(kind: String) = expectMsgPF() {
+        case NeedWork(PreWarmedData(_, kind)) => true
+    }
+
+    /** Expect a NeedWork message with warmed data */
+    def expectWarmed(namespace: String, action: ExecutableWhiskAction) = {
+        val test = EntityName(namespace)
+        expectMsgPF() {
+            case NeedWork(WarmedData(_, `test`, `action`, _)) => true
+        }
+    }
+
+    /** Expect the container to pause successfully */
+    def expectPause(machine: ActorRef) = {
+        expectMsg(Transition(machine, Ready, Pausing))
+        expectWarmed(invocationNamespace.name, action)
+        expectMsg(Transition(machine, Pausing, Paused))
+    }
+
+    /** Creates an inspectable version of the ack method, which records all calls in a buffer */
+    def createAcker = LoggedFunction { (_: TransactionId, _: WhiskActivation) => Future.successful(()) }
+
+    /** Creates an inspectable factory */
+    def createFactory(response: Future[Container]) = LoggedFunction {
+        (_: TransactionId, _: String, _: ImageName, _: Boolean, _: ByteSize) => response
+    }
+
+    val store = stubFunction[TransactionId, WhiskActivation, Future[Any]]
+
+    behavior of "ContainerProxy"
+
+    /*
+     * SUCCESSFUL CASES
+     */
+    it should "create a container given a Start message" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.successful(container))
+
+        val machine = childActorOf(ContainerProxy.props(factory, createAcker, store))
+        registerCallback(machine)
+        preWarm(machine)
+
+        factory.calls should have size 1
+        val (tid, name, _, _, memory) = factory.calls(0)
+        tid shouldBe TransactionId.invokerWarmup
+        name should fullyMatch regex """wsk_\d+_prewarm_actionKind"""
+        memory shouldBe memoryLimit
+    }
+
+    it should "run a container which has been started before, write an active ack, write to the store, pause and remove the container" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+
+        preWarm(machine)
+        run(machine, Started)
+
+        // Timeout causes the container to pause
+        timeout(machine)
+        expectPause(machine)
+
+        // Another pause causes the container to be removed
+        timeout(machine)
+        expectMsg(ContainerRemoved)
+        expectMsg(Transition(machine, Paused, Removing))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 1
+            container.logsCount shouldBe 1
+            container.suspendCount shouldBe 1
+            container.destroyCount shouldBe 1
+            acker.calls should have size 1
+            store.verify(message.transid, *)
+        }
+    }
+
+    it should "run an action and continue with a next run without pausing the container" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        preWarm(machine)
+
+        run(machine, Started)
+        // Note that there are no intermediate state changes
+        run(machine, Ready)
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 2
+            container.logsCount shouldBe 2
+            container.suspendCount shouldBe 0
+            acker.calls should have size 2
+            store.verify(message.transid, *).repeat(2)
+        }
+    }
+
+    it should "run an action after pausing the container" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        preWarm(machine)
+
+        run(machine, Started)
+        timeout(machine)
+        expectPause(machine)
+        run(machine, Paused)
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 2
+            container.logsCount shouldBe 2
+            container.suspendCount shouldBe 1
+            container.resumeCount shouldBe 1
+            acker.calls should have size 2
+            store.verify(message.transid, *).repeat(2)
+        }
+    }
+
+    it should "successfully run on an uninitialized container" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        run(machine, Uninitialized)
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 1
+            container.logsCount shouldBe 1
+            acker.calls should have size 1
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    /*
+     * ERROR CASES
+     */
+    it should "complete the transaction and abort if container creation fails" in within(timeout) {
+        val container = new TestContainer
+        val factory = createFactory(Future.failed(new Exception()))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        machine ! Run(action, message)
+        expectMsg(Transition(machine, Uninitialized, Running))
+        expectMsg(ContainerRemoved)
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 0
+            container.runCount shouldBe 0
+            container.logsCount shouldBe 0 // gather no logs
+            container.destroyCount shouldBe 0 // no destroying possible as no container could be obtained
+            acker.calls should have size 1
+            acker.calls(0)._2.response should be a 'whiskError
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    it should "complete the transaction and destroy the container on a failed init" in within(timeout) {
+        val container = new TestContainer {
+            override def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+                initializeCount += 1
+                Future.failed(InitializationError(Interval.zero, ActivationResponse.applicationError("boom")))
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        machine ! Run(action, message)
+        expectMsg(Transition(machine, Uninitialized, Running))
+        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+        expectMsg(Transition(machine, Running, Removing))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 0 // should not run the action
+            container.logsCount shouldBe 1
+            container.destroyCount shouldBe 1
+            acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    it should "complete the transaction and destroy the container on a failed run" in within(timeout) {
+        val container = new TestContainer {
+            override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+                runCount += 1
+                Future.successful((Interval.zero, ActivationResponse.applicationError("boom")))
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        machine ! Run(action, message)
+        expectMsg(Transition(machine, Uninitialized, Running))
+        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+        expectMsg(Transition(machine, Running, Removing))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 1
+            container.logsCount shouldBe 1
+            container.destroyCount shouldBe 1
+            acker.calls(0)._2.response shouldBe ActivationResponse.applicationError("boom")
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    it should "resend the job to the parent if resuming a container fails" in within(timeout) {
+        val container = new TestContainer {
+            override def resume()(implicit transid: TransactionId) = {
+                resumeCount += 1
+                Future.failed(new RuntimeException())
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        run(machine, Uninitialized) // first run an activation
+        timeout(machine) // times out Ready state so container suspends
+        expectPause(machine)
+
+        val runMessage = Run(action, message)
+        machine ! runMessage
+        expectMsg(Transition(machine, Paused, Running))
+        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+        expectMsg(Transition(machine, Running, Removing))
+        expectMsg(runMessage)
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.runCount shouldBe 1
+            container.suspendCount shouldBe 1
+            container.resumeCount shouldBe 1
+            container.destroyCount shouldBe 1
+        }
+    }
+
+    it should "remove the container if suspend fails" in within(timeout) {
+        val container = new TestContainer {
+            override def suspend()(implicit transid: TransactionId) = {
+                suspendCount += 1
+                Future.failed(new RuntimeException())
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        run(machine, Uninitialized)
+        timeout(machine) // times out Ready state so container suspends
+        expectMsg(Transition(machine, Ready, Pausing))
+        expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
+        expectMsg(Transition(machine, Pausing, Removing))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.suspendCount shouldBe 1
+            container.destroyCount shouldBe 1
+        }
+    }
+
+    /*
+     * DELAYED DELETION CASES
+     */
+    // this test represents a Remove message whenever you are in the "Running" state. Therefore, testing
+    // a Remove while /init should suffice to guarantee test coverage here.
+    it should "delay a deletion message until the transaction is completed successfully" in within(timeout) {
+        val initPromise = Promise[Interval]
+        val container = new TestContainer {
+            override def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+                initializeCount += 1
+                initPromise.future
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+
+        // Start running the action
+        machine ! Run(action, message)
+        expectMsg(Transition(machine, Uninitialized, Running))
+
+        // Schedule the container to be removed
+        machine ! Remove
+
+        // Finish /init, note that /run and log-collecting happens nonetheless
+        initPromise.success(Interval.zero)
+        expectWarmed(invocationNamespace.name, action)
+        expectMsg(Transition(machine, Running, Ready))
+
+        // Remove the container after the transaction finished
+        expectMsg(ContainerRemoved)
+        expectMsg(Transition(machine, Ready, Removing))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 1
+            container.logsCount shouldBe 1
+            container.suspendCount shouldBe 0 // skips pausing the container
+            container.destroyCount shouldBe 1
+            acker.calls should have size 1
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    // this tests a Run message in the "Removing" state. The contract between the pool and state-machine
+    // is, that only one Run is to be sent until a "NeedWork" comes back. If we sent a NeedWork but no work is
+    // there, we might run into the final timeout which will schedule a removal of the container. There is a
+    // time window though, in which the pool doesn't know of that decision yet. We handle the collision by
+    // sending the Run back to the pool so it can reschedule.
+    it should "send back a Run message which got sent before the container decided to remove itself" in within(timeout) {
+        val destroyPromise = Promise[Unit]
+        val container = new TestContainer {
+            override def destroy()(implicit transid: TransactionId): Future[Unit] = {
+                destroyCount += 1
+                destroyPromise.future
+            }
+        }
+        val factory = createFactory(Future.successful(container))
+        val acker = createAcker
+
+        val machine = childActorOf(ContainerProxy.props(factory, acker, store))
+        registerCallback(machine)
+        run(machine, Uninitialized)
+        timeout(machine)
+        expectPause(machine)
+        timeout(machine)
+
+        // We don't know of this timeout, so we schedule a run.
+        machine ! Run(action, message)
+
+        // State-machine shuts down nonetheless.
+        expectMsg(ContainerRemoved)
+        expectMsg(Transition(machine, Paused, Removing))
+
+        // Pool gets the message again.
+        expectMsg(Run(action, message))
+
+        awaitAssert {
+            factory.calls should have size 1
+            container.initializeCount shouldBe 1
+            container.runCount shouldBe 1
+            container.logsCount shouldBe 1
+            container.suspendCount shouldBe 1
+            container.resumeCount shouldBe 1
+            container.destroyCount shouldBe 1
+            acker.calls should have size 1
+            store.verify(message.transid, *).repeat(1)
+        }
+    }
+
+    /**
+     * Implements all the good cases of a perfect run to facilitate error case overriding.
+     */
+    class TestContainer extends Container {
+        var suspendCount = 0
+        var resumeCount = 0
+        var destroyCount = 0
+        var initializeCount = 0
+        var runCount = 0
+        var logsCount = 0
+
+        def suspend()(implicit transid: TransactionId): Future[Unit] = {
+            suspendCount += 1
+            Future.successful(())
+        }
+        def resume()(implicit transid: TransactionId): Future[Unit] = {
+            resumeCount += 1
+            Future.successful(())
+        }
+        def destroy()(implicit transid: TransactionId): Future[Unit] = {
+            destroyCount += 1
+            Future.successful(())
+        }
+        def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+            initializeCount += 1
+            initializer shouldBe action.containerInitializer
+            timeout shouldBe action.limits.timeout.duration
+            Future.successful(Interval.zero)
+        }
+        def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+            runCount += 1
+            environment.fields("api_key") shouldBe message.user.authkey.toJson
+            environment.fields("namespace") shouldBe invocationNamespace.toJson
+            environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
+            environment.fields("activation_id") shouldBe message.activationId.toJson
+            val deadline = Instant.ofEpochMilli(environment.fields("deadline").convertTo[String].toLong)
+            val maxDeadline = Instant.now.plusMillis(timeout.toMillis)
+
+            // The deadline should be in the future but must be smaller than or equal
+            // a freshly computed deadline, as they get computed slightly after each other
+            deadline should (be <= maxDeadline and be >= Instant.now)
+
+            Future.successful((Interval.zero, ActivationResponse.success()))
+        }
+        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]] = {
+            logsCount += 1
+            Future.successful(List("helloTest"))
+        }
+    }
+}


### PR DESCRIPTION
A proxy that wraps a Container. It is used to keep track of the lifecycle
of a container and to guarantee a contract between the client of the container
and the container itself.

The contract is as follows:
1. Only one job is to be sent to the ContainerProxy at one time. ContainerProxy
   will delay all further jobs until the first job is finished for defensiveness
   reasons.
2. The next job can be sent to the ContainerProxy after it indicated capacity by
   sending NeedWork to its parent.
3. A Remove message can be sent at any point in time. Like multiple jobs though,
   it will be delayed until the currently running job has finished.

Closes #2091