### PR TITLE
Provide DockerContainer implementation

### DIFF
--- a/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
@@ -50,7 +50,7 @@ import whisk.core.entity.size.SizeLong
  * @param timeoutMsec the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
-class HttpUtils(
+protected[core] class HttpUtils(
     hostname: String,
     timeout: FiniteDuration,
     maxResponse: ByteSize) {

--- a/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
+++ b/core/invoker/src/main/scala/whisk/core/container/HttpUtils.scala
@@ -50,7 +50,7 @@ import whisk.core.entity.size.SizeLong
  * @param timeoutMsec the timeout in msecs to wait for a response
  * @param maxResponse the maximum size in bytes the connection will accept
  */
-protected[container] class HttpUtils(
+class HttpUtils(
     hostname: String,
     timeout: FiniteDuration,
     maxResponse: ByteSize) {

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -47,7 +47,7 @@ trait Container {
     def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)]
 
     /** Obtains logs up to a given threshold from the container. Optionally waits for a sentinel to appear. */
-    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]]
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]]
 }
 
 /** Indicates a general error with the container */

--- a/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/Container.scala
@@ -56,10 +56,10 @@ sealed abstract class ContainerError(msg: String) extends Exception(msg)
 /** Indicates an error while starting a container */
 sealed abstract class ContainerStartupError(msg: String) extends ContainerError(msg)
 
-/** Indicates an error while starting a container of a managed runtime */
+/** Indicates any error while starting a container either of a managed runtime or a non-application-specific blackbox container */
 case class WhiskContainerStartupError(msg: String) extends ContainerStartupError(msg)
 
-/** Indicates an error while starting a blackbox container */
+/** Indicates an application-specific error while starting a blackbox container */
 case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
 
 /** Indicates an error while initializing a container */

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerClient.scala
@@ -16,18 +16,20 @@
 
 package whisk.core.containerpool.docker
 
-import scala.util.Try
 import java.io.FileNotFoundException
 import java.nio.file.Files
 import java.nio.file.Paths
-import scala.concurrent.Future
+
 import scala.concurrent.ExecutionContext
-import whisk.common.Logging
-import whisk.common.TransactionId
-import whisk.common.LoggingMarkers
-import akka.event.Logging.ErrorLevel
+import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
+
+import akka.event.Logging.ErrorLevel
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.common.TransactionId
 
 /**
  * Serves as interface to the docker CLI tool.

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -21,8 +21,7 @@ import java.time.Instant
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
@@ -57,7 +56,7 @@ object DockerContainer {
      * @param environment environment variables to set on the container
      * @param network network to launch the container in
      * @param name optional name for the container
-     * @return a container
+     * @return a Future which either completes with a DockerContainer or one of two specific failures
      */
     def create(transid: TransactionId,
                image: String,
@@ -67,7 +66,7 @@ object DockerContainer {
                environment: Map[String, String] = Map(),
                network: String = "bridge",
                name: Option[String] = None)(
-                   implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging) = {
+                   implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging): Future[DockerContainer] = {
         implicit val tid = transid
 
         val environmentArgs = (environment + ("SERVICE_IGNORE" -> true.toString)).map {
@@ -78,7 +77,7 @@ object DockerContainer {
             "--cap-drop", "NET_RAW",
             "--cap-drop", "NET_ADMIN",
             "--ulimit", "nofile=1024:1024",
-            "--pids-limit", "1024", // OW PR 2119
+            "--pids-limit", "1024",
             "--cpu-shares", cpuShares.toString,
             "--memory", s"${memory.toMB}m",
             "--memory-swap", s"${memory.toMB}m",
@@ -123,7 +122,7 @@ object DockerContainer {
  * @param ip the ip of the container
  */
 class DockerContainer(id: ContainerId, ip: ContainerIp)(
-    implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging) extends Container with ActionLogDriver {
+    implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, logger: Logging) extends Container with ActionLogDriver {
 
     /** The last read-position in the log file */
     private var logFileOffset = 0L
@@ -153,7 +152,7 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
             } else if (result.interval.duration >= timeout) {
                 Future.failed(InitializationError(ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true)), result.interval))
             } else {
-                Future.failed(InitializationError(ActivationResponse.processInitResponseContent(result.response, log), result.interval))
+                Future.failed(InitializationError(ActivationResponse.processInitResponseContent(result.response, logger), result.interval))
             }
         }
     }
@@ -168,12 +167,12 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
             case Success(r: RunResult) =>
                 transid.finished(this, start.copy(start = r.interval.start), s"running result: ${r.toBriefString}", endTime = r.interval.end)
             case Failure(t) =>
-                transid.failed(this, start, s"initializiation failed with $t")
+                transid.failed(this, start, s"run failed with $t")
         }.map { result =>
             val response = if (result.interval.duration >= timeout) {
                 ActivationResponse.applicationError(Messages.timedoutActivation(timeout, false))
             } else {
-                ActivationResponse.processRunResponseContent(result.response, log)
+                ActivationResponse.processRunResponseContent(result.response, logger)
             }
 
             (result.interval, response)
@@ -210,7 +209,7 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
                 val (isComplete, isTruncated, formattedLogs) = processJsonDriverLogContents(rawLog, waitForSentinel, limit)
 
                 if (retries > 0 && !isComplete && !isTruncated) {
-                    log.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
+                    logger.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
                     Thread.sleep(logsRetryWait.toMillis)
                     readLogs(retries - 1)
                 } else {
@@ -219,7 +218,7 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
                 }
             }.andThen {
                 case Failure(e) =>
-                    log.error(this, s"Failed to obtain logs of ${id.asString}: ${e.getClass} - ${e.getMessage}")
+                    logger.error(this, s"Failed to obtain logs of ${id.asString}: ${e.getClass} - ${e.getMessage}")
             }
         }
 

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -133,7 +133,7 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
     /** HTTP connection to the container, will be lazily established by callContainer */
     private var httpConnection: Option[HttpUtils] = None
 
