### PR TITLE
issue 1953 option --result invokes implicit blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd openwhisk/tools/vagrant
 
 Wait for hello action output:
 ```
-wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+wsk action invoke /whisk.system/utils/echo -p message hello --result
 {
     "message": "hello"
 }

--- a/ansible/README_DISTRIBUTED.md
+++ b/ansible/README_DISTRIBUTED.md
@@ -110,5 +110,5 @@ Setup your CLI and verify that OpenWhisk is working.
 
 ```
 ../bin/wsk property set --auth $(cat files/auth.whisk.system) --apihost <edge_url>
-../bin/wsk -i -v action invoke /whisk.system/samples/helloWorld --blocking --result
+../bin/wsk -i -v action invoke /whisk.system/samples/helloWorld --result
 ```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -139,7 +139,7 @@ Parameters can be passed to the action when it is invoked.
 
   To pass parameters directly through the command-line, supply a key/value pair to the `--param` flag:
   ```
-  $ wsk action invoke --blocking --result hello --param name Bernie --param place Vermont
+  $ wsk action invoke --result hello --param name Bernie --param place Vermont
   ```
 
   In order to use a file containing parameter content, create a file containing the parameters in JSON format. The
@@ -154,7 +154,7 @@ Parameters can be passed to the action when it is invoked.
   ```
 
   ```
-  $ wsk action invoke --blocking --result hello --param-file parameters.json
+  $ wsk action invoke --result hello --param-file parameters.json
   ```
 
   ```
@@ -163,7 +163,8 @@ Parameters can be passed to the action when it is invoked.
   }
   ```
 
-  Notice the use of the `--result` option to display only the invocation result.
+  Notice the use of the `--result` option to display only the invocation result. This option invokes an action implicitly as a blocking invocation and the option `--blocking`can be omitted.
+  
 
 ### Setting default parameters
 
@@ -196,7 +197,7 @@ Rather than pass all the parameters to an action every time, you can bind certai
 2. Invoke the action, passing only the `name` parameter this time.
 
   ```
-  $ wsk action invoke --blocking --result hello --param name Bernie
+  $ wsk action invoke --result hello --param name Bernie
   ```
   ```
   {
@@ -211,7 +212,7 @@ Rather than pass all the parameters to an action every time, you can bind certai
   Using the `--param` flag:
 
   ```
-  $ wsk action invoke --blocking --result hello --param name Bernie --param place "Washington, DC"
+  $ wsk action invoke --result hello --param name Bernie --param place "Washington, DC"
   ```
 
   Using the `--param-file` flag:
@@ -225,7 +226,7 @@ Rather than pass all the parameters to an action every time, you can bind certai
   ```
 
   ```
-  $ wsk action invoke --blocking --result hello --param-file parameters.json
+  $ wsk action invoke --result hello --param-file parameters.json
   ```
 
   ```
@@ -264,7 +265,7 @@ JavaScript functions that run asynchronously may need to return the activation r
   $ wsk action create asyncAction asyncAction.js
   ```
   ```
-  $ wsk action invoke --blocking --result asyncAction
+  $ wsk action invoke --result asyncAction
   ```
   ```
   {
@@ -340,7 +341,7 @@ This example invokes a Yahoo Weather service to get the current conditions at a 
   $ wsk action create weather weather.js
   ```
   ```
-  $ wsk action invoke --blocking --result weather --param location "Brooklyn, NY"
+  $ wsk action invoke --result weather --param location "Brooklyn, NY"
   ```
   ```
   {
@@ -404,7 +405,7 @@ To create an OpenWhisk action from this package:
 4. You can invoke the action like any other:
 
   ```
