### PR TITLE
Make JVM options available at deployment time

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -68,6 +68,8 @@ defaultLimits:
 # port means outer port
 controller:
   port: 10001
+  heap: "{{ controller_heap | default('2g') }}"
+  arguments: "{{ controller_arguments | default('') }}"
   blackboxFraction: 0.10
 
 consul:
@@ -92,6 +94,8 @@ zookeeper:
 
 invoker:
   port: 12001
+  heap: "{{ invoker_heap | default('2g') }}"
+  arguments: "{{ invoker_arguments | default('') }}"
   numcore: 2
   coreshare: 2
   serializeDockerOp: true

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -34,6 +34,8 @@
       "SERVICE_CHECK_HTTP": "/ping"
       "SERVICE_CHECK_TIMEOUT": "2s"
       "SERVICE_CHECK_INTERVAL": "15s"
+      "JAVA_OPTS": "-Xmx{{ controller.heap }}"
+      "CONTROLLER_OPTS": "{{ controller.arguments }}"
     volumes:
       - "{{ whisk_logs_dir }}/controller:/logs"
     ports:

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -49,6 +49,8 @@
         -e SERVICE_CHECK_HTTP=/ping
         -e SERVICE_CHECK_TIMEOUT=2s
         -e SERVICE_CHECK_INTERVAL=15s
+        -e JAVA_OPTS=-Xmx{{ invoker.heap }}
+        -e INVOKER_OPTS={{ invoker.arguments }}
         -v /sys/fs/cgroup:/sys/fs/cgroup
         -v /run/runc:/run/runc
         -v {{whisk_logs_dir}}/invoker{{play_hosts.index(inventory_hostname)}}:/logs

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.controller.Controller"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+CrashOnOutOfMemoryError", "-XX:+PrintGCDetails"]
+applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -20,4 +20,4 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "whisk.core.invoker.Invoker"
-applicationDefaultJvmArgs = ["-Xmx2g", "-XX:+CrashOnOutOfMemoryError", "-XX:+PrintGCDetails"]
+applicationDefaultJvmArgs = ["-XX:+CrashOnOutOfMemoryError"]


### PR DESCRIPTION
Currently, JVM settings are hardcoded into our images. The only value we really want to have on those applications is the restart on OOM behavior though. The other settings are highly dependent on the deployment infrastructure.

- `controller|invoker_heap` are used to control the heap of both components.
- `controller|invoker_arguments` are used for free-form JVM arguments.