### PR TITLE
Use the correct repo to checkout swift-watson-sdk

### DIFF
--- a/core/swift3Action/spm-build/Package.swift
+++ b/core/swift3Action/spm-build/Package.swift
@@ -19,8 +19,8 @@ import PackageDescription
 let package = Package(
     name: "Action",
         dependencies: [
-    .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.0.1"),
+            .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", "1.0.1"),
             .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", "14.2.0"),
-            .Package(url: "https://github.com/IBM-Swift/swift-watson-sdk.git", "0.4.1")
+            .Package(url: "https://github.com/watson-developer-cloud/swift-sdk.git", "0.14.3")
         ]
 )


### PR DESCRIPTION
The *right* repository got fixes to work on Linux quite recently, hence the duplication was lifted. This the correct repository for dependency management.