### PR TITLE
Remove `sealed` qualifier from RunWskCmd trait

### DIFF
--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -881,7 +881,7 @@ object Wsk {
         if (WhiskProperties.useCLIDownload) Buffer(getDownloadedGoCLIPath) else Buffer(WhiskProperties.getCLIPath)
 }
 
-sealed trait RunWskCmd extends Matchers {
+trait RunWskCmd extends Matchers {
 
     /**
      * The base command to run.


### PR DESCRIPTION
Remove `sealed` qualifier from RunWskCmd trait
- to allow class extension outside of Wsk.scala file