### PR TITLE
Exit components on OutOfMemory exceptions

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -8,15 +8,15 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ENV VERSION 8
-ENV UPDATE 77
-ENV BUILD 03
+ENV UPDATE 121
+ENV BUILD 13
 
 ENV JAVA_HOME /usr/lib/jvm/java-${VERSION}-oracle
 ENV JRE_HOME ${JAVA_HOME}/jre
 
 RUN curl --silent --location --retry 3 --cacert /etc/ssl/certs/GeoTrust_Global_CA.pem \
   --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-  http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/server-jre-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
+  http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/e9e7ea248e2c4826b92b3f075a80e441/server-jre-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
   | tar xz -C /tmp && \
   mkdir -p /usr/lib/jvm && mv /tmp/jdk1.${VERSION}.0_${UPDATE} "${JAVA_HOME}" && \
   apt-get autoclean && apt-get --purge -y autoremove && \

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+PrintGCDetails"]
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+CrashOnOutOfMemoryError", "-XX:+PrintGCDetails"]

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError"]
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+PrintGCDetails"]

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-Xmx2g"]
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError"]

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.invoker.Invoker"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError"]
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+PrintGCDetails"]

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.invoker.Invoker"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+PrintGCDetails"]
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+CrashOnOutOfMemoryError", "-XX:+PrintGCDetails"]

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -20,5 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.invoker.Invoker"
-applicationDefaultJvmArgs = ["-Xmx2g"]
-
+applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+ExitOnOutOfMemoryError"]


### PR DESCRIPTION
Scala's idiomatic error handling makes it "hardish" to exit the JVM on fatal errors (for example if a Future fails with a fatal exception). The added flags just ignore error handling and exit the JVM, which we can recover by a docker auto-restart for example.

I bumped the Java versions because the flag was added in 8u92. Figured we might as well go to latest. It got released in January, so it should be stable.