### PR TITLE
Implement a containerpool controlling container proxies

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool
+
+import scala.collection.mutable
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.ActorRefFactory
+import akka.actor.Props
+import whisk.common.AkkaLogging
+import whisk.core.dispatcher.ActivationFeed.ContainerReleased
+import whisk.core.entity.ByteSize
+import whisk.core.entity.CodeExec
+import whisk.core.entity.EntityName
+import whisk.core.entity.ExecutableWhiskAction
+import whisk.core.entity.size._
+
+sealed trait WorkerState
+case object Busy extends WorkerState
+case object Free extends WorkerState
+
+case class WorkerData(data: ContainerData, state: WorkerState)
+
+/**
+ * A pool managing containers to run actions on.
+ *
+ * This pool fulfills the other half of the ContainerProxy contract. Only
+ * one job (either Start or Run) is sent to a child-actor at any given
+ * time. The pool then waits for a response of that container, indicating
+ * the container is done with the job. Only then will the pool send another
+ * request to that container.
+ *
+ * Upon actor creation, the pool will start to prewarm containers according
+ * to the provided prewarmConfig, iff set. Those containers will **not** be
+ * part of the poolsize calculation, which is capped by the poolSize parameter.
+ * Prewarm containers are only used, if they have matching arguments
+ * (kind, memory) and there is space in the pool.
+ *
+ * @param childFactory method to create new containers
+ * @param poolSize maximum size of containers allowed in the pool
+ * @param feed actor to request more work from
+ * @param prewarmConfig optional settings for container prewarming
+ */
+class ContainerPool(
+    childFactory: ActorRefFactory => ActorRef,
+    poolSize: Int,
+    feed: ActorRef,
+    prewarmConfig: Option[PrewarmingConfig] = None) extends Actor {
+    val logging = new AkkaLogging(context.system.log)
+
+    val pool = new mutable.HashMap[ActorRef, WorkerData]
+    val prewarmedPool = new mutable.HashMap[ActorRef, WorkerData]
+
+    prewarmConfig.foreach { config =>
+        logging.info(this, s"pre-warming ${config.count} ${config.exec.kind} containers")
+        (1 to config.count).foreach { _ =>
+            prewarmContainer()
+        }
+    }
+
+    def receive: Receive = {
+        // A job to run on a container
+        case r: Run =>
+            // Schedule a job to a warm container
+            ContainerPool.schedule(r.action, r.msg.user.namespace, pool.toMap).orElse {
+                // Create a cold container iff there's space in the pool
+                if (pool.size < poolSize) {
+                    takePrewarmContainer(r.action).orElse {
+                        Some(createContainer())
+                    }
+                } else None
+            }.orElse {
+                // Remove a container and create a new one for the given job
+                ContainerPool.remove(r.msg.user.namespace, pool.toMap).map { toDelete =>
+                    removeContainer(toDelete)
+                    createContainer()
+                }
+            } match {
+                case Some(actor) =>
+                    pool.get(actor) match {
+                        case Some(w) =>
+                            pool.update(actor, WorkerData(w.data, Busy))
+                            actor ! r
+                        case None =>
+                            logging.error(this, "actor data not found")
+                            self ! r
+                    }
+                case None =>
+                    // "reenqueue" the request to find a container at a later point in time
+                    self ! r
+            }
+
+        // Container is free to take more work
+        case NeedWork(data: WarmedData) =>
+            pool.update(sender(), WorkerData(data, Free))
+            feed ! ContainerReleased
+
+        // Container is prewarmed and ready to take work
+        case NeedWork(data: PreWarmedData) =>
+            prewarmedPool.update(sender(), WorkerData(data, Free))
+
+        // Container got removed
+        case ContainerRemoved =>
+            pool.remove(sender())
+    }
+
+    /** Creates a new container and updates state accordingly. */
+    def createContainer() = {
+        val ref = childFactory(context)
+        pool.update(ref, WorkerData(NoData(), Free))
+        ref
+    }
+
+    /** Creates a new prewarmed container */
+    def prewarmContainer() = prewarmConfig.foreach(config => childFactory(context) ! Start(config.exec, config.memoryLimit))
+
+    /**
+     * Takes a prewarm container out of the prewarmed pool
+     * iff a container with a matching kind is found.
+     *
+     * @param kind the kind you want to invoke
+     * @return the container iff found
+     */
+    def takePrewarmContainer(action: ExecutableWhiskAction) = prewarmConfig.flatMap { config =>
+        val kind = action.exec.kind
+        val memory = action.limits.memory.megabytes.MB
+        prewarmedPool.find {
+            case (_, WorkerData(PreWarmedData(_, `kind`, `memory`), _)) => true
+            case _ => false
+        }.map {
+            case (ref, data) =>
+                // Move the container to the usual pool
+                pool.update(ref, data)
+                prewarmedPool.remove(ref)
+                // Create a new prewarm container
+                prewarmContainer()
+
+                ref
+        }
+    }
+
+    /** Removes a container and updates state accordingly. */
+    def removeContainer(toDelete: ActorRef) = {
+        toDelete ! Remove
+        pool.remove(toDelete)
+    }
+}
+
+object ContainerPool {
+    /**
+     * Finds the best container for a given job to run on.
+     *
+     * Selects an arbitrary warm container from the passed pool of idle containers
+     * that matches the action and the invocation namespace. The implementation uses
+     * matching such that structural equality of action and the invocation namespace
+     * is required.
+     * Returns None iff no matching container is in the idle pool.
+     * Does not consider pre-warmed containers.
+     *
+     * @param action the action to run
+     * @param namespace the namespace, that wants to run the action
+     * @param idles a map of idle containers, awaiting work
+     * @return a container if one found
+     */
+    def schedule[A](action: ExecutableWhiskAction, namespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
+        idles.find {
+            case (_, WorkerData(WarmedData(_, `namespace`, `action`, _), Free)) => true
+            case _ => false
+        }.map(_._1)
+    }
+
+    /**
+     * Finds the best container to remove to make space for the job passed to run.
+     *
+     * Determines which namespace consumes most resources in the current pool and
+     * takes away one of their containers iff the namespace placing the new job is
+     * not already the most consuming one.
+     *
+     * @param namespace the namespace that wants to get a container
+     * @param pool a map of all containers in the pool
+     * @return a container to be removed iff found
+     */
+    def remove[A](namespace: EntityName, pool: Map[A, WorkerData]): Option[A] = {
+        val grouped = pool.collect {
+            case (ref, WorkerData(w: WarmedData, _)) => ref -> w
+        }.groupBy {
+            case (ref, data) => data.namespace
+        }
+
+        if (!grouped.isEmpty) {
+            val (maxConsumer, containersToDelete) = grouped.maxBy(_._2.size)
+            val (ref, _) = containersToDelete.minBy(_._2.lastUsed)
+            Some(ref)
+        } else None
+    }
+
+    def props(factory: ActorRefFactory => ActorRef,
+              size: Int,
+              feed: ActorRef,
+              prewarmConfig: Option[PrewarmingConfig] = None) = Props(new ContainerPool(factory, size, feed, prewarmConfig))
+}
+
+/** Contains settings needed to perform container prewarming */
+case class PrewarmingConfig(count: Int, exec: CodeExec[_], memoryLimit: ByteSize)

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -178,9 +178,9 @@ object ContainerPool {
      * @param idles a map of idle containers, awaiting work
      * @return a container if one found
      */
-    def schedule[A](action: ExecutableWhiskAction, namespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
+    def schedule[A](action: ExecutableWhiskAction, invocationNamespace: EntityName, idles: Map[A, WorkerData]): Option[A] = {
         idles.find {
-            case (_, WorkerData(WarmedData(_, `namespace`, `action`, _), Free)) => true
+            case (_, WorkerData(WarmedData(_, `invocationNamespace`, `action`, _), Free)) => true
             case _ => false
         }.map(_._1)
     }
@@ -196,11 +196,11 @@ object ContainerPool {
      * @param pool a map of all containers in the pool
      * @return a container to be removed iff found
      */
-    def remove[A](namespace: EntityName, pool: Map[A, WorkerData]): Option[A] = {
+    def remove[A](invocationNamespace: EntityName, pool: Map[A, WorkerData]): Option[A] = {
         val grouped = pool.collect {
             case (ref, WorkerData(w: WarmedData, _)) => ref -> w
         }.groupBy {
-            case (ref, data) => data.namespace
+            case (ref, data) => data.invocationNamespace
         }
 
         if (!grouped.isEmpty) {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -52,13 +52,13 @@ case class WorkerData(data: ContainerData, state: WorkerState)
  * (kind, memory) and there is space in the pool.
  *
  * @param childFactory method to create new containers
- * @param poolSize maximum size of containers allowed in the pool
+ * @param maxPoolSize maximum size of containers allowed in the pool
  * @param feed actor to request more work from
  * @param prewarmConfig optional settings for container prewarming
  */
 class ContainerPool(
     childFactory: ActorRefFactory => ActorRef,
-    poolSize: Int,
+    maxPoolSize: Int,
     feed: ActorRef,
     prewarmConfig: Option[PrewarmingConfig] = None) extends Actor {
     val logging = new AkkaLogging(context.system.log)
@@ -79,7 +79,7 @@ class ContainerPool(
             // Schedule a job to a warm container
             ContainerPool.schedule(r.action, r.msg.user.namespace, pool.toMap).orElse {
                 // Create a cold container iff there's space in the pool
-                if (pool.size < poolSize) {
+                if (pool.size < maxPoolSize) {
                     takePrewarmContainer(r.action).orElse {
                         Some(createContainer())
                     }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerPool.scala
@@ -69,7 +69,7 @@ class ContainerPool(
     prewarmConfig.foreach { config =>
         logging.info(this, s"pre-warming ${config.count} ${config.exec.kind} containers")
         (1 to config.count).foreach { _ =>
-            prewarmContainer()
+            prewarmContainer(config.exec, config.memoryLimit)
         }
     }
 
@@ -127,7 +127,8 @@ class ContainerPool(
     }
 
     /** Creates a new prewarmed container */
-    def prewarmContainer() = prewarmConfig.foreach(config => childFactory(context) ! Start(config.exec, config.memoryLimit))
+    def prewarmContainer(exec: CodeExec[_], memoryLimit: ByteSize) =
+        prewarmConfig.foreach(config => childFactory(context) ! Start(exec, memoryLimit))
 
     /**
      * Takes a prewarm container out of the prewarmed pool
@@ -148,7 +149,7 @@ class ContainerPool(
                 pool.update(ref, data)
                 prewarmedPool.remove(ref)
                 // Create a new prewarm container
-                prewarmContainer()
+                prewarmContainer(config.exec, config.memoryLimit)
 
                 ref
         }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/ContainerProxy.scala
@@ -53,7 +53,7 @@ case object Removing extends ContainerState
 sealed abstract class ContainerData(val lastUsed: Instant)
 case class NoData() extends ContainerData(Instant.EPOCH)
 case class PreWarmedData(container: Container, kind: String, memoryLimit: ByteSize) extends ContainerData(Instant.EPOCH)
-case class WarmedData(container: Container, namespace: EntityName, action: ExecutableWhiskAction, override val lastUsed: Instant) extends ContainerData(lastUsed)
+case class WarmedData(container: Container, invocationNamespace: EntityName, action: ExecutableWhiskAction, override val lastUsed: Instant) extends ContainerData(lastUsed)
 
 // Events received by the actor
 case class Start(exec: CodeExec[_], memoryLimit: ByteSize)

--- a/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
+++ b/core/invoker/src/main/scala/whisk/core/dispatcher/ActivationFeed.scala
@@ -34,7 +34,7 @@ object ActivationFeed {
     case class FillQueueWithMessages()
 
     /** Indicates resources are available because transaction completed, may cause pipeline fill. */
-    case class ContainerReleased(tid: TransactionId) extends ActivationNotification
+    case object ContainerReleased extends ActivationNotification
 
     /** Indicate resources are available because transaction failed, may cause pipeline fill. */
     case class FailedActivation(tid: TransactionId) extends ActivationNotification

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -111,7 +111,7 @@ class Invoker(
                     case Success(activation) =>
                         transactionPromise.completeWith {
                             // this completes the successful activation case (1)
-                            completeTransaction(tran, activation, ContainerReleased(transid))
+                            completeTransaction(tran, activation, ContainerReleased)
                         }
 
                     case Failure(t) =>

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -124,6 +124,7 @@ class ContainerPoolTests extends TestKit(ActorSystem("ContainerPool"))
 
         pool ! runMessage
         containers(0).expectMsg(runMessage)
+        containers(1).expectNoMsg(100.milliseconds)
     }
 
     it should "create a container if it cannot find a matching container" in within(timeout) {

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.test
+
+import java.time.Instant
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FlatSpec
+import org.scalatest.FlatSpecLike
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import akka.actor.ActorRefFactory
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import akka.testkit.TestProbe
+import whisk.common.TransactionId
+import whisk.core.connector.ActivationMessage
+import whisk.core.containerpool._
+import whisk.core.dispatcher.ActivationFeed.ContainerReleased
+import whisk.core.entity._
+import whisk.core.entity.ExecManifest.RuntimeManifest
+import whisk.core.entity.ExecManifest.ImageName
+import whisk.core.entity.size._
+
+/**
+ * Behavior tests for the ContainerPool
+ *
+ * These tests test the runtime behavior of a ContainerPool actor.
+ */
+@RunWith(classOf[JUnitRunner])
+class ContainerPoolTests extends TestKit(ActorSystem("ContainerPool"))
+    with ImplicitSender
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockFactory {
+
+    override def afterAll = TestKit.shutdownActorSystem(system)
+
+    val timeout = 5.seconds
+
+    // Common entities to pass to the tests. We don't really care what's inside
+    // those for the behavior testing here, as none of the contents will really
+    // reach a container anyway. We merely assert that passing and extraction of
+    // the values is done properly.
+    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+    val memoryLimit = 256.MB
+
+    val invocationNamespace = EntityName("invocationSpace")
+    val action = ExecutableWhiskAction(EntityPath("actionSpace"), EntityName("actionName"), exec)
+
+    val message = ActivationMessage(
+        TransactionId.testing,
+        action.fullyQualifiedName(true),
+        action.rev,
+        Identity(Subject(), invocationNamespace, AuthKey(), Set()),
+        ActivationId(),
+        invocationNamespace.toPath,
+        None)
+
+    val runMessage = Run(action, message)
+
+    /** Helper to create PreWarmedData */
+    def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) = PreWarmedData(stub[Container], kind, memoryLimit)
+
+    /** Helper to create WarmedData */
+    def warmedData(action: ExecutableWhiskAction = action, namespace: String = "invocationSpace", lastUsed: Instant = Instant.now) =
+        WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
+
+    /** Creates a sequence of containers and a factory returning this sequence. */
+    def testContainers(n: Int) = {
+        val containers = (0 to n).map(_ => TestProbe())
+        val queue = mutable.Queue(containers: _*)
+        val factory = (fac: ActorRefFactory) => queue.dequeue().ref
+        (containers, factory)
+    }
+
+    behavior of "ContainerPool"
+
+    it should "indicate free resources to the feed only if a warm container responds" in within(timeout) {
+        val (containers, factory) = testContainers(1)
+        val feed = TestProbe()
+
+        val pool = system.actorOf(ContainerPool.props(factory, 0, feed.ref))
+        containers(0).send(pool, NeedWork(warmedData()))
+        feed.expectMsg(ContainerReleased)
+    }
+
+    /*
+     * CONTAINER SCHEDULING
+     *
+     * These tests only test the simplest approaches. Look below for full coverage tests
+     * of the respective scheduling methods.
+     */
+    it should "reuse a warm container" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+        val pool = system.actorOf(ContainerPool.props(factory, 2, feed.ref))
+
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        containers(0).send(pool, NeedWork(warmedData()))
+
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+    }
+
+    it should "create a container if it cannot find a matching container" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        val pool = system.actorOf(ContainerPool.props(factory, 2, feed.ref))
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        // Note that the container doesn't respond, thus it's not free to take work
+        pool ! runMessage
+        containers(1).expectMsg(runMessage)
+    }
+
+    it should "remove a container to make space in the pool if it is already full" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        // a pool with only 1 slot
+        val pool = system.actorOf(ContainerPool.props(factory, 1, feed.ref))
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        containers(0).send(pool, NeedWork(warmedData()))
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        pool ! runMessage
+        containers(0).expectMsg(Remove)
+        containers(1).expectMsg(runMessage)
+    }
+
+    /*
+     * CONTAINER PREWARMING
+     */
+    it should "create prewarmed containers on startup" in within(timeout) {
+        val (containers, factory) = testContainers(1)
+        val feed = TestProbe()
+
+        val pool = system.actorOf(ContainerPool.props(factory, 0, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
+        containers(0).expectMsg(Start(exec, memoryLimit))
+    }
+
+    it should "use a prewarmed container and create a new one to fill its place" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        val pool = system.actorOf(ContainerPool.props(factory, 1, feed.ref, Some(PrewarmingConfig(1, exec, memoryLimit))))
+        containers(0).expectMsg(Start(exec, memoryLimit))
+        containers(0).send(pool, NeedWork(preWarmedData(exec.kind)))
+        pool ! Run(action, message)
+        containers(1).expectMsg(Start(exec, memoryLimit))
+    }
+
+    it should "not use a prewarmed container if it doesn't fit the kind" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        val alternativeExec = CodeExecAsString(RuntimeManifest("anotherKind", ImageName("testImage")), "testCode", None)
+
+        val pool = system.actorOf(ContainerPool.props(factory, 1, feed.ref, Some(PrewarmingConfig(1, alternativeExec, memoryLimit))))
+        containers(0).expectMsg(Start(alternativeExec, memoryLimit)) // container0 was prewarmed
+        containers(0).send(pool, NeedWork(preWarmedData(alternativeExec.kind)))
+        pool ! runMessage
+        containers(1).expectMsg(runMessage) // but container1 is used
+    }
+
+    it should "not use a prewarmed container if it doesn't fit memory wise" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        val alternativeLimit = 128.MB
+
+        val pool = system.actorOf(ContainerPool.props(factory, 1, feed.ref, Some(PrewarmingConfig(1, exec, alternativeLimit))))
+        containers(0).expectMsg(Start(exec, alternativeLimit)) // container0 was prewarmed
+        containers(0).send(pool, NeedWork(preWarmedData(exec.kind, alternativeLimit)))
+        pool ! runMessage
+        containers(1).expectMsg(runMessage) // but container1 is used
+    }
+
+    /*
+     * CONTAINER DELETION
+     */
+    it should "not reuse a container which is scheduled for deletion" in within(timeout) {
+        val (containers, factory) = testContainers(2)
+        val feed = TestProbe()
+
+        val pool = system.actorOf(ContainerPool.props(factory, 2, feed.ref))
+
+        // container0 is created and used
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        containers(0).send(pool, NeedWork(warmedData()))
+
+        // container0 is reused
+        pool ! runMessage
+        containers(0).expectMsg(runMessage)
+        containers(0).send(pool, NeedWork(warmedData()))
+
+        // container0 is deleted
+        containers(0).send(pool, ContainerRemoved)
+
+        // container1 is created and used
+        pool ! Run(action, message)
+        containers(1).expectMsg(Run(action, message))
+    }
+
+}
+
+/**
+ * Unit tests for the ContainerPool object.
+ *
+ * These tests test only the "static" methods "schedule" and "remove"
+ * of the ContainerPool object.
+ */
+@RunWith(classOf[JUnitRunner])
+class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
+
+    val actionExec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+
+    /** Helper to create a new action from String representations */
+    def createAction(namespace: String = "actionNS", name: String = "actionName") =
+        ExecutableWhiskAction(EntityPath(namespace), EntityName(name), actionExec)
+
+    /** Helper to create WarmedData with sensible defaults */
+    def warmedData(action: ExecutableWhiskAction = createAction(), namespace: String = "anyNamespace", lastUsed: Instant = Instant.now) =
+        WarmedData(stub[Container], EntityName(namespace), action, lastUsed)
+
+    /** Helper to create PreWarmedData with sensible defaults */
+    def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
+
+    /** Helper to create NoData */
+    def noData() = NoData()
+
+    /** Helper to create a free Worker, for shorter notation */
+    def freeWorker(data: ContainerData) = WorkerData(data, Free)
+
+    behavior of "ContainerPool schedule()"
+
+    it should "not provide a container if idle pool is empty" in {
+        ContainerPool.schedule(createAction(), EntityName("anyNamespace"), Map()) shouldBe None
+    }
+
+    it should "reuse an applicable warm container from idle pool with one container" in {
+        val data = warmedData()
+        val pool = Map('name -> freeWorker(data))
+
+        // copy to make sure, referencial equality doesn't suffice
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe Some('name)
+    }
+
+    it should "reuse an applicable warm container from idle pool with several applicable containers" in {
+        val data = warmedData()
+        val pool = Map(
+            'first -> freeWorker(data),
+            'second -> freeWorker(data))
+
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) should contain oneOf ('first, 'second)
+    }
+
+    it should "reuse an applicable warm container from idle pool with several different containers" in {
+        val matchingData = warmedData()
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()),
+            'warm -> freeWorker(matchingData))
+
+        ContainerPool.schedule(matchingData.action.copy(), matchingData.namespace, pool) shouldBe Some('warm)
+    }
+
+    it should "not reuse a container from idle pool with non-warm containers" in {
+        val data = warmedData()
+        // data is **not** in the pool!
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()))
+
+        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different invocation namespace" in {
+        val data = warmedData()
+        val pool = Map('warm -> freeWorker(data))
+        val differentNamespace = EntityName(data.namespace.asString + "butDifferent")
+
+        data.namespace should not be differentNamespace
+        ContainerPool.schedule(data.action.copy(), differentNamespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different action name" in {
+        val data = warmedData()
+        val differentAction = data.action.copy(name = EntityName(data.action.name.asString + "butDifferent"))
+        val pool = Map(
+            'warm -> freeWorker(data))
+
+        data.action.name should not be differentAction.name
+        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+    }
+
+    it should "not reuse a warm container with different action version" in {
+        val data = warmedData()
+        val differentAction = data.action.copy(version = data.action.version.upMajor)
+        val pool = Map(
+            'warm -> freeWorker(data))
+
+        data.action.version should not be differentAction.version
+        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+    }
+
+    behavior of "ContainerPool remove()"
+
+    it should "not provide a container if pool is empty" in {
+        ContainerPool.remove(EntityName("anyNamespace"), Map()) shouldBe None
+    }
+
+    it should "not provide a container from busy pool with non-warm containers" in {
+        val pool = Map(
+            'none -> freeWorker(noData()),
+            'pre -> freeWorker(preWarmedData()))
+
+        ContainerPool.remove(EntityName("anyNamespace"), pool) shouldBe None
+    }
+
+    it should "provide a container from pool with one single container regardless of invocation namespace" in {
+        val data = warmedData()
+        val pool = Map('warm -> freeWorker(data))
+
+        ContainerPool.remove(data.namespace, pool) shouldBe Some('warm)
+        ContainerPool.remove(EntityName(data.namespace.asString + "butDifferent"), pool) shouldBe Some('warm)
+    }
+
+    it should "provide oldest container from busy pool with multiple containers" in {
+        val commonNamespace = "commonNamespace"
+        val first = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(1))
+        val second = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(2))
+        val oldest = warmedData(namespace = commonNamespace, lastUsed = Instant.ofEpochMilli(0))
+
+        val pool = Map(
+            'first -> freeWorker(first),
+            'second -> freeWorker(second),
+            'oldest -> freeWorker(oldest))
+
+        ContainerPool.remove(EntityName(commonNamespace), pool) shouldBe Some('oldest)
+    }
+
+    it should "provide oldest container of largest namespace group from busy pool with multiple containers" in {
+        val smallNamespace = "smallNamespace"
+        val mediumNamespace = "mediumNamespace"
+        val largeNamespace = "largeNamespace"
+
+        // Note: We choose the oldest from the **largest** pool, although all other containers are even older.
+        val myData = warmedData(namespace = smallNamespace, lastUsed = Instant.ofEpochMilli(0))
+        val pool = Map(
+            'my -> freeWorker(myData),
+            'other -> freeWorker(warmedData(namespace = mediumNamespace, lastUsed = Instant.ofEpochMilli(1))),
+            'largeYoung -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(3))),
+            'largeOld -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(2))))
+
+        ContainerPool.remove(myData.namespace, pool) shouldBe Some('largeOld)
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerPoolTests.scala
@@ -271,7 +271,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
         val pool = Map('name -> freeWorker(data))
 
         // copy to make sure, referencial equality doesn't suffice
-        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe Some('name)
+        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe Some('name)
     }
 
     it should "reuse an applicable warm container from idle pool with several applicable containers" in {
@@ -280,7 +280,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'first -> freeWorker(data),
             'second -> freeWorker(data))
 
-        ContainerPool.schedule(data.action.copy(), data.namespace, pool) should contain oneOf ('first, 'second)
+        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) should contain oneOf ('first, 'second)
     }
 
     it should "reuse an applicable warm container from idle pool with several different containers" in {
@@ -290,7 +290,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'pre -> freeWorker(preWarmedData()),
             'warm -> freeWorker(matchingData))
 
-        ContainerPool.schedule(matchingData.action.copy(), matchingData.namespace, pool) shouldBe Some('warm)
+        ContainerPool.schedule(matchingData.action.copy(), matchingData.invocationNamespace, pool) shouldBe Some('warm)
     }
 
     it should "not reuse a container from idle pool with non-warm containers" in {
@@ -300,15 +300,15 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'none -> freeWorker(noData()),
             'pre -> freeWorker(preWarmedData()))
 
-        ContainerPool.schedule(data.action.copy(), data.namespace, pool) shouldBe None
+        ContainerPool.schedule(data.action.copy(), data.invocationNamespace, pool) shouldBe None
     }
 
     it should "not reuse a warm container with different invocation namespace" in {
         val data = warmedData()
         val pool = Map('warm -> freeWorker(data))
-        val differentNamespace = EntityName(data.namespace.asString + "butDifferent")
+        val differentNamespace = EntityName(data.invocationNamespace.asString + "butDifferent")
 
-        data.namespace should not be differentNamespace
+        data.invocationNamespace should not be differentNamespace
         ContainerPool.schedule(data.action.copy(), differentNamespace, pool) shouldBe None
     }
 
@@ -319,7 +319,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'warm -> freeWorker(data))
 
         data.action.name should not be differentAction.name
-        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+        ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
     }
 
     it should "not reuse a warm container with different action version" in {
@@ -329,7 +329,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'warm -> freeWorker(data))
 
         data.action.version should not be differentAction.version
-        ContainerPool.schedule(differentAction, data.namespace, pool) shouldBe None
+        ContainerPool.schedule(differentAction, data.invocationNamespace, pool) shouldBe None
     }
 
     behavior of "ContainerPool remove()"
@@ -350,8 +350,8 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
         val data = warmedData()
         val pool = Map('warm -> freeWorker(data))
 
-        ContainerPool.remove(data.namespace, pool) shouldBe Some('warm)
-        ContainerPool.remove(EntityName(data.namespace.asString + "butDifferent"), pool) shouldBe Some('warm)
+        ContainerPool.remove(data.invocationNamespace, pool) shouldBe Some('warm)
+        ContainerPool.remove(EntityName(data.invocationNamespace.asString + "butDifferent"), pool) shouldBe Some('warm)
     }
 
     it should "provide oldest container from busy pool with multiple containers" in {
@@ -381,6 +381,6 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
             'largeYoung -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(3))),
             'largeOld -> freeWorker(warmedData(namespace = largeNamespace, lastUsed = Instant.ofEpochMilli(2))))
 
-        ContainerPool.remove(myData.namespace, pool) shouldBe Some('largeOld)
+        ContainerPool.remove(myData.invocationNamespace, pool) shouldBe Some('largeOld)
     }
 }

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -110,7 +110,7 @@ class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
 
     /** Expect a NeedWork message with prewarmed data */
     def expectPreWarmed(kind: String) = expectMsgPF() {
-        case NeedWork(PreWarmedData(_, kind)) => true
+        case NeedWork(PreWarmedData(_, kind, memoryLimit)) => true
     }
 
     /** Expect a NeedWork message with warmed data */

--- a/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
+++ b/tests/src/test/scala/whisk/core/dispatcher/test/DispatcherTests.scala
@@ -147,7 +147,7 @@ class DispatcherTests
             // that dispatcher refilled the pipeline
             stream.reset()
             Console.withOut(stream) {
-                dispatcher.activationFeed ! ActivationFeed.ContainerReleased(transid)
+                dispatcher.activationFeed ! ActivationFeed.ContainerReleased
                 // wait until additional message is drained
                 retry({
                     withClue("additional messages processed") {


### PR DESCRIPTION
This pool fulfills the other half of the ContainerProxy contract. Only
one job (either Start or Run) is sent to a child-actor at any given
time. The pool then waits for a response of that container, indicating
the container is done with the job. Only then will the pool send another
request to that container.

Upon actor creation, the pool will start to prewarm containers according
to the provided prewarmConfig, iff set. Those containers will **not** be
part of the poolsize calculation, which is capped by the poolSize parameter.
Prewarm containers are only used, if they have matching arguments
(kind, memory) and there is space in the pool.

Closes #2090