### PR TITLE
relax the ssl certificate validation for test cases

### DIFF
--- a/tests/src/test/scala/system/rest/RestUtil.scala
+++ b/tests/src/test/scala/system/rest/RestUtil.scala
@@ -37,7 +37,7 @@ trait RestUtil {
     // force RestAssured to allow all hosts in SSL certificates
     protected val sslconfig = {
         new RestAssuredConfig().
-            sslConfig(new SSLConfig().keystore("keystore", trustStorePassword).allowAllHostnames());
+            sslConfig(new SSLConfig().relaxedHTTPSValidation())
     }
 
     /**


### PR DESCRIPTION
This change relaxes the https certificate validation in test cases and will unblock integration testing of API gateway. Today we only accept certificates that are added to the keystore. An alternative solution is to add the certificate of the API Gateway to that keystore. However, to avoid the same issue to happen in the future and since this is only for testing purposes I'am proposing to relax the ssl handling.