### PR TITLE
add node-jq to nodeJs base image

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -43,6 +43,7 @@ moment@2.17.0 \
 mongodb@2.2.11 \
 mustache@2.3.0 \
 nano@6.2.0 \
+node-jq@0.5.2 \
 node-uuid@1.4.7 \
 nodemailer@2.6.4 \
 oauth2-server@2.4.1 \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -289,6 +289,7 @@ The following packages are available for use by Python actions, in addition to t
 - lxml v3.6.4
 - MarkupSafe v1.0
 - multidict v2.1.4
+- node-jq v0.5.2
 - packaging v16.8
 - parsel v1.1.0
 - pyasn1 v0.2.3


### PR DESCRIPTION
I would like to claim jq is generally useful for composition use cases and thus deserves to be included in the base image.

If included, I will also contribute a jq action for the utils package.