### PR TITLE
Factor out Docker config and log file handling to DockerClientFileAccess

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -59,8 +59,13 @@ class DockerClient(dockerHost: Option[String] = None)(executionContext: Executio
     def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] =
         runCmd((Seq("run", "-d") ++ args ++ Seq(image)): _*).map(ContainerId.apply)
 
-    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp] =
-        runCmd("inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString).map(ContainerIp.apply)
+    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] =
+        runCmd("inspect", "--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString).flatMap {
+            _ match {
+                case "<no value>" => Future.failed(new NoSuchElementException)
+                case stdout       => Future.successful(ContainerIp(stdout))
+            }
+        }
 
     def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] =
         runCmd("pause", id.asString).map(_ => ())
@@ -109,12 +114,17 @@ trait DockerApi {
     def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId]
 
     /**
-     * Gets the IP adress of a given container.
+     * Gets the IP address of a given container.
+     *
+     * A container may have more than one network. The container has an
+     * IP address in each of these networks such that the network name
+     * is needed.
      *
      * @param id the id of the container to get the IP address from
+     * @param network name of the network to get the IP address from
      * @return ip of the container
      */
-    def inspectIPAddress(id: ContainerId)(implicit transid: TransactionId): Future[ContainerIp]
+    def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp]
 
     /**
      * Pauses the container with the given id.

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.file.Paths
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.blocking
+
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+import whisk.common.Logging
+import whisk.common.TransactionId
+
+class DockerClientWithFileAccess(
+    dockerHost: Option[String] = None,
+    containersDirectory: File = Paths.get("containers").toFile)(executionContext: ExecutionContext)(implicit log: Logging)
+    extends DockerClient(dockerHost)(executionContext)(log) with DockerApiWithFileAccess {
+
+    implicit private val ec = executionContext
+
+    /**
+     * Provides the home directory of the specified Docker container.
+     *
+     * Assumes that property "containersDirectory" holds the location of the
+     * home directory of all Docker containers. Default: directory "containers"
+     * in the current working directory.
+     *
+     * Does not verify that the returned directory actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's home directory
+     */
+    protected def containerDirectory(containerId: ContainerId) =
+        new File(containersDirectory, containerId.asString).getCanonicalFile()
+
+    /**
+     * Provides the configuration file of the specified Docker container.
+     *
+     * Assumes that the file has the well-known location and name.
+     *
+     * Does not verify that the returned file actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's configuration file
+     */
+    protected def containerConfigFile(containerId: ContainerId) = {
+        new File(containerDirectory(containerId), "config.v2.json").getCanonicalFile()
+    }
+
+    /**
+     * Provides the log file of the specified Docker container written by
+     * Docker's JSON log driver.
+     *
+     * Assumes that the file has the well-known location and name.
+     *
+     * Does not verify that the returned file actually exists.
+     *
+     * @param containerId Id of the desired Docker container
+     * @return canonical location of the container's log file
+     */
+    protected def containerLogFile(containerId: ContainerId) =
+        new File(containerDirectory(containerId), s"${containerId.asString}-json.log").getCanonicalFile()
+
+    /**
+     * Provides the contents of the specified Docker container's configuration
+     * file as JSON object.
+     *
+     * @param configFile the container's configuration file in JSON format
+     * @return contents of configuration file as JSON object
+     */
+    protected def configFileContents(configFile: File): Future[JsObject] = Future {
+        blocking { // Needed due to synchronous file operations
+            val source = scala.io.Source.fromFile(configFile)
+            val config = try source.mkString finally source.close()
+            config.parseJson.asJsObject
+        }
+    }
+
+    /**
+     * Extracts the IP of the container from the local config file of the docker daemon.
+     *
+     * A container may have more than one network. The container has an
+     * IP address in each of these networks such that the network name
+     * is needed.
+     *
+     * @param id the id of the container to get the IP address from
+     * @param network name of the network to get the IP address from
+     * @return the ip address of the container
+     */
+    protected def ipAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = {
+        configFileContents(containerConfigFile(id)).map { json =>
+            val networks = json.fields("NetworkSettings").asJsObject.fields("Networks").asJsObject
+            val specifiedNetwork = networks.fields(network).asJsObject
+            val ipAddr = specifiedNetwork.fields("IPAddress")
+            ContainerIp(ipAddr.convertTo[String])
+        }
+    }
+
+    // See implemented trait for description
+    override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+        ipAddressFromFile(id, network).recoverWith {
+            case _ => super.inspectIPAddress(id, network)
+        }
+    }
+
+    // See implemented trait for description
+    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = Future {
+        blocking { // Needed due to synchronous file operations
+            var fis: FileInputStream = null
+            try {
+                val file = containerLogFile(containerId)
+                val size = file.length
+
+                fis = new FileInputStream(file)
+                val channel = fis.getChannel().position(fromPos)
+
+                // Buffer allocation may fail if the log file is too large to hold in memory or
+                // too few space is left on the heap, respectively.
+                var remainingBytes = (size - fromPos).toInt
+                val readBuffer = ByteBuffer.allocate(remainingBytes)
+
+                while (remainingBytes > 0) {
+                    val readBytes = channel.read(readBuffer)
+                    if (readBytes > 0) {
+                        remainingBytes -= readBytes
+                    } else if (readBytes < 0) {
+                        remainingBytes = 0
+                    }
+                }
+
+                readBuffer
+            } catch {
+                case e: Exception =>
+                    throw new IOException(s"rawContainerLogs failed on ${containerId}", e)
+
+            } finally {
+                if (fis != null) fis.close()
+            }
+        }
+    }
+}
+
+trait DockerApiWithFileAccess extends DockerApi {
+
+    /**
+     * Obtains the container's stdout and stderr by reading the internal docker log file
+     * for the container. Said file is written by docker's JSON log driver and has
+     * a "well-known" location and name.
+     *
+     * Reads the log file from the specified position to its end. The returned ByteBuffer
+     * indicates how many bytes were actually read from the file.
+     *
+     * For warm containers, the container log file already holds output from
+     * previous activations that have to be skipped. For this reason, a starting position can be specified.
+     *
+     * Attention: a ByteBuffer is allocated to keep the file from the specified position to its end
+     * fully in memory. At the moment, there is no size limit checking which can lead to
+     * out-of-memory exceptions for very large files.
+     *
+     * Deals with incomplete reads and premature end of file situations. Behavior is undefined
+     * if the log file is changed or truncated while reading.
+     *
+     * @param containerId the container for which to provide logs
+     * @param fromPos position where to start reading the container's log file
+     * @return a ByteBuffer holding the read log file contents
+     */
+    def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer]
+}

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClientWithFileAccess.scala
@@ -51,8 +51,9 @@ class DockerClientWithFileAccess(
      * @param containerId Id of the desired Docker container
      * @return canonical location of the container's home directory
      */
-    protected def containerDirectory(containerId: ContainerId) =
+    protected def containerDirectory(containerId: ContainerId) = {
         new File(containersDirectory, containerId.asString).getCanonicalFile()
+    }
 
     /**
      * Provides the configuration file of the specified Docker container.
@@ -79,8 +80,9 @@ class DockerClientWithFileAccess(
      * @param containerId Id of the desired Docker container
      * @return canonical location of the container's log file
      */
-    protected def containerLogFile(containerId: ContainerId) =
+    protected def containerLogFile(containerId: ContainerId) = {
         new File(containerDirectory(containerId), s"${containerId.asString}-json.log").getCanonicalFile()
+    }
 
     /**
      * Provides the contents of the specified Docker container's configuration

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -32,7 +32,7 @@ import whisk.http.Messages
 /**
  * Represents a single log line as read from a docker log
  */
-protected[invoker] case class LogLine(time: String, stream: String, log: String) {
+protected[core] case class LogLine(time: String, stream: String, log: String) {
     def toFormattedString = f"$time%-30s $stream: ${log.trim}"
     def dropRight(maxBytes: ByteSize) = {
         val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
@@ -40,11 +40,11 @@ protected[invoker] case class LogLine(time: String, stream: String, log: String)
     }
 }
 
-protected[invoker] object LogLine extends DefaultJsonProtocol {
+protected[core] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
-protected[invoker] trait ActionLogDriver {
+protected[core] trait ActionLogDriver {
 
     // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
     protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -32,7 +32,7 @@ import whisk.http.Messages
 /**
  * Represents a single log line as read from a docker log
  */
-protected[core] case class LogLine(time: String, stream: String, log: String) {
+protected[invoker] case class LogLine(time: String, stream: String, log: String) {
     def toFormattedString = f"$time%-30s $stream: ${log.trim}"
     def dropRight(maxBytes: ByteSize) = {
         val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
@@ -40,11 +40,11 @@ protected[core] case class LogLine(time: String, stream: String, log: String) {
     }
 }
 
-protected[core] object LogLine extends DefaultJsonProtocol {
+protected[invoker] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
-protected[core] trait ActionLogDriver {
+protected[invoker] trait ActionLogDriver {
 
     // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
     protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -49,9 +49,9 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
     val dockerCommand = "docker"
 
     /** Returns a DockerClient with a mocked result for 'executeProcess' */
-    def dockerClient(result: Future[String]) = new DockerClient()(global) {
+    def dockerClient(execResult: Future[String]) = new DockerClient()(global) {
         override val dockerCmd = Seq(dockerCommand)
-        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = result
+        override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
     }
 
     behavior of "DockerClient"
@@ -71,6 +71,12 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         filters.foreach {
             case (k, v) => firstLine should include(s"--filter $k=$v")
         }
+    }
+
+    it should "throw NoSuchElementException if specified network does not exist when using 'inspectIPAddress'" in {
+        val dc = dockerClient { Future.successful("<no value>") }
+
+        a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
     }
 
     it should "write proper log markers on a successful command" in {
@@ -100,8 +106,9 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         runAndVerify(dc.rm(id), "rm", Seq("-f", id.asString))
         runAndVerify(dc.ps(), "ps")
 
-        val inspectArgs = Seq("--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", id.asString)
-        runAndVerify(dc.inspectIPAddress(id), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
+        val network = "userland"
+        val inspectArgs = Seq("--format", s"{{.NetworkSettings.Networks.${network}.IPAddress}}", id.asString)
+        runAndVerify(dc.inspectIPAddress(id, network), "inspect", inspectArgs) shouldBe ContainerIp(stdout)
 
         val image = "image"
         val runArgs = Seq("--memory", "256m", "--cpushares", "1024")
@@ -129,7 +136,7 @@ class DockerClientTests extends FlatSpec with Matchers with StreamLogging with B
         runAndVerify(dc.unpause(id), "unpause")
         runAndVerify(dc.rm(id), "rm")
         runAndVerify(dc.ps(), "ps")
-        runAndVerify(dc.inspectIPAddress(id), "inspect")
+        runAndVerify(dc.inspectIPAddress(id, "network"), "inspect")
         runAndVerify(dc.run("image"), "run")
         runAndVerify(dc.pull("image"), "pull")
     }

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import scala.concurrent.Future
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.fixture.{ FlatSpec => FixtureFlatSpec }
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import org.scalatest.Matchers
+import common.StreamLogging
+import whisk.core.containerpool.docker.ContainerId
+import whisk.common.TransactionId
+import org.scalatest.BeforeAndAfterEach
+import whisk.core.containerpool.docker.ContainerIp
+import whisk.core.containerpool.docker.DockerClientWithFileAccess
+import spray.json._
+import java.nio.charset.StandardCharsets
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+import scala.language.reflectiveCalls // Needed to invoke publicIpAddressFromFile() method of structural dockerClientForIp extension
+
+@RunWith(classOf[JUnitRunner])
+class DockerClientWithFileAccessTestsIp extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+    val id = ContainerId("Id")
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    val dockerCommand = "docker"
+    val networkInConfigFile = "networkConfig"
+    val networkInDockerInspect = "networkInspect"
+    val ipInConfigFile = ContainerIp("10.0.0.1")
+    val ipInDockerInspect = ContainerIp("10.0.0.2")
+    val dockerConfig =
+        JsObject("NetworkSettings" ->
+            JsObject("Networks" ->
+                JsObject(s"${networkInConfigFile}" ->
+                    JsObject("IPAddress" -> JsString(s"${ipInConfigFile.asString}")))))
+
+    /** Returns a DockerClient with mocked results */
+    def dockerClient(
+        execResult: Future[String] = Future.successful(ipInDockerInspect.asString),
+        readResult: Future[JsObject] = Future.successful(dockerConfig)) =
+        new DockerClientWithFileAccess()(global) {
+            override val dockerCmd = Seq(dockerCommand)
+            override def executeProcess(args: String*)(implicit ec: ExecutionContext) = execResult
+            override def configFileContents(configFile: File) = readResult
+            // Make protected ipAddressFromFile available for testing - requires reflectiveCalls
+            def publicIpAddressFromFile(id: ContainerId, network: String): Future[ContainerIp] = ipAddressFromFile(id, network)
+        }
+
+    behavior of "DockerClientWithFileAccess - ipAddressFromFile"
+
+    it should "throw NoSuchElementException if specified network is not in configuration file" in {
+        val dc = dockerClient()
+
+        a[NoSuchElementException] should be thrownBy await(dc.publicIpAddressFromFile(id, "foo network"))
+    }
+
+    behavior of "DockerClientWithFileAccess - inspectIPAddress"
+
+    it should "read from config file" in {
+        val dc = dockerClient()
+
+        await(dc.inspectIPAddress(id, networkInConfigFile)) shouldBe ipInConfigFile
+        logLines.foreach { _ should not include (s"${dockerCommand} inspect") }
+    }
+
+    it should "fall back to 'docker inspect' if config file cannot be read" in {
+        val dc = dockerClient(readResult = Future.failed(new RuntimeException()))
+
+        await(dc.inspectIPAddress(id, networkInDockerInspect)) shouldBe ipInDockerInspect
+        logLines.head should include(s"${dockerCommand} inspect")
+    }
+
+    it should "throw NoSuchElementException if specified network does not exist" in {
+        val dc = dockerClient(execResult = Future.successful("<no value>"))
+
+        a[NoSuchElementException] should be thrownBy await(dc.inspectIPAddress(id, "foo network"))
+    }
+}
+
+@RunWith(classOf[JUnitRunner])
+class DockerClientWithFileAccessTestsLogs extends FixtureFlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {
+
+    override def beforeEach = stream.reset()
+
+    implicit val transid = TransactionId.testing
+
+    behavior of "DockerClientWithFileAccess - rawContainerLogs"
+
+    /** Returns a DockerClient with mocked results */
+    def dockerClient(logFile: File) = new DockerClientWithFileAccess()(global) {
+        override def containerLogFile(containerId: ContainerId) = logFile
+    }
+
+    def await[A](f: Future[A], timeout: FiniteDuration = 500.milliseconds) = Await.result(f, timeout)
+
+    case class FixtureParam(file: File, writer: FileWriter, dc: DockerClientWithFileAccess)
+
+    def withFixture(test: OneArgTest) = {
+        val file = File.createTempFile(this.getClass.getName, test.name.replaceAll("[^a-zA-Z0-9.-]", "_"))
+        val writer = new FileWriter(file)
+        val dc = dockerClient(file)
+
+        val fixture = FixtureParam(file, writer, dc)
+
+        try {
+            withFixture(test.toNoArgTest(fixture))
+        } finally {
+            writer.close()
+            file.delete()
+        }
+    }
+
+    def writeLogFile(fixture: FixtureParam, content: String) = {
+        fixture.writer.write(content)
+        fixture.writer.flush()
+    }
+
+    val containerId = ContainerId("Id")
+
+    it should "tolerate an empty log file" in { fixture =>
+        val logText = ""
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream should have size 0
+    }
+
+    it should "read a full log file" in { fixture =>
+        val logText = "text"
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe logText
+        stream should have size 0
+    }
+
+    it should "read a log file portion" in { fixture =>
+        val logText =
+            """Hey, dude-it'z true not sad
+              |Take a thrash song and make it better
+              |Admit it! Beatallica'z under your skin!
+              |So now begin to be a shredder""".stripMargin
+        val from = 66 // start at third line...
+        val expectedText = logText.substring(from)
+
+        writeLogFile(fixture, logText)
+
+        val buffer = await(fixture.dc.rawContainerLogs(containerId, fromPos = from))
+        val logContent = new String(buffer.array, buffer.arrayOffset, buffer.position, StandardCharsets.UTF_8)
+
+        logContent shouldBe expectedText
+        stream should have size 0
+    }
+
+    it should "provide an empty result on failure" in { fixture =>
+        fixture.writer.close()
+        fixture.file.delete()
+
+        an[IOException] should be thrownBy await(fixture.dc.rawContainerLogs(containerId, fromPos = 0))
+        stream should have size 0
+    }
+}


### PR DESCRIPTION
Prepare new container-pool implementation - see #2086.

Factor out all file-based operations from DockerClient such that the DockerClient can also work with a remote docker host. Two operations are supported:

- Obtain a container's IP address: Read from container's config file in the first place and fall back to using `docker inspect` if file reading doesn't work. The file reading variant is preferable because it's faster than `docker inspect`.
- Obtain a container's stdout / stderr output: Read from container's log output written by the JSON log driver. At the moment, there is no falling back to `docker logs`.