### PR TITLE
Reduce unnecessary typecasts in log reading + turn off activation caching

### DIFF
--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -113,6 +113,6 @@ object WhiskActivation
     override val collectionName = "activations"
     override implicit val serdes = jsonFormat13(WhiskActivation.apply)
 
-    override val cacheEnabled = true
+    override val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskActivation) = w.docid.asDocInfo
 }

--- a/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/WhiskActivation.scala
@@ -113,6 +113,8 @@ object WhiskActivation
     override val collectionName = "activations"
     override implicit val serdes = jsonFormat13(WhiskActivation.apply)
 
+    // Caching activations doesn't make much sense in the common case as usually,
+    // an activation is only asked for once.
     override val cacheEnabled = false
     override def cacheKeyForUpdate(w: WhiskActivation) = w.docid.asDocInfo
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -114,6 +114,6 @@ protected[invoker] trait ActionLogDriver {
         if (lines.hasNext) truncated = true
         if (truncated) logLines.append(Messages.truncateLogs(limit))
 
-        ((hasOut && hasErr) || !requireSentinel, truncated || lines.hasNext, logLines.toVector)
+        ((hasOut && hasErr) || !requireSentinel, truncated, logLines.toVector)
     }
 }

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -27,6 +27,7 @@ import whisk.common.{ Logging, TransactionId }
 import whisk.core.entity._
 import whisk.core.entity.size.{ SizeInt, SizeString }
 import scala.collection.mutable.Buffer
+import whisk.http.Messages
 
 /**
  * Represents a single log line as read from a docker log
@@ -61,13 +62,13 @@ protected[invoker] trait ActionLogDriver {
      * @return Tuple containing (isComplete, isTruncated, logs)
      */
     protected def processJsonDriverLogContents(logMsgs: String, requireSentinel: Boolean, limit: ByteSize)(
-        implicit transid: TransactionId, logging: Logging): (Boolean, Boolean, Vector[LogLine]) = {
+        implicit transid: TransactionId, logging: Logging): (Boolean, Boolean, Vector[String]) = {
 
         var hasOut = false
         var hasErr = false
         var truncated = false
         var bytesSoFar = 0.B
-        val logLines = Buffer[LogLine]()
+        val logLines = Buffer[String]()
         val lines = logMsgs.lines
 
         // read whiles bytesSoFar <= limit when requireSentinel to try and grab sentinel if they exist to indicate completion
@@ -81,12 +82,12 @@ protected[invoker] trait ActionLogDriver {
                         if (t.log.nonEmpty) {
                             bytesSoFar += t.log.sizeInBytes
                             if (bytesSoFar <= limit) {
-                                logLines.append(t)
+                                logLines.append(t.toFormattedString)
                             } else {
                                 // chop off the right most bytes that overflow
                                 val chopped = t.dropRight(bytesSoFar - limit)
                                 if (chopped.log.nonEmpty) {
-                                    logLines.append(chopped)
+                                    logLines.append(chopped.toFormattedString)
                                 }
                                 truncated = true
                             }
@@ -109,6 +110,9 @@ protected[invoker] trait ActionLogDriver {
                     logging.error(this, s"log line skipped/did not parse: $t")
             }
         }
+
+        if (lines.hasNext) truncated = true
+        if (truncated) logLines.append(Messages.truncateLogs(limit))
 
         ((hasOut && hasErr) || !requireSentinel, truncated || lines.hasNext, logLines.toVector)
     }


### PR DESCRIPTION
These bits are rather sensitive and can have quite high volumes of data passing through. Therefore, casting through different collections is to be avoided.