### PR TITLE
Add flag to configure split of whisks and activations db.

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -7,6 +7,11 @@ db_password: couch_password
 db_host: "{{ groups['db'] | first }}"
 db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
 
+# The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
+# If it is false, all activations will be written into the whisks-db.
+# This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
+db_split_actions_and_activations: false
+
 whisk_version_name: local
 nginx_conf_dir: /tmp/nginx
 consul_conf_dir: /tmp/consul

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -16,6 +16,11 @@ db_protocol: "{{ lookup('ini', 'db_protocol section=db_creds file={{ playbook_di
 db_host: "{{ lookup('ini', 'db_host section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 
+# The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
+# If it is false, all activations will be written into the whisks-db.
+# This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
+db_split_actions_and_activations: false
+
 limits:
   actions:
     invokes:

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -21,6 +21,11 @@ db_protocol: "{{ lookup('ini', 'db_protocol section=db_creds file={{ playbook_di
 db_host: "{{ lookup('ini', 'db_host section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_local.ini') }}"
 
+# The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
+# If it is false, all activations will be written into the whisks-db.
+# This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
+db_split_actions_and_activations: false
+
 limits:
   actions:
     invokes:


### PR DESCRIPTION
All actions, rules, triggers, packages and activations are stored in this database. Because of all the activations, this database becomes really huge over time.
To keep the database with the artifacts, created by the users (actions, ...), small we had the idea to put all activations into another database. The activations-db.

To solve the problem of the migration of existing OpenWhisk deployments, my proposal is to make the split configurable with ansible.
This PR creates this flag. By default, the whisks database will be used to store activations.
After some time, I'll open another PR, that changes the default to use the activations-db.
Again, after some time, I'll open a third PR to remove this flag again. By default, all activations will go into the activations-db.
The reason for removing this flag again is, that it will be easier to maintain only one configuration: the configuration to use two seperate dbs.
And we think, that all owners of OpenWhisk deployments agree that it would be good to split configuration data of the user (actions, ...) and logs (activations, ...).

If you need to migrate your deployment, it would work with the steps on the following document:
https://gist.github.com/cbickel/37e651965781b27de245eac0ce831a53

Does anyone have any concerns about this change or any comments?


The new flag is used here:
https://github.com/openwhisk/openwhisk/blob/master/ansible/group_vars/all#L114