### PR TITLE
issue 2028 do not print auth key on console

### DIFF
--- a/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/WskBasicUsageTests.scala
@@ -99,7 +99,7 @@ class WskBasicUsageTests
             val env = Map("WSK_CONFIG_FILE" -> tmpwskprops.getAbsolutePath())
             val stdout = wsk.cli(Seq("property", "set", "-i", "--apihost", wskprops.apihost, "--auth", wskprops.authKey,
                 "--namespace", namespace), env = env).stdout
-            stdout should include(s"ok: whisk auth set to ${wskprops.authKey}")
+            stdout should include(s"ok: whisk auth set")
             stdout should include(s"ok: whisk API host set to ${wskprops.apihost}")
             stdout should include(s"ok: whisk namespace set to ${namespace}")
         } finally {

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -186,15 +186,8 @@ var propertyUnsetCmd = &cobra.Command{
         if flags.property.auth {
             delete(props, "AUTH")
             okMsg += fmt.Sprintf(
-                wski18n.T("{{.ok}} whisk auth unset",
+                wski18n.T("{{.ok}} whisk auth unset.\n",
                     map[string]interface{}{"ok": color.GreenString("ok:")}))
-            if len(DefaultAuth) > 0 {
-                okMsg += fmt.Sprintf(
-                    wski18n.T("; the default value will be used. Run 'wsk property get --auth' to see the new value.\n"))
-            } else {
-                okMsg += fmt.Sprint(
-                    wski18n.T("; there is no default value that can be used.\n"))
-            }
         }
 
         if flags.property.namespace {
@@ -215,16 +208,8 @@ var propertyUnsetCmd = &cobra.Command{
         if flags.property.apihost {
             delete(props, "APIHOST")
             okMsg += fmt.Sprintf(
-                wski18n.T("{{.ok}} whisk API host unset",
+                wski18n.T("{{.ok}} whisk API host unset.\n",
                     map[string]interface{}{"ok": color.GreenString("ok:")}))
-            if len(DefaultAPIHost) > 0 {
-                okMsg += fmt.Sprintf(
-                    wski18n.T("; the default value of {{.default}} will be used.\n",
-                        map[string]interface{}{"default": boldString(DefaultAPIHost)}))
-            } else {
-                okMsg += fmt.Sprint(
-                    wski18n.T("; there is no default value that can be used.\n"))
-            }
         }
 
         if flags.property.apiversion {

--- a/tools/cli/go-whisk-cli/commands/property.go
+++ b/tools/cli/go-whisk-cli/commands/property.go
@@ -81,8 +81,8 @@ var propertySetCmd = &cobra.Command{
             props["AUTH"] = auth
             client.Config.AuthToken = auth
             okMsg += fmt.Sprintf(
-                wski18n.T("{{.ok}} whisk auth set to {{.auth}}\n",
-                    map[string]interface{}{"ok": color.GreenString("ok:"), "auth": boldString(auth)}))
+                wski18n.T("{{.ok}} whisk auth set. Run 'wsk property get --auth' to see the new value.\n",
+                    map[string]interface{}{"ok": color.GreenString("ok:")}))
         }
 
         if apiHost := flags.property.apihostSet; len(apiHost) > 0 {
@@ -190,8 +190,7 @@ var propertyUnsetCmd = &cobra.Command{
                     map[string]interface{}{"ok": color.GreenString("ok:")}))
             if len(DefaultAuth) > 0 {
                 okMsg += fmt.Sprintf(
-                    wski18n.T("; the default value of {{.default}} will be used.\n",
-                        map[string]interface{}{"default": boldString(DefaultAuth)}))
+                    wski18n.T("; the default value will be used. Run 'wsk property get --auth' to see the new value.\n"))
             } else {
                 okMsg += fmt.Sprint(
                     wski18n.T("; there is no default value that can be used.\n"))

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -253,8 +253,8 @@
     "translation": "Unable to set the property value: {{.err}}"
   },
   {
-    "id": "{{.ok}} whisk auth set to {{.auth}}\n",
-    "translation": "{{.ok}} whisk auth set to {{.auth}}\n"
+    "id": "{{.ok}} whisk auth set. Run 'wsk property get --auth' to see the new value.\n",
+    "translation": "{{.ok}} whisk auth set. Run 'wsk property get --auth' to see the new value.\n"
   },
   {
     "id": "Unable to set API host value; the API host value '{{.apihost}}' is invalid: {{.err}}",
@@ -311,6 +311,10 @@
   {
     "id": "; the default value of {{.default}} will be used.\n",
     "translation": "; the default value of {{.default}} will be used.\n"
+  },
+  {
+    "id": "; the default value will be used. Run 'wsk property get --auth' to see the new value.\n",
+    "translation": "; the default value will be used. Run 'wsk property get --auth' to see the new value.\n"
   },
   {
     "id": "; there is no default value that can be used.\n",

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -293,16 +293,16 @@
     "translation": "Unable to unset the property value: {{.err}}"
   },
   {
-    "id": "{{.ok}} whisk auth unset",
-    "translation": "{{.ok}} whisk auth unset"
+    "id": "{{.ok}} whisk auth unset.\n",
+    "translation": "{{.ok}} whisk auth unset.\n"
   },
   {
     "id": "{{.ok}} whisk namespace unset",
     "translation": "{{.ok}} whisk namespace unset"
   },
   {
-    "id": "{{.ok}} whisk API host unset",
-    "translation": "{{.ok}} whisk API host unset"
+    "id": "{{.ok}} whisk API host unset.\n",
+    "translation": "{{.ok}} whisk API host unset.\n"
   },
   {
     "id": "{{.ok}} whisk API version unset",
@@ -311,10 +311,6 @@
   {
     "id": "; the default value of {{.default}} will be used.\n",
     "translation": "; the default value of {{.default}} will be used.\n"
-  },
-  {
-    "id": "; the default value will be used. Run 'wsk property get --auth' to see the new value.\n",
-    "translation": "; the default value will be used. Run 'wsk property get --auth' to see the new value.\n"
   },
   {
     "id": "; there is no default value that can be used.\n",


### PR DESCRIPTION
Fixes https://github.com/openwhisk/openwhisk/issues/2028
wsk property set --auth <xxxxxxx>    should not echo the auth key to the console

changed output string, NLS translation id and text, and the related unit test case