-    def halt()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
+    def suspend()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
     def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
     def destroy()(implicit transid: TransactionId): Future[Unit] = docker.rm(id)
 
@@ -150,9 +150,9 @@ class DockerContainer(id: ContainerId, ip: ContainerIp)(
             if (result.ok) {
                 Future.successful(result.interval)
             } else if (result.interval.duration >= timeout) {
-                Future.failed(InitializationError(ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true)), result.interval))
+                Future.failed(InitializationError(result.interval, ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true))))
             } else {
-                Future.failed(InitializationError(ActivationResponse.processInitResponseContent(result.response, logger), result.interval))
+                Future.failed(InitializationError(result.interval, ActivationResponse.processInitResponseContent(result.response, logger)))
             }
         }
     }

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -16,31 +16,33 @@
 
 package whisk.core.containerpool.docker
 
-import scala.concurrent.Future
-import spray.json.JsObject
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
-import whisk.core.container.HttpUtils
-import whisk.core.entity.size._
-import scala.util.Success
-import scala.util.Failure
+import java.nio.charset.StandardCharsets
 import java.time.Instant
-import whisk.core.container.RunResult
-import whisk.core.container.Interval
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import whisk.common.TransactionId
 import whisk.common.Logging
 import whisk.common.LoggingMarkers
-import whisk.core.entity.ByteSize
-import java.nio.charset.StandardCharsets
-import whisk.http.Messages
-import whisk.core.entity.ActivationResponse
+import whisk.common.TransactionId
+import whisk.core.container.HttpUtils
+import whisk.core.container.Interval
+import whisk.core.container.RunResult
 import whisk.core.containerpool.BlackboxStartupError
-import whisk.core.containerpool.WhiskContainerStartupError
-import whisk.core.containerpool.InitializationError
 import whisk.core.containerpool.Container
+import whisk.core.containerpool.InitializationError
+import whisk.core.containerpool.WhiskContainerStartupError
+import whisk.core.entity.ActivationResponse
+import whisk.core.entity.ByteSize
+import whisk.core.entity.size._
 import whisk.core.invoker.ActionLogDriver
