### PR TITLE
Write a startup log in each component

### DIFF
--- a/common/scala/src/main/scala/whisk/common/Logging.scala
+++ b/common/scala/src/main/scala/whisk/common/Logging.scala
@@ -196,6 +196,11 @@ object LoggingMarkers {
     private val kafka = "kafka"
     private val loadbalancer = "loadbalancer"
 
+    /*
+     * Controller related markers
+     */
+    def CONTROLLER_STARTUP(i: Int) = LogMarkerToken(controller, s"startup$i", count)
+
     // Time of the activation in controller until it is delivered to Kafka
     val CONTROLLER_ACTIVATION = LogMarkerToken(controller, activation, start)
     val CONTROLLER_ACTIVATION_BLOCKING = LogMarkerToken(controller, "blockingActivation", start)
@@ -205,6 +210,11 @@ object LoggingMarkers {
 
     // Time that is needed to produce message in kafka
     val CONTROLLER_KAFKA = LogMarkerToken(controller, kafka, start)
+
+    /*
+     * Invoker related markers
+     */
+    def INVOKER_STARTUP(i: Int) = LogMarkerToken(invoker, s"startup$i", count)
 
     // Time that is needed to execute the action
     val INVOKER_ACTIVATION_RUN = LogMarkerToken(invoker, "activationRun", start)
@@ -217,6 +227,9 @@ object LoggingMarkers {
     def INVOKER_DOCKER_CMD(cmd: String) = LogMarkerToken(invoker, s"docker.$cmd", start)
     def INVOKER_RUNC_CMD(cmd: String) = LogMarkerToken(invoker, s"runc.$cmd", start)
 
+    /*
+     * General markers
+     */
     val DATABASE_CACHE_HIT = LogMarkerToken(database, "cacheHit", count)
     val DATABASE_CACHE_MISS = LogMarkerToken(database, "cacheMiss", count)
     val DATABASE_SAVE = LogMarkerToken(database, "saveDocument", start)

--- a/core/controller/src/main/scala/whisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/Controller.scala
@@ -43,6 +43,7 @@ import whisk.core.entity.ActivationId.ActivationIdGenerator
 import whisk.core.loadBalancer.LoadBalancerService
 import whisk.http.BasicHttpService
 import whisk.http.BasicRasService
+import whisk.common.LoggingMarkers
 
 /**
  * The Controller is the service that provides the REST API for OpenWhisk.
@@ -84,7 +85,7 @@ class Controller(
         }
     }
 
-    logging.info(this, s"starting controller instance ${instance}")
+    TransactionId.controller.mark(this, LoggingMarkers.CONTROLLER_STARTUP(instance), s"starting controller instance ${instance}")
 
     // initialize datastores
     private implicit val actorSystem = context.system

--- a/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/Invoker.scala
@@ -64,6 +64,8 @@ class Invoker(
 
     private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
+    TransactionId.invoker.mark(this, LoggingMarkers.INVOKER_STARTUP(instance), s"starting invoker instance ${instance}")
+
     /** This generates completion messages back to the controller */
     val producer = new KafkaProducerConnector(config.kafkaHost, executionContext)
 


### PR DESCRIPTION
This will enable proper identification of component startups via our log marker system.