-  $ wsk action invoke --blocking --result packageAction --param lines "[\"and now\", \"for something completely\", \"different\" ]"
+  $ wsk action invoke --result packageAction --param lines "[\"and now\", \"for something completely\", \"different\" ]"
   ```
   ```
   {
@@ -452,7 +453,7 @@ Several utility actions are provided in a package called `/whisk.system/utils` t
 3. Invoke the action:
 
   ```
-  $ wsk action invoke --blocking --result sequenceAction --param payload "Over-ripe sushi,\nThe Master\nIs full of regret."
+  $ wsk action invoke --result sequenceAction --param payload "Over-ripe sushi,\nThe Master\nIs full of regret."
   ```
   ```
   {
@@ -502,7 +503,7 @@ The CLI automatically infers the type of the action from the source file extensi
 Action invocation is the same for Python actions as it is for JavaScript actions:
 
 ```
-$ wsk action invoke --blocking --result helloPython --param name World
+$ wsk action invoke --result helloPython --param name World
 ```
 
 ```
@@ -592,7 +593,7 @@ the tool determines that from the file extension.
 Action invocation is the same for Swift actions as it is for JavaScript actions:
 
 ```
-$ wsk action invoke --blocking --result helloSwift --param name World
+$ wsk action invoke --result helloSwift --param name World
 ```
 
 ```
@@ -709,7 +710,7 @@ e.g., `--main com.example.MyMain`.
 Action invocation is the same for Java actions as it is for Swift and JavaScript actions:
 
 ```
-$ wsk action invoke --blocking --result helloJava --param name World
+$ wsk action invoke --result helloJava --param name World
 ```
 
 ```
@@ -794,7 +795,7 @@ For the instructions that follow, assume that the Docker user ID is `janesmith` 
   The action may be invoked as any other OpenWhisk action.
 
   ```
-  $ wsk action invoke --blocking --result example --param payload Rey
+  $ wsk action invoke --result example --param payload Rey
   ```
   ```
   {

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -84,7 +84,7 @@ You can invoke actions in a package, just as with other actions. The next few st
 2. Invoke the action without any parameters.
 
   ```
-  $ wsk action invoke --blocking --result /whisk.system/samples/greeting
+  $ wsk action invoke --result /whisk.system/samples/greeting
   ```
   ```
   {
@@ -97,7 +97,7 @@ You can invoke actions in a package, just as with other actions. The next few st
 3. Invoke the action with parameters.
 
   ```
-  $ wsk action invoke --blocking --result /whisk.system/samples/greeting --param name Mork --param place Ork
+  $ wsk action invoke --result /whisk.system/samples/greeting --param name Mork --param place Ork
   ```
   ```
   {
@@ -143,7 +143,7 @@ In the following simple example, you bind to the `/whisk.system/samples` package
 3. Invoke an action in the package binding.
 
   ```
-  $ wsk action invoke --blocking --result valhallaSamples/greeting --param name Odin
+  $ wsk action invoke --result valhallaSamples/greeting --param name Odin
   ```
   ```
   {
@@ -156,7 +156,7 @@ In the following simple example, you bind to the `/whisk.system/samples` package
 4. Invoke an action and overwrite the default parameter value.
 
   ```
-  $ wsk action invoke --blocking --result valhallaSamples/greeting --param name Odin --param place Asgard
+  $ wsk action invoke --result valhallaSamples/greeting --param name Odin --param place Asgard
   ```
   ```
   {
@@ -293,7 +293,7 @@ To create a custom package with a simple action in it, try the following example
 6. Invoke the action in the package.
 
   ```
-  $ wsk action invoke --blocking --result custom/identity
+  $ wsk action invoke --result custom/identity
   ```
   ```
   {}
@@ -354,7 +354,7 @@ You can set default parameters for all the entities in a package. You do this by
 3. Invoke the identity action without any parameters to verify that the action indeed inherits the parameters.
 
   ```
-  $ wsk action invoke --blocking --result custom/identity
+  $ wsk action invoke --result custom/identity
   ```
   ```
   {
@@ -366,7 +366,7 @@ You can set default parameters for all the entities in a package. You do this by
 4. Invoke the identity action with some parameters. Invocation parameters are merged with the package parameters; the invocation parameters override the package parameters.
 
   ```
-  $ wsk action invoke --blocking --result custom/identity --param city Dallas --param state Texas
+  $ wsk action invoke --result custom/identity --param city Dallas --param state Texas
   ```
   ```
   {

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -30,7 +30,7 @@ To use this example, follow these steps:
 3. Then, invoke the action by entering the following commands.
 
     ```
-    $ wsk action invoke hello --blocking --result
+    $ wsk action invoke hello --result
     ```
 
     This command outputs:
@@ -42,7 +42,7 @@ To use this example, follow these steps:
     ```
 
     ```
-    $ wsk action invoke hello --blocking --result --param name Fred
+    $ wsk action invoke hello --result --param name Fred
     ```
 
     This command outputs:

--- a/tests/src/test/scala/system/basic/WskBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskBasicTests.scala
@@ -291,7 +291,7 @@ class WskBasicTests
 
             wsk.action.get(name, fieldFilter = Some("name")).stdout should include(s"""$successMsg name\n"$name"""")
             wsk.action.get(name, fieldFilter = Some("version")).stdout should include(s"""$successMsg version\n"0.0.1"""")
-            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include (s"""$successMsg""")
+            wsk.action.get(name, fieldFilter = Some("exec")).stdout should include(s"""$successMsg""")
             wsk.action.get(name, fieldFilter = Some("exec")).stdout should include regex (s"""$successMsg exec\n\\{\\s+"kind":\\s+"nodejs:6",\\s+"code":\\s+"\\/\\*\\*[\\\\r]*\\\\n \\* Hello, world.[\\\\r]*\\\\n \\*\\/[\\\\r]*\\\\nfunction main\\(params\\) \\{[\\\\r]*\\\\n    greeting \\= 'hello, ' \\+ params.payload \\+ '!'[\\\\r]*\\\\n    console.log\\(greeting\\);[\\\\r]*\\\\n    return \\{payload: greeting\\}[\\\\r]*\\\\n\\}""")
             wsk.action.get(name, fieldFilter = Some("parameters")).stdout should include regex (s"""$successMsg parameters\n\\[\\s+\\{\\s+"key":\\s+"payload",\\s+"value":\\s+"test"\\s+\\}\\s+\\]""")
             wsk.action.get(name, fieldFilter = Some("annotations")).stdout should include regex (s"""$successMsg annotations\n\\[\\s+\\{\\s+"key":\\s+"exec",\\s+"value":\\s+"nodejs:6"\\s+\\}\\s+\\]""")
@@ -362,7 +362,7 @@ class WskBasicTests
             assetHelper.withCleaner(wsk.action, name) {
                 (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
             }
-            wsk.action.invoke(name, Map("payload" -> "one two three".toJson), blocking = true, result = true)
+            wsk.action.invoke(name, Map("payload" -> "one two three".toJson), result = true)
                 .stdout should include regex (""""count": 3""")
     }
 
@@ -411,7 +411,7 @@ class WskBasicTests
                     action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
             }
 
-            val stdout = wsk.action.invoke(name, blocking = true, result = true).stdout
+            val stdout = wsk.action.invoke(name, result = true).stdout
             stdout.parseJson.asJsObject shouldBe JsObject()
     }
 
@@ -424,10 +424,10 @@ class WskBasicTests
                 (action, _) =>
                     action.create(name, Some(TestUtils.getTestActionFilename("timeout.js")),
                         timeout = Some(allowedActionDuration))
-                    action.invoke(name, parameters = params, blocking = true, result = true, expectedExitCode = ACCEPTED)
+                    action.invoke(name, parameters = params, result = true, expectedExitCode = ACCEPTED)
             }
 
-            res.stderr should include ("""but the request has not yet finished""")
+            res.stderr should include("""but the request has not yet finished""")
     }
 
     it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {

--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -531,6 +531,16 @@ class WskBasicUsageTests
             }
     }
 
+    it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
+        (wp, assetHelper) =>
+            val name = "invokeResult"
+            assetHelper.withCleaner(wsk.action, name) {
+                (action, _) => action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
+            }
+            val run = wsk.action.invoke(name, Map("payload" -> "Robert".toJson), blocking = true, result = true)
+            run.stdout should include regex (""""payload": "hello, Robert!""")
+    }
+
     it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
             val name = "deadline"

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -144,6 +144,7 @@ var actionInvokeCmd = &cobra.Command{
                 return getJSONFromStringsParamError(paramArgs, false, err)
             }
         }
+        if flags.action.result {flags.common.blocking = true}
 
         res, _, err := client.Actions.Invoke(
             qualifiedName.entityName,
@@ -900,7 +901,7 @@ func init() {
     actionInvokeCmd.Flags().StringSliceVarP(&flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
     actionInvokeCmd.Flags().StringVarP(&flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
     actionInvokeCmd.Flags().BoolVarP(&flags.common.blocking, "blocking", "b", false, wski18n.T("blocking invoke"))
-    actionInvokeCmd.Flags().BoolVarP(&flags.action.result, "result", "r", false, wski18n.T("show only activation result if a blocking activation (unless there is a failure)"))
+    actionInvokeCmd.Flags().BoolVarP(&flags.action.result, "result", "r", false, wski18n.T("blocking invoke; show only activation result (unless there is a failure)"))
 
     actionGetCmd.Flags().BoolVarP(&flags.common.summary, "summary", "s", false, wski18n.T("summarize action details"))
 

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -908,8 +908,8 @@
     "translation": "blocking invoke"
   },
   {
-    "id": "show only activation result if a blocking activation (unless there is a failure)",
-    "translation": "show only activation result if a blocking activation (unless there is a failure)"
+    "id": "blocking invoke; show only activation result (unless there is a failure)",
+    "translation": "blocking invoke; show only activation result (unless there is a failure)"
   },
   {
     "id": "exclude the first `SKIP` number of actions from the result",

--- a/tools/macos/README.md
+++ b/tools/macos/README.md
@@ -114,7 +114,7 @@ Follow instructions in [Configure CLI](../../docs/README.md#setting-up-the-openw
 
 ### Use the wsk CLI
 ```
-bin/wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+bin/wsk action invoke /whisk.system/utils/echo -p message hello --result
 {
     "message": "hello"
 }

--- a/tools/ubuntu-setup/README.md
+++ b/tools/ubuntu-setup/README.md
@@ -44,7 +44,7 @@ should be `172.17.0.1` or more formally, the IP of the `edge` host from the
 
 ### Use the wsk CLI
 ```
-bin/wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+bin/wsk action invoke /whisk.system/utils/echo -p message hello --result
 {
     "message": "hello"
 }

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -41,7 +41,7 @@ For more information on data store configurations see [tools/db/README.md](../db
 
 ### Wait for hello action output
 ```
-wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+wsk action invoke /whisk.system/utils/echo -p message hello --result
 {
     "message": "hello"
 }
@@ -70,7 +70,7 @@ The following commands assume that you have `wsk` setup correctly in your PATH.
 wsk property set --apihost 192.168.33.13 --auth `vagrant ssh -- cat openwhisk/ansible/files/auth.guest`
 
 # Run the hello sample action
-wsk -i action invoke /whisk.system/utils/echo -p message hello --blocking --result
+wsk -i action invoke /whisk.system/utils/echo -p message hello --result
 {
     "message": "hello"
 }
@@ -92,12 +92,12 @@ For your convenience, a `wsk` wrapper is provided inside the VM which delegates 
 
 Calling the wsk CLI via `vagrant ssh` directly
 ```
-vagrant ssh -- wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+vagrant ssh -- wsk action invoke /whisk.system/utils/echo -p message hello --result
 ```
 Calling the wsk CLI by login into the Vagrant VM
 ```
 vagrant ssh
-wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+wsk action invoke /whisk.system/utils/echo -p message hello --result
 ```
 
 ### Run OpenWhisk tests

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -157,7 +157,7 @@ $script_end = <<SCRIPT
   chown -R vagrant:vagrant $HOME
   # This allows user to see how to configure the wsk cli outside the VM 
   wsk property set --apihost 192.168.33.13 --namespace guest --auth `cat ${ANSIBLE_HOME}/files/auth.guest`
-  wsk action invoke /whisk.system/utils/echo -p message hello --blocking --result
+  wsk action invoke /whisk.system/utils/echo -p message hello --result
 SCRIPT
 
   config.vm.provision "script_end", type: "shell", keep_color: true, inline: $script_end


### PR DESCRIPTION
issue 1953 blocking action invoke from CLI with result

New behaviour:

`wsk action invoke <name> --result`
invokes the action implicit as blocking invocation.
If --result is specified, --blocking can be omitted.

Specifying --blocking and --result still works. 


Changes :
added --result option processing in action.go
changed --result option help message
added unit test case
changed documentations : `--blocking --result` to `--result` 