### PR TITLE
wsk api create to enable CORS by default

### DIFF
--- a/core/routemgmt/common/apigw-utils.js
+++ b/core/routemgmt/common/apigw-utils.js
@@ -340,11 +340,10 @@ function generateBaseSwaggerApi(basepath, apiname) {
     'paths': {},
     'x-ibm-configuration': {
       'assembly': {
+      },
+      'cors': {
+        'enabled': true
       }
-// CORS support pending openwhisk-apigateway issue #186
-//      'cors': {
-//        'enabled': true
-//      }
     }
   };
   return swaggerApi;

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -671,6 +671,7 @@ class ApiGwTests
       rr = apiGet(basepathOrApiName = Some(testapiname))
       rr.stdout should include(testbasepath)
       rr.stdout should include(s"${actionName}")
+      rr.stdout should include regex (""""cors":\s*\{\s*\n\s*"enabled":\s*true""")
       rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.json""")
     }
     finally {

--- a/tools/cli/go-whisk/whisk/api.go
+++ b/tools/cli/go-whisk/whisk/api.go
@@ -146,7 +146,10 @@ type ApiSwaggerV2 struct {
     BasePath        string    `json:"basePath,omitempty"`
     Info            *ApiSwaggerInfo `json:"info,omitempty"`
     Paths           map[string]map[string]*ApiSwaggerOperationV2 `json:"paths,omitempty"`  // Paths["/a/path"]["get"] -> a generic object
-    XConfig         map[string]map[string][]map[string]map[string]interface{} `json:"x-ibm-configuration,omitempty"`
+    SecurityDef     interface{} `json:"securityDefinitions,omitempty"`
+    Security        interface{} `json:"security,omitempty"`
+    XConfig         interface{} `json:"x-ibm-configuration,omitempty"`
+    XRateLimit      interface{} `json:"x-ibm-rate-limit,omitempty"`
 }
 
 type ApiSwaggerInfo struct {


### PR DESCRIPTION
- `wsk api create` will now enable basic CORS by default.
- `wsk api get` will now display additional support fields, including the CORS setting

Fixes #2169 
Fixes #2182 
