### PR TITLE
Add a fudge factor to handle clock skew in the invokers

### DIFF
--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -82,13 +82,18 @@ class WskRuleTests
         }
     }
 
+    /**
+     * Append the current timestamp in ms
+     */
+    def withTimestamp(text: String) = s"${text}-${System.currentTimeMillis}"
+
     behavior of "Whisk rules"
 
     it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "r1to1"
-            val triggerName = "t1to1"
-            val actionName = "a1 to 1" // spaces in name intended for greater test coverage
+            val ruleName = withTimestamp("r1to1")
+            val triggerName = withTimestamp("t1to1")
+            val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
 
             ruleSetup(Seq(
                 (ruleName, triggerName, (actionName, actionName, defaultAction))),
@@ -113,10 +118,10 @@ class WskRuleTests
 
     it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "pr1to1"
-            val triggerName = "pt1to1"
-            val pkgName = "rule pkg" // spaces in name intended to test uri path encoding
-            val actionName = "a1 to 1"
+            val ruleName = withTimestamp("pr1to1")
+            val triggerName = withTimestamp("pt1to1")
+            val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+            val actionName = withTimestamp("a1 to 1")
             val pkgActionName = s"$pkgName/$actionName"
 
             assetHelper.withCleaner(wsk.pkg, pkgName) {
@@ -146,11 +151,11 @@ class WskRuleTests
 
     it should "invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "pr1to1"
-            val triggerName = "pt1to1"
-            val pkgName = "rule pkg" // spaces in name intended to test uri path encoding
-            val pkgBindingName = "rule pkg binding"
-            val actionName = "a1 to 1"
+            val ruleName = withTimestamp("pr1to1")
+            val triggerName = withTimestamp("pt1to1")
+            val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+            val pkgBindingName = withTimestamp("rule pkg binding")
+            val actionName = withTimestamp("a1 to 1")
             val pkgActionName = s"$pkgName/$actionName"
 
             assetHelper.withCleaner(wsk.pkg, pkgName) {
@@ -183,9 +188,9 @@ class WskRuleTests
 
     it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "ruleDelete"
-            val triggerName = "ruleDeleteTrigger"
-            val actionName = "ruleDeleteAction"
+            val ruleName = withTimestamp("ruleDelete")
+            val triggerName = withTimestamp("ruleDeleteTrigger")
+            val actionName = withTimestamp("ruleDeleteAction")
 
             assetHelper.withCleaner(wsk.trigger, triggerName) {
                 (trigger, name) => trigger.create(name)
@@ -212,9 +217,9 @@ class WskRuleTests
 
     it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "ruleDisable"
-            val triggerName = "ruleDisableTrigger"
-            val actionName = "ruleDisableAction"
+            val ruleName = withTimestamp("ruleDisable")
+            val triggerName = withTimestamp("ruleDisableTrigger")
+            val actionName = withTimestamp("ruleDisableAction")
 
             ruleSetup(Seq(
                 (ruleName, triggerName, (actionName, actionName, defaultAction))),
@@ -238,10 +243,10 @@ class WskRuleTests
 
     it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val ruleName = "ruleRecreate"
-            val triggerName1 = "ruleRecreateTrigger1"
-            val triggerName2 = "ruleRecreateTrigger2"
-            val actionName = "ruleRecreateAction"
+            val ruleName = withTimestamp("ruleRecreate")
+            val triggerName1 = withTimestamp("ruleRecreateTrigger1")
+            val triggerName2 = withTimestamp("ruleRecreateTrigger2")
+            val actionName = withTimestamp("ruleRecreateAction")
 
             assetHelper.withCleaner(wsk.trigger, triggerName1) {
                 (trigger, name) => trigger.create(name)
@@ -273,9 +278,9 @@ class WskRuleTests
 
     it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val triggerName1 = "t2to1a"
-            val triggerName2 = "t2to1b"
-            val actionName = "a2to1"
+            val triggerName1 = withTimestamp("t2to1a")
+            val triggerName2 = withTimestamp("t2to1b")
+            val actionName = withTimestamp("a2to1")
 
             ruleSetup(Seq(
                 ("r2to1a", triggerName1, (actionName, actionName, defaultAction)),
@@ -303,9 +308,9 @@ class WskRuleTests
 
     it should "connect one trigger to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val triggerName = "t1to2"
-            val actionName1 = "a1to2a"
-            val actionName2 = "a1to2b"
+            val triggerName = withTimestamp("t1to2")
+            val actionName1 = withTimestamp("a1to2a")
+            val actionName2 = withTimestamp("a1to2b")
 
             ruleSetup(Seq(
                 ("r1to2a", triggerName, (actionName1, actionName1, defaultAction)),
@@ -327,10 +332,10 @@ class WskRuleTests
 
     it should "connect two triggers to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
         (wp, assetHelper) =>
-            val triggerName1 = "t1to1a"
-            val triggerName2 = "t1to1b"
-            val actionName1 = "a1to1a"
-            val actionName2 = "a1to1b"
+            val triggerName1 = withTimestamp("t1to1a")
+            val triggerName2 = withTimestamp("t1to1b")
+            val actionName1 = withTimestamp("a1to1a")
+            val actionName2 = withTimestamp("a1to1b")
 
             ruleSetup(Seq(
                 ("r2to2a", triggerName1, (actionName1, actionName1, defaultAction)),


### PR DESCRIPTION
Due to clock skew among invokers, it is possible for an action invoked by a rule _appears_ to start before the trigger which activated the rule was even fired. As such, these tests tend to fail because it is looking for action activations that start strictly after the time the trigger activation started.

This change introduces a "fudge factor" to allow the test to find the expected action activations that appear to start at most 500ms before the trigger activation start time.

Resolves #2195 