+import whisk.http.Messages
 
 object DockerContainer {
     /**

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker
+
+import scala.concurrent.Future
+import spray.json.JsObject
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+import whisk.core.container.HttpUtils
+import whisk.core.entity.size._
+import scala.util.Success
+import scala.util.Failure
+import java.time.Instant
+import whisk.core.container.RunResult
+import whisk.core.container.Interval
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+import whisk.common.TransactionId
+import whisk.common.Logging
+import whisk.common.LoggingMarkers
+import whisk.core.entity.ByteSize
+import java.nio.charset.StandardCharsets
+import whisk.http.Messages
+import whisk.core.entity.ActivationResponse
+import whisk.core.containerpool.BlackboxStartupError
+import whisk.core.containerpool.WhiskContainerStartupError
+import whisk.core.containerpool.InitializationError
+import whisk.core.containerpool.Container
+import whisk.core.invoker.ActionLogDriver
+
+object DockerContainer {
+    /**
+     * Creates a container running on a docker daemon.
+     *
+     * @param transid transaction creating the container
+     * @param image image to create the container from
+     * @param userProvidedImage whether the image is provided by the user
+     *     or is an OpenWhisk provided image
+     * @param memory memorylimit of the container
+     * @param cpuShares sharefactor for the container
+     * @param environment environment variables to set on the container
+     * @param network network to launch the container in
+     * @param name optional name for the container
+     * @return a container
+     */
+    def create(transid: TransactionId,
+               image: String,
+               userProvidedImage: Boolean = false,
+               memory: ByteSize = 256.MB,
+               cpuShares: Int = 0,
+               environment: Map[String, String] = Map(),
+               network: String = "bridge",
+               name: Option[String] = None)(
+                   implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging) = {
+        implicit val tid = transid
+
+        val environmentArgs = (environment + ("SERVICE_IGNORE" -> true.toString)).map {
+            case (key, value) => Seq("-e", s"$key=$value")
+        }.flatten
+
+        val args = Seq(
+            "--cap-drop", "NET_RAW",
+            "--cap-drop", "NET_ADMIN",
+            "--ulimit", "nofile=1024:1024",
+            "--pids-limit", "1024", // OW PR 2119
+            "--cpu-shares", cpuShares.toString,
+            "--memory", s"${memory.toMB}m",
+            "--memory-swap", s"${memory.toMB}m",
+            "--network", network) ++
+            environmentArgs ++
+            name.map(n => Seq("--name", n)).getOrElse(Seq.empty)
+
+        val pulled = if (userProvidedImage) {
+            docker.pull(image).recoverWith {
+                case _ => Future.failed(BlackboxStartupError(s"Failed to pull container image '$image'."))
+            }
+        } else Future.successful(())
+
+        val container = for {
+            _ <- pulled
+            id <- docker.run(image, args)
+            ip <- docker.inspectIPAddress(id, network).andThen {
+                // remove the container immediatly if inspect failed as
+                // we cannot recover that case automatically
+                case Failure(_) => docker.rm(id)
+            }
+        } yield new DockerContainer(id, ip)
+
+        container.recoverWith {
+            case t => if (userProvidedImage) {
+                Future.failed(BlackboxStartupError(t.getMessage))
+            } else {
+                Future.failed(WhiskContainerStartupError(t.getMessage))
+            }
+        }
+    }
+}
+
+/**
+ * Represents a container as run by docker.
+ *
+ * This class contains OpenWhisk specific behavior and as such does not necessarily
+ * use docker commands to achieve the effects needed.
+ *
+ * @constructor
+ * @param id the id of the container
+ * @param ip the ip of the container
+ */
+class DockerContainer(id: ContainerId, ip: ContainerIp)(
+    implicit docker: DockerApiWithFileAccess, runc: RuncApi, ec: ExecutionContext, log: Logging) extends Container with ActionLogDriver {
+
+    /** The last read-position in the log file */
+    private var logFileOffset = 0L
+
+    protected val logsRetryCount = 15
+    protected val logsRetryWait = 100.millis
+
+    /** HTTP connection to the container, will be lazily established by callContainer */
+    private var httpConnection: Option[HttpUtils] = None
+
+    def halt()(implicit transid: TransactionId): Future[Unit] = runc.pause(id)
+    def resume()(implicit transid: TransactionId): Future[Unit] = runc.resume(id)
+    def destroy()(implicit transid: TransactionId): Future[Unit] = docker.rm(id)
+
+    def initialize(initializer: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[Interval] = {
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_INIT, s"sending initialization to $id $ip")
+
+        val body = JsObject("value" -> initializer)
+        callContainer("/init", body, timeout, retry = true).andThen { // never fails
+            case Success(r: RunResult) =>
+                transid.finished(this, start.copy(start = r.interval.start), s"initialization result: ${r.toBriefString}", endTime = r.interval.end)
+            case Failure(t) =>
+                transid.failed(this, start, s"initializiation failed with $t")
+        }.flatMap { result =>
+            if (result.ok) {
+                Future.successful(result.interval)
+            } else if (result.interval.duration >= timeout) {
+                Future.failed(InitializationError(ActivationResponse.applicationError(Messages.timedoutActivation(timeout, true)), result.interval))
+            } else {
+                Future.failed(InitializationError(ActivationResponse.processInitResponseContent(result.response, log), result.interval))
+            }
+        }
+    }
+
+    def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+        val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
+        val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION_RUN, s"sending arguments to $actionName at $id $ip")
+
+        val parameterWrapper = JsObject("value" -> parameters)
+        val body = JsObject(parameterWrapper.fields ++ environment.fields)
+        callContainer("/run", body, timeout, retry = false).andThen { // never fails
+            case Success(r: RunResult) =>
+                transid.finished(this, start.copy(start = r.interval.start), s"running result: ${r.toBriefString}", endTime = r.interval.end)
+            case Failure(t) =>
+                transid.failed(this, start, s"initializiation failed with $t")
+        }.map { result =>
+            val response = if (result.interval.duration >= timeout) {
+                ActivationResponse.applicationError(Messages.timedoutActivation(timeout, false))
+            } else {
+                ActivationResponse.processRunResponseContent(result.response, log)
+            }
+
+            (result.interval, response)
+        }
+    }
+
+    /**
+     * Obtains the container's stdout and stderr output and converts it to our own JSON format.
+     * At the moment, this is done by reading the internal Docker log file for the container.
+     * Said file is written by Docker's JSON log driver and has a "well-known" location and name.
+     *
+     * For warm containers, the container log file already holds output from
+     * previous activations that have to be skipped. For this reason, a starting position
+     * is kept and updated upon each invocation.
+     *
+     * If asked, check for sentinel markers - but exclude the identified markers from
+     * the result returned from this method.
+     *
+     * Only parses and returns as much logs as fit in the passed log limit.
+     * Even if the log limit is exceeded, advance the starting position for the next invocation
+     * behind the bytes most recently read - but don't actively read any more until sentinel
+     * markers have been found.
+     *
+     * @param limit the limit to apply to the log size
+     * @param waitForSentinel determines if the processor should wait for a sentinel to appear
+     *
+     * @return a vector of Strings with log lines in our own JSON format
+     */
+    def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
+
+        def readLogs(retries: Int): Future[Vector[String]] = {
+            docker.rawContainerLogs(id, logFileOffset).flatMap { rawLogBytes =>
+                val rawLog = new String(rawLogBytes.array, rawLogBytes.arrayOffset, rawLogBytes.position, StandardCharsets.UTF_8)
+                val (isComplete, isTruncated, formattedLogs) = processJsonDriverLogContents(rawLog, waitForSentinel, limit)
+
+                if (retries > 0 && !isComplete && !isTruncated) {
+                    log.info(this, s"log cursor advanced but missing sentinel, trying $retries more times")
+                    Thread.sleep(logsRetryWait.toMillis)
+                    readLogs(retries - 1)
+                } else {
+                    logFileOffset += rawLogBytes.position - rawLogBytes.arrayOffset
+                    Future.successful(formattedLogs)
+                }
+            }.andThen {
+                case Failure(e) =>
+                    log.error(this, s"Failed to obtain logs of ${id.asString}: ${e.getClass} - ${e.getMessage}")
+            }
+        }
+
+        readLogs(logsRetryCount)
+    }
+
+    /**
+     * Makes an HTTP request to the container.
+     *
+     * Note that `http.post` will not throw an exception, hence the generated Future cannot fail.
+     *
+     * @param path relative path to use in the http request
+     * @param body body to send
+     * @param timeout timeout of the request
+     * @param retry whether or not to retry the request
+     */
+    protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
+        val started = Instant.now()
+        val http = httpConnection.getOrElse {
+            val conn = new HttpUtils(s"${ip.asString}:8080", timeout, 1.MB)
+            httpConnection = Some(conn)
+            conn
+        }
+        Future {
+            http.post(path, body, retry)
+        }.map { response =>
+            val finished = Instant.now()
+            RunResult(Interval(started, finished), response)
+        }
+    }
+}

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -44,10 +44,12 @@ protected[invoker] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 
-protected[invoker] trait ActionLogDriver {
-
+protected[core] object ActionLogDriver {
     // The action proxies inserts this line in the logs at the end of each activation for stdout/stderr
-    protected val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+    val LOG_ACTIVATION_SENTINEL = "XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX"
+}
+
+protected[core] trait ActionLogDriver {
 
     /**
      * Given the JSON driver's raw output of a docker container, convert it into our own
@@ -77,7 +79,7 @@ protected[invoker] trait ActionLogDriver {
             Try(lines.next().parseJson.convertTo[LogLine]) match {
                 case Success(t) =>
                     // if sentinels are expected, do not account for their size, otherwise, all bytes are accounted for
-                    if (requireSentinel && t.log.trim != LOG_ACTIVATION_SENTINEL || !requireSentinel) {
+                    if (requireSentinel && t.log.trim != ActionLogDriver.LOG_ACTIVATION_SENTINEL || !requireSentinel) {
                         // ignore empty log lines
                         if (t.log.nonEmpty) {
                             bytesSoFar += t.log.sizeInBytes

--- a/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
+++ b/core/invoker/src/main/scala/whisk/core/invoker/ActionLogDriver.scala
@@ -32,7 +32,7 @@ import whisk.http.Messages
 /**
  * Represents a single log line as read from a docker log
  */
-protected[invoker] case class LogLine(time: String, stream: String, log: String) {
+protected[core] case class LogLine(time: String, stream: String, log: String) {
     def toFormattedString = f"$time%-30s $stream: ${log.trim}"
     def dropRight(maxBytes: ByteSize) = {
         val bytes = log.getBytes(StandardCharsets.UTF_8).dropRight(maxBytes.toBytes.toInt)
@@ -40,7 +40,7 @@ protected[invoker] case class LogLine(time: String, stream: String, log: String)
     }
 }
 
-protected[invoker] object LogLine extends DefaultJsonProtocol {
+protected[core] object LogLine extends DefaultJsonProtocol {
     implicit val serdes = jsonFormat3(LogLine.apply)
 }
 

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -16,25 +16,26 @@
 
 package whisk.core.containerpool.docker.test
 
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
 
 import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.concurrent.Await
 import org.scalatest.Matchers
+
 import common.StreamLogging
-import whisk.core.containerpool.docker.ContainerId
-import whisk.common.TransactionId
-import org.scalatest.BeforeAndAfterEach
 import whisk.common.LogMarker
 import whisk.common.LoggingMarkers.INVOKER_DOCKER_CMD
-import whisk.core.containerpool.docker.DockerClient
+import whisk.common.TransactionId
+import whisk.core.containerpool.docker.ContainerId
 import whisk.core.containerpool.docker.ContainerIp
+import whisk.core.containerpool.docker.DockerClient
 
 @RunWith(classOf[JUnitRunner])
 class DockerClientTests extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerClientWithFileAccessTests.scala
@@ -16,30 +16,32 @@
 
 package whisk.core.containerpool.docker.test
 
-import scala.concurrent.Future
-
-import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
-import org.scalatest.fixture.{ FlatSpec => FixtureFlatSpec }
-import org.scalatest.junit.JUnitRunner
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.concurrent.Await
-import org.scalatest.Matchers
-import common.StreamLogging
-import whisk.core.containerpool.docker.ContainerId
-import whisk.common.TransactionId
-import org.scalatest.BeforeAndAfterEach
-import whisk.core.containerpool.docker.ContainerIp
-import whisk.core.containerpool.docker.DockerClientWithFileAccess
-import spray.json._
-import java.nio.charset.StandardCharsets
 import java.io.File
 import java.io.FileWriter
 import java.io.IOException
+import java.nio.charset.StandardCharsets
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
 import scala.language.reflectiveCalls // Needed to invoke publicIpAddressFromFile() method of structural dockerClientForIp extension
+
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.Matchers
+import org.scalatest.fixture.{ FlatSpec => FixtureFlatSpec }
+
+import common.StreamLogging
+import spray.json._
+import whisk.common.TransactionId
+import whisk.core.containerpool.docker.ContainerId
+import whisk.core.containerpool.docker.ContainerIp
+import whisk.core.containerpool.docker.DockerClientWithFileAccess
 
 @RunWith(classOf[JUnitRunner])
 class DockerClientWithFileAccessTestsIp extends FlatSpec with Matchers with StreamLogging with BeforeAndAfterEach {

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.core.containerpool.docker.test
+
+import java.time.Instant
+
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import common.StreamLogging
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.Matchers
+import org.scalatest.Inspectors._
+import spray.json._
+import whisk.common.LoggingMarkers._
+import whisk.common.LogMarker
+import whisk.common.TransactionId
+import whisk.core.container.Interval
+import whisk.core.container.RunResult
+import whisk.core.containerpool._
+import whisk.core.containerpool.docker._
+import whisk.core.entity.ActivationResponse
+import whisk.core.entity.ActivationResponse.ContainerResponse
+import whisk.core.entity.ActivationResponse.Timeout
+import whisk.core.entity.size._
+import whisk.http.Messages
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import whisk.core.invoker.ActionLogDriver
+import whisk.core.invoker.LogLine
+import java.io.IOException
+
+/**
+ * Unit tests for ContainerPool schedule
+ */
+@RunWith(classOf[JUnitRunner])
+class DockerContainerTests extends FlatSpec
+    with Matchers
+    with MockFactory
+    with StreamLogging
+    with ScalaFutures
+    with BeforeAndAfterEach {
+
+    override def beforeEach() = {
+        stream.reset()
+    }
+
+    /** Awaits the given future, throws the exception enclosed in Failure. */
+    def await[A](f: Future[A], timeout: FiniteDuration = 100.millisecond) = Await.result[A](f, timeout)
+
+    val containerId = ContainerId("id")
+    /**
+     * Constructs a testcontainer with overridden IO methods. Results of the override can be provided
+     * as parameters.
+     */
+    def dockerContainer(
+        id: ContainerId = containerId,
+        ip: ContainerIp = ContainerIp("ip"))(
+            ccRes: Future[RunResult] = Future.successful(RunResult(intervalOf(1.millisecond), Right(ContainerResponse(true, "", None)))),
+            retryCount: Int = 0)(
+                implicit docker: DockerApiWithFileAccess, runc: RuncApi): DockerContainer = {
+
+        new DockerContainer(id, ip) {
+            override protected def callContainer(path: String, body: JsObject, timeout: FiniteDuration, retry: Boolean = false): Future[RunResult] = {
+                ccRes
+            }
+            override protected val logsRetryCount = retryCount
+            override protected val logsRetryWait = 0.milliseconds
+        }
+    }
+
+    /** Creates an interval starting at EPOCH with the given duration. */
+    def intervalOf(duration: FiniteDuration) = Interval(Instant.EPOCH, Instant.ofEpochMilli(duration.toMillis))
+
+    behavior of "DockerContainer"
+
+    implicit val transid = TransactionId.testing
+
+    /*
+     * CONTAINER CREATION
+     */
+    it should "create a new instance" in {
+        implicit val docker = new TestDockerClient
+        implicit val runc = stub[RuncApi]
+
+        val image = "image"
+        val memory = 128.MB
+        val cpuShares = 1
+        val environment = Map("test" -> "hi")
+        val network = "testwork"
+        val name = "myContainer"
+
+        val container = DockerContainer.create(
+            transid = transid,
+            image = image,
+            memory = memory,
+            cpuShares = cpuShares,
+            environment = environment,
+            network = network,
+            name = Some(name))
+
+        await(container)
+
+        docker.pulls should have size 0
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 0
+
+        val (testImage, args) = docker.runs.head
+        testImage shouldBe "image"
+
+        // Assert fixed values are passed as well
+        args should contain allOf ("--cap-drop", "NET_RAW", "NET_ADMIN")
+        args should contain inOrder ("--ulimit", "nofile=1024:1024")
+        args should contain inOrder ("--pids-limit", "1024") // OW PR 2119
+
+        // Assert proper parameter translation
+        args should contain inOrder ("--memory", s"${memory.toMB}m")
+        args should contain inOrder ("--memory-swap", s"${memory.toMB}m")
+        args should contain inOrder ("--cpu-shares", cpuShares.toString)
+        args should contain inOrder ("--network", network)
+        args should contain inOrder ("--name", name)
+
+        // Assert proper environment passing
+        args should contain allOf ("-e", "test=hi", "SERVICE_IGNORE=true")
+    }
+
+    it should "pull a user provided image before creating the container" in {
+        implicit val docker = new TestDockerClient
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        await(container)
+
+        docker.pulls should have size 1
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 0
+    }
+
+    it should "remove the container if inspect fails" in {
+        implicit val docker = new TestDockerClient {
+            override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+                inspects += ((id, network))
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image")
+        a[WhiskContainerStartupError] should be thrownBy await(container)
+
+        docker.pulls should have size 0
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 1
+    }
+
+    it should "disambiguate errors if user images are provided" in {
+        implicit val docker = new TestDockerClient {
+            override def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+                inspects += ((id, network))
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        a[BlackboxStartupError] should be thrownBy await(container)
+
+        docker.pulls should have size 1
+        docker.runs should have size 1
+        docker.inspects should have size 1
+        docker.rms should have size 1
+    }
+
+    it should "return a specific error if pulling a user provided image failed" in {
+        implicit val docker = new TestDockerClient {
+            override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+                pulls += image
+                Future.failed(new RuntimeException())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = DockerContainer.create(transid = transid, image = "image", userProvidedImage = true)
+        a[BlackboxStartupError] should be thrownBy await(container)
+
+        docker.pulls should have size 1
+        docker.runs should have size 0
+        docker.inspects should have size 0
+        docker.rms should have size 0
+    }
+
+    /*
+     * DOCKER COMMANDS
+     */
+    it should "halt and resume container via runc" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val id = ContainerId("id")
+        val container = new DockerContainer(id, ContainerIp("ip"))
+
+        container.halt()
+        container.resume()
+
+        (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)
+        (runc.resume(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    }
+
+    it should "destroy a container via Docker" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val id = ContainerId("id")
+        val container = new DockerContainer(id, ContainerIp("ip"))
+
+        container.destroy()
+
+        (docker.rm(_: ContainerId)(_: TransactionId)).verify(id, transid)
+    }
+
+    /*
+     * INITIALIZE
+     *
+     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+     * and so are the tests for those.
+     */
+    it should "initialize a container" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val interval = intervalOf(1.millisecond)
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Right(ContainerResponse(true, "", None))))
+        }
+
+        val initInterval = container.initialize(JsObject(), 1.second)
+        initInterval.futureValue shouldBe interval
+
+        // assert the starting log is there
+        val start = LogMarker.parse(logLines.head)
+        start.token shouldBe INVOKER_ACTIVATION_INIT
+
+        // assert the end log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    }
+
+    it should "properly deal with a timeout during initialization" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val initTimeout = 1.second
+        val interval = intervalOf(initTimeout + 1.nanoseconds)
+
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Left(Timeout())))
+        }
+
+        val init = container.initialize(JsObject(), initTimeout)
+
+        val error = the[InitializationError] thrownBy await(init)
+        error.interval shouldBe interval
+        error.response.statusCode shouldBe ActivationResponse.ApplicationError
+
+        // assert the finish log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_INIT.asFinish
+    }
+
+    /*
+     * RUN
+     *
+     * Only tests for quite simple cases. Disambiguation of errors is delegated to ActivationResponse
+     * and so are the tests for those.
+     */
+    it should "run a container" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val interval = intervalOf(1.millisecond)
+        val result = JsObject()
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Right(ContainerResponse(true, result.compactPrint, None))))
+        }
+
+        val runResult = container.run(JsObject(), JsObject(), 1.second)
+        runResult.futureValue shouldBe (interval, ActivationResponse.success(Some(result)))
+
+        // assert the starting log is there
+        val start = LogMarker.parse(logLines.head)
+        start.token shouldBe INVOKER_ACTIVATION_RUN
+
+        // assert the end log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+        end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
+    }
+
+    it should "properly deal with a timeout during run" in {
+        implicit val docker = stub[DockerApiWithFileAccess]
+        implicit val runc = stub[RuncApi]
+
+        val runTimeout = 1.second
+        val interval = intervalOf(runTimeout + 1.nanoseconds)
+
+        val container = dockerContainer() {
+            Future.successful(RunResult(interval, Left(Timeout())))
+        }
+
+        val runResult = container.run(JsObject(), JsObject(), runTimeout)
+
+        runResult.futureValue shouldBe (interval, ActivationResponse.applicationError(Messages.timedoutActivation(runTimeout, false)))
+
+        // assert the finish log is there
+        val end = LogMarker.parse(logLines.last)
+        end.token shouldBe INVOKER_ACTIVATION_RUN.asFinish
+    }
+
+    /*
+     * LOGS
+     */
+    def toByteBuffer(s: String): ByteBuffer = {
+        val bb = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))
+        // Set position behind provided string to simulate read - this is what FileChannel.read() does
+        // Otherwise position would be 0 indicating that buffer is empty
+        bb.position(bb.capacity())
+        bb
+    }
+
+    def toRawLog(log: Seq[LogLine], appendSentinel: Boolean = true): ByteBuffer = {
+        val appendedLog = if (appendSentinel) {
+            val lastTime = log.lastOption.map { case LogLine(time, _, _) => time }.getOrElse(Instant.EPOCH.toString)
+            log :+
+                LogLine(lastTime, "stderr", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}\n") :+
+                LogLine(lastTime, "stdout", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}\n")
+        } else {
+            log
+        }
+        toByteBuffer(appendedLog.map(_.toJson.compactPrint).mkString("", "\n", "\n"))
+    }
+
+    it should "read a simple log with sentinel" in {
+        val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
+        val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = true)
+        val readResults = mutable.Queue(rawLog)
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(readResults.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer(id = containerId)()
+        // Read with tight limit to verify that no truncation occurs
+        val processedLogs = await(container.logs(limit = expectedLogEntry.log.sizeInBytes, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size 1
+        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+        id shouldBe containerId
+        fromPos shouldBe 0
+
+        processedLogs should have size 1
+        processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
+    }
+
+    it should "read a simple log without sentinel" in {
+        val expectedLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is a log entry.\n")
+        val rawLog = toRawLog(Seq(expectedLogEntry), appendSentinel = false)
+        val readResults = mutable.Queue(rawLog)
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(readResults.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer(id = containerId)()
+        // Read without tight limit so that the full read result is processed
+        val processedLogs = await(container.logs(limit = 1.MB, waitForSentinel = false))
+
+        docker.rawContainerLogsInvocations should have size 1
+        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+        id shouldBe containerId
+        fromPos shouldBe 0
+
+        processedLogs should have size 1
+        processedLogs shouldBe Vector(expectedLogEntry.toFormattedString)
+    }
+
+    it should "fail log reading if error occurs during file reading" in {
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.failed(new IOException)
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer()()
+        an[IOException] should be thrownBy await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size 1
+        val (id, fromPos) = docker.rawContainerLogsInvocations(0)
+        id shouldBe containerId
+        fromPos shouldBe 0
+
+        exactly(1, logLines) should include(s"Failed to obtain logs of ${containerId.asString}")
+    }
+
+    it should "read two consecutive logs with sentinel" in {
+        val firstLogEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first log.\n")
+        val secondLogEntry = LogLine(Instant.EPOCH.plusSeconds(1L).toString, "stderr", "This is the second log.\n")
+        val firstRawLog = toRawLog(Seq(firstLogEntry), appendSentinel = true)
+        val secondRawLog = toRawLog(Seq(secondLogEntry), appendSentinel = true)
+        val returnValues = mutable.Queue(firstRawLog, secondRawLog)
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(returnValues.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer()()
+        // Read without tight limit so that the full read result is processed
+        val processedFirstLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+        val processedSecondLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size 2
+        val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
+        fromPos1 shouldBe 0
+        val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
+        fromPos2 shouldBe firstRawLog.capacity() // second read should start behind the first line
+
+        processedFirstLog should have size 1
+        processedFirstLog shouldBe Vector(firstLogEntry.toFormattedString)
+        processedSecondLog should have size 1
+        processedSecondLog shouldBe Vector(secondLogEntry.toFormattedString)
+    }
+
+    it should "retry log reading if sentinel cannot be found in the first place" in {
+        val retries = 15
+        val expectedLog = (1 to retries).map { i =>
+            LogLine(
+                Instant.EPOCH.plusMillis(i.toLong).toString,
+                "stdout",
+                s"This is log entry ${i}.\n")
+        }.toVector
+        val returnValues = mutable.Queue.empty[ByteBuffer]
+        for (i <- 0 to retries) {
+            // Sentinel only added for the last return value
+            returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = (i == retries))
+        }
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(returnValues.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer()(retryCount = retries)
+        // Read without tight limit so that the full read result is processed
+        val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size retries + 1
+        forAll(docker.rawContainerLogsInvocations) {
+            case (_, fromPos) => fromPos shouldBe 0
+        }
+
+        processedLog should have size expectedLog.length
+        processedLog shouldBe expectedLog.map(_.toFormattedString)
+
+        (retries to 1).foreach { i => exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times") }
+    }
+
+    it should "provide full log if log reading retries are exhausted and no sentinel can be found" in {
+        val retries = 15
+        val expectedLog = (1 to retries).map { i =>
+            LogLine(
+                Instant.EPOCH.plusMillis(i.toLong).toString,
+                "stdout",
+                s"This is log entry ${i}.\n")
+        }.toVector
+        val returnValues = mutable.Queue.empty[ByteBuffer]
+        for (i <- 0 to retries) {
+            returnValues += toRawLog(expectedLog.take(i).toSeq, appendSentinel = false)
+        }
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(returnValues.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer()(retryCount = retries)
+        // Read without tight limit so that the full read result is processed
+        val processedLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size retries + 1
+        forAll(docker.rawContainerLogsInvocations) {
+            case (_, fromPos) => fromPos shouldBe 0
+        }
+
+        processedLog should have size expectedLog.length
+        processedLog shouldBe expectedLog.map(_.toFormattedString)
+
+        (retries to 1).foreach { i => exactly(1, logLines) should include(s"log cursor advanced but missing sentinel, trying ${i} more times") }
+    }
+
+    it should "truncate logs and advance reading position to end of current read" in {
+        val firstLogFirstEntry = LogLine(Instant.EPOCH.toString, "stdout", "This is the first line in first log.\n")
+        val firstLogSecondEntry = LogLine(Instant.EPOCH.plusMillis(1L).toString, "stderr", "This is the second line in first log.\n")
+
+        val secondLogFirstEntry = LogLine(Instant.EPOCH.plusMillis(2L).toString, "stdout", "This is the first line in second log.\n")
+        val secondLogSecondEntry = LogLine(Instant.EPOCH.plusMillis(3L).toString, "stdout", "This is the second line in second log.\n")
+        val secondLogLimit = 4
+
+        val thirdLogFirstEntry = LogLine(Instant.EPOCH.plusMillis(4L).toString, "stdout", "This is the first line in third log.\n")
+
+        val firstRawLog = toRawLog(Seq(firstLogFirstEntry, firstLogSecondEntry), appendSentinel = true)
+        val secondRawLog = toRawLog(Seq(secondLogFirstEntry, secondLogSecondEntry), appendSentinel = false)
+        val thirdRawLog = toRawLog(Seq(thirdLogFirstEntry), appendSentinel = true)
+
+        val returnValues = mutable.Queue(firstRawLog, secondRawLog, thirdRawLog)
+
+        implicit val docker = new TestDockerClient {
+            override def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+                rawContainerLogsInvocations += ((containerId, fromPos))
+                Future.successful(returnValues.dequeue())
+            }
+        }
+        implicit val runc = stub[RuncApi]
+
+        val container = dockerContainer()()
+        val processedFirstLog = await(container.logs(limit = firstLogFirstEntry.log.sizeInBytes, waitForSentinel = true))
+        val processedSecondLog = await(container.logs(limit = secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes, waitForSentinel = false))
+        val processedThirdLog = await(container.logs(limit = 1.MB, waitForSentinel = true))
+
+        docker.rawContainerLogsInvocations should have size 3
+        val (_, fromPos1) = docker.rawContainerLogsInvocations(0)
+        fromPos1 shouldBe 0
+        val (_, fromPos2) = docker.rawContainerLogsInvocations(1)
+        fromPos2 shouldBe firstRawLog.capacity() // second read should start behind full content of first read
+        val (_, fromPos3) = docker.rawContainerLogsInvocations(2)
+        fromPos3 shouldBe firstRawLog.capacity() + secondRawLog.capacity() // third read should start behind full content of first and second read
+
+        processedFirstLog should have size 2
+        processedFirstLog(0) shouldBe firstLogFirstEntry.toFormattedString
+        processedFirstLog(1) should startWith(Messages.truncateLogs(firstLogFirstEntry.log.sizeInBytes))
+
+        processedSecondLog should have size 2
+        processedSecondLog(0) shouldBe secondLogFirstEntry.copy(log = secondLogFirstEntry.log.take(secondLogLimit)).toFormattedString
+        processedSecondLog(1) should startWith(Messages.truncateLogs(secondLogFirstEntry.log.take(secondLogLimit).sizeInBytes))
+
+        processedThirdLog should have size 1
+        processedThirdLog(0) shouldBe thirdLogFirstEntry.toFormattedString
+    }
+
+    class TestDockerClient extends DockerApiWithFileAccess {
+        var runs = mutable.Buffer.empty[(String, Seq[String])]
+        var inspects = mutable.Buffer.empty[(ContainerId, String)]
+        var pauses = mutable.Buffer.empty[ContainerId]
+        var unpauses = mutable.Buffer.empty[ContainerId]
+        var rms = mutable.Buffer.empty[ContainerId]
+        var pulls = mutable.Buffer.empty[String]
+        var rawContainerLogsInvocations = mutable.Buffer.empty[(ContainerId, Long)]
+
+        def run(image: String, args: Seq[String] = Seq.empty[String])(implicit transid: TransactionId): Future[ContainerId] = {
+            runs += ((image, args))
+            Future.successful(ContainerId("testId"))
+        }
+
+        def inspectIPAddress(id: ContainerId, network: String)(implicit transid: TransactionId): Future[ContainerIp] = {
+            inspects += ((id, network))
+            Future.successful(ContainerIp("testIp"))
+        }
+
+        def pause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            pauses += id
+            Future.successful(())
+        }
+
+        def unpause(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            unpauses += id
+            Future.successful(())
+        }
+
+        def rm(id: ContainerId)(implicit transid: TransactionId): Future[Unit] = {
+            rms += id
+            Future.successful(())
+        }
+
+        def ps(filters: Seq[(String, String)] = Seq(), all: Boolean = false)(implicit transid: TransactionId): Future[Seq[ContainerId]] = ???
+
+        def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+            pulls += image
+            Future.successful(())
+        }
+
+        def rawContainerLogs(containerId: ContainerId, fromPos: Long): Future[ByteBuffer] = {
+            rawContainerLogsInvocations += ((containerId, fromPos))
+            Future.successful(ByteBuffer.wrap(Array[Byte]()))
+        }
+    }
+}

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -16,6 +16,9 @@
 
 package whisk.core.containerpool.docker.test
 
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 import scala.collection.mutable
@@ -24,15 +27,16 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-import common.StreamLogging
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.FlatSpec
+import org.scalatest.Inspectors._
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.Matchers
-import org.scalatest.Inspectors._
+
+import common.StreamLogging
 import spray.json._
 import whisk.common.LoggingMarkers._
 import whisk.common.LogMarker
@@ -45,12 +49,9 @@ import whisk.core.entity.ActivationResponse
 import whisk.core.entity.ActivationResponse.ContainerResponse
 import whisk.core.entity.ActivationResponse.Timeout
 import whisk.core.entity.size._
-import whisk.http.Messages
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 import whisk.core.invoker.ActionLogDriver
 import whisk.core.invoker.LogLine
-import java.io.IOException
+import whisk.http.Messages
 
 /**
  * Unit tests for ContainerPool schedule

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -225,7 +225,7 @@ class DockerContainerTests extends FlatSpec
         val id = ContainerId("id")
         val container = new DockerContainer(id, ContainerIp("ip"))
 
-        container.halt()
+        container.suspend()
         container.resume()
 
         (runc.pause(_: ContainerId)(_: TransactionId)).verify(id, transid)

--- a/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/test/ContainerProxyTests.scala
@@ -535,9 +535,9 @@ class ContainerProxyTests extends TestKit(ActorSystem("ContainerProxys"))
 
             Future.successful((Interval.zero, ActivationResponse.success()))
         }
-        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[List[String]] = {
+        def logs(limit: ByteSize, waitForSentinel: Boolean)(implicit transid: TransactionId): Future[Vector[String]] = {
             logsCount += 1
-            Future.successful(List("helloTest"))
+            Future.successful(Vector("helloTest"))
         }
     }
 }

--- a/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
@@ -41,8 +41,8 @@ class ActionLogDriverTests
     private def makeLogMsgs(lines: Seq[String], stream: String = "stdout", addSentinel: Boolean = true) = {
         val msgs = if (addSentinel) {
             lines.map((stream, _)) :+
-                ("stdout", s"$LOG_ACTIVATION_SENTINEL\n") :+
-                ("stderr", s"$LOG_ACTIVATION_SENTINEL\n")
+                ("stdout", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n") :+
+                ("stderr", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n")
         } else {
             lines.map((stream, _))
         }
@@ -77,8 +77,8 @@ class ActionLogDriverTests
             raw"""|{"time":"","stream":"stdout","log":"a"}
                   |{"time":"","stream":"stdout","log":"b"}
                   |{"time":"","stream":"stdout","log":"c"}
-                  |{"time":"","stream":"stdout","log":"$LOG_ACTIVATION_SENTINEL\n"}
-                  |{"time":"","stream":"stderr","log":"$LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
+                  |{"time":"","stream":"stdout","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}
+                  |{"time":"","stream":"stderr","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
         }
     }
 

--- a/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
+++ b/tests/src/test/scala/whisk/core/invoker/ActionLogDriverTests.scala
@@ -41,8 +41,8 @@ class ActionLogDriverTests
     private def makeLogMsgs(lines: Seq[String], stream: String = "stdout", addSentinel: Boolean = true) = {
         val msgs = if (addSentinel) {
             lines.map((stream, _)) :+
-                ("stdout", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n") :+
-                ("stderr", s"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n")
+                ("stdout", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}") :+
+                ("stderr", s"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}")
         } else {
             lines.map((stream, _))
         }
@@ -77,8 +77,8 @@ class ActionLogDriverTests
             raw"""|{"time":"","stream":"stdout","log":"a"}
                   |{"time":"","stream":"stdout","log":"b"}
                   |{"time":"","stream":"stdout","log":"c"}
-                  |{"time":"","stream":"stdout","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}
-                  |{"time":"","stream":"stderr","log":"$ActionLogDriver.LOG_ACTIVATION_SENTINEL\n"}""".stripMargin('|')
+                  |{"time":"","stream":"stdout","log":"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}"}
+                  |{"time":"","stream":"stderr","log":"${ActionLogDriver.LOG_ACTIVATION_SENTINEL}"}""".stripMargin('|')
         }
     }
 


### PR DESCRIPTION
This implementation is an abstraction layer for using Docker containers as OpenWhisk action containers - in preparation of a new container pool implementation (#2086). The `DockerContainer` implementation provides a high-level abstraction for the operations required by OpenWhisk:

- Create, destroy, halt, resume a container
- Initialize and run an action inside a container
- Obtain container logs

Closes #2089