### PR TITLE
Update from Go 1.7 to 1.8

### DIFF
--- a/tools/cli/Dockerfile
+++ b/tools/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.8
 
 # Install zip
 RUN apt-get -y update && \


### PR DESCRIPTION
- Increase build speed by as much as 15%
- More info on Go 1.8: https://blog.golang.org/go1.8