### PR TITLE
Avoid clobbering Python's built-in dict datatype

### DIFF
--- a/tests/dat/actions/hello.py
+++ b/tests/dat/actions/hello.py
@@ -19,12 +19,9 @@
 """
 
 
-def main(dict):
+def main(args_dict):
     """Main."""
-    if 'name' in dict:
-        name = dict['name']
-    else:
-        name = "stranger"
-    greeting = "Hello " + name + "!"
+    name = args_dict.get('name', 'stranger')
+    greeting = 'Hello ' + name + '!'
     print(greeting)
-    return {"greeting": greeting}
+    return {'greeting': greeting}

--- a/tests/dat/actions/hello.py
+++ b/tests/dat/actions/hello.py
@@ -19,9 +19,9 @@
 """
 
 
-def main(args_dict):
+def main(args):
     """Main."""
-    name = args_dict.get('name', 'stranger')
+    name = args.get('name', 'stranger')
     greeting = 'Hello ' + name + '!'
     print(greeting)
     return {'greeting': greeting}


### PR DESCRIPTION
It considered bad practice to name a variable in such a way that it clobbers access to Python's built-in [dict](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict) datatype.