### PR TITLE
update watson-developer-cloud npm to 2.29.0

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -66,7 +66,7 @@ twilio@2.11.1 \
 underscore@1.8.3 \
 uuid@3.0.0 \
 validator@6.1.0 \
-watson-developer-cloud@2.14.3 \
+watson-developer-cloud@2.29.0 \
 when@3.7.7 \
 winston@2.3.0 \
 ws@1.1.1 \


### PR DESCRIPTION
This is necessary to pick up recent changes to watson services.

:large_blue_circle:  PG2 1480