### PR TITLE
Update doc to more accurately reflect input mechanism for Docker actions

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -361,7 +361,7 @@ Docker actions run a user-supplied binary in a Docker container. The binary runs
 
 The Docker skeleton is a convenient way to build OpenWhisk-compatible Docker images. You can install the skeleton with the `wsk sdk install docker` CLI command.
 
-The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via a singlecommand-line argument string which can be deserialized as a `JSON` object. It must return a result via `stdout`.
+The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via a single command-line argument string which can be deserialized as a `JSON` object. It must return a result via `stdout`.
 
 You may include any compilation steps or dependencies by modifying the `Dockerfile` included in the `dockerSkeleton`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -361,7 +361,7 @@ Docker actions run a user-supplied binary in a Docker container. The binary runs
 
 The Docker skeleton is a convenient way to build OpenWhisk-compatible Docker images. You can install the skeleton with the `wsk sdk install docker` CLI command.
 
-The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via `stdin` and must return a result via `stdout`.
+The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via a singlecommand-line argument string which can be deserialized as a `JSON` object. It must return a result via `stdout`.
 
 You may include any compilation steps or dependencies by modifying the `Dockerfile` included in the `dockerSkeleton`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -361,7 +361,7 @@ Docker actions run a user-supplied binary in a Docker container. The binary runs
 
 The Docker skeleton is a convenient way to build OpenWhisk-compatible Docker images. You can install the skeleton with the `wsk sdk install docker` CLI command.
 
-The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via a single command-line argument string which can be deserialized as a `JSON` object. It must return a result via `stdout`.
+The main binary program must be located in `/action/exec` inside the container. The executable receives the input arguments via a single command-line argument string which can be deserialized as a `JSON` object. It must return a result via `stdout` as a single-line string of serialized `JSON`.
 
 You may include any compilation steps or dependencies by modifying the `Dockerfile` included in the `dockerSkeleton`.
 


### PR DESCRIPTION
Previously, the documentation stated that a docker action must take
input from `stdin`. After reviewing the code in actionproxy.py (see
lines 128-132), it's clear that this statement is incorrect. Instead,
the executable must take it's argument as a single quoted command-line
argument that can be deserialized as a JSON object.

This issue arose in attempting to implement a docker action using python
and several custom packages (not trivially implemented as a native
python action). If the executable truly read from `stdin`, the following
code would be the correct approach:

```python
import sys
import json

in_raw = sys.stdin.read()
try:
    js = json.loads(in_raw)
    print >> sys.stderr, "successfully interpreted json"
    print json.dumps(js, indent=2)
except ValueError:
    print >> sys.stderr, "failed to interpret json"
    print "{}"
```

This does not work, however, when implemented as a docker action since
the `sys.stdin.read()` blocks while waiting for an EOF. Instead, the
following code does work:

```python
import sys
import json

if len(sys.argv) != 2:
    print >> sys.stderr, "Incorrectly formatted input"
    print "{}"
else:
    try:
        js = json.loads(sys.argv[1])
        print >> sys.stderr, "successfully interpreted json"
        print json.dumps(js, indent=2)
    except ValueError:
        print >> sys.stderr, "failed to interpret json"
        print "{}"
```