### PR TITLE
Set default db for activations to activations-db

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -10,7 +10,7 @@ db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
 # The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
 # If it is false, all activations will be written into the whisks-db.
 # This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
-db_split_actions_and_activations: false
+db_split_actions_and_activations: true
 
 whisk_version_name: local
 nginx_conf_dir: /tmp/nginx

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -19,7 +19,7 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 # The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
 # If it is false, all activations will be written into the whisks-db.
 # This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
-db_split_actions_and_activations: false
+db_split_actions_and_activations: true
 
 limits:
   actions:

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -24,7 +24,7 @@ db_port: "{{ lookup('ini', 'db_port section=db_creds file={{ playbook_dir }}/db_
 # The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
 # If it is false, all activations will be written into the whisks-db.
 # This flag will be removed in the future and the default will be, that all activations are written into an activations-db.
-db_split_actions_and_activations: false
+db_split_actions_and_activations: true
 
 limits:
   actions:

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -105,13 +105,20 @@ nginx:
     api: 443
     adminportal: 8443
 
+# These are the variables to define all database relevant settings.
+# The authKeys are the users, that are initially created to use OpenWhisk.
+# The keys are stored in ansible/files and will be inserted into the authentication databse.
+# The key db.whisk.actions is the name of the database where all artifacts of the user are stored. These artifacts are actions, triggers, rules and packages.
+# The key db.whisk.activation is the name of the database where all activations are stored.
+# The key db.whisk.auth is the name of the authentication database where all keys of all users are stored.
+# The db_prefix is defined for each environment on its own. The CouchDb credentials are also defined for each environment on its own.
 db:
   authkeys:
   - guest
   - whisk.system
   whisk:
     actions: "{{ db_prefix }}whisks"
-    activations: "{% if db_split_actions_and_activations is defined and db_split_actions_and_activations %}{{ db_prefix }}activations{% else %}{{ db_prefix }}whisks{% endif %}"
+    activations: "{% if db_split_actions_and_activations %}{{ db_prefix }}activations{% else %}{{ db_prefix }}whisks{% endif %}"
     auth: "{{ db_prefix }}subjects"
 
 apigateway:

--- a/ansible/tasks/db/recreateDb.yml
+++ b/ansible/tasks/db/recreateDb.yml
@@ -1,7 +1,7 @@
 ---
-# Delete and recreate the specified database.
-# dbName - name of the database to recreate
-# forceRecreation - deletes the database
+# (re))create the specified database.
+# dbName - name of the database to (re)create
+# forceRecreation - if true, the databases will be deleted (if it exists) and recreated. If false, it will not be recreated.
 
 - name: check if {{ dbName }} with {{ db_provider }} exists
   uri:


### PR DESCRIPTION
This PR changes the default setting of all environments to use the activations-db for activations, instead of the whisks-db.
It also requires the flag `db_split_actions_and_activations` to be set. It still can be false, but if it is false, you should care about the migration of your activations to the activations-db.

If you don't matter throwing away all your data, just execute the ansible playbook `wipe.yml`, after `db_split_actions_and_activations` is set to true.
If you want to keep all your data, follow the instructions on the following page:
https://gist.github.com/cbickel/37e651965781b27de245eac0ce831a53

PG1#1437