### PR TITLE
`wsk api delete` command may not completely delete endpoint

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -341,6 +341,10 @@ function generateBaseSwaggerApi(basepath, apiname) {
     'x-ibm-configuration': {
       'assembly': {
       }
+// CORS support pending openwhisk-apigateway issue #186
+//      'cors': {
+//        'enabled': true
+//      }
     }
   };
   return swaggerApi;
@@ -501,11 +505,11 @@ function removeEndpointFromSwaggerApi(swaggerApi, endpoint) {
 
 function deleteActionOperationInvocationDetails(swagger, operationId) {
   console.log('deleteActionOperationInvocationDetails: deleting case entry for ' + operationId);
-  var caseArr = _.get(swagger, 'x-ibm-configuration.assembly.execute[1].operation-switch.case') || [];
+  var caseArr = _.get(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case') || [];
   if (caseArr.length > 0) {
     var caseIdx = getCaseOperationIdx(caseArr, operationId);
     _.pullAt(caseArr, caseIdx);
-    _.set(swagger, 'x-ibm-configuration.assembly.execute[1].operation-switch.case', caseArr);
+    _.set(swagger, 'x-ibm-configuration.assembly.execute[0].operation-switch.case', caseArr);
   } else {
     console.log('deleteActionOperationInvocationDetails: empty case[] array; case operation '+operationId+' does not exist');
   }

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -1003,7 +1003,7 @@ var apiDeleteCmdV2 = &cobra.Command{
         _, err := client.Apis.DeleteV2(apiDeleteReq, apiDeleteReqOptions)
         if err != nil {
             whisk.Debug(whisk.DbgError, "client.Apis.DeleteV2(%#v, %#v) error: %s\n", apiDeleteReq, apiDeleteReqOptions, err)
-            errMsg := wski18n.T("Unable to delete action: {{.err}}", map[string]interface{}{"err": err})
+            errMsg := wski18n.T("Unable to delete API: {{.err}}", map[string]interface{}{"err": err})
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr


### PR DESCRIPTION
Fix is to delete all artifacts in the swagger for the specified endpoint