### PR TITLE
Implement a cache backed by Caffeine

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
     compile 'org.apache.kafka:kafka-clients:0.10.0.0'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.4.0'
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
Caffeine is the successor of ConcurrentLinkedHashMap, which is no longer under active development. spray.caching hasn't upgraded yet, so this is our own implementation of spray.caching using Caffeine.

Benefits are:
- Better performance.
- Usage of SoftReferences to correspond to memory pressure.

For more details, see: https://github.com/ben-manes/caffeine/