### PR TITLE
Add wsk cli support for importing/exporting API configuration in YAML format

### DIFF
--- a/tests/dat/apigw/local.api.bad.yaml
+++ b/tests/dat/apigw/local.api.bad.yaml
@@ -1,0 +1,35 @@
+some bad yaml in
+these []]]
+lines:
+
+basePath: /bp
+info:
+  title: /bp
+  version: 1.0.0
+paths:
+  /rp:
+    get:
+      operationId: get_/rp
+      responses:
+        default:
+          description: Default response
+      x-openwhisk:
+        action: webhttpecho
+        namespace: guest
+        package: ""
+        url: https://127.0.0.1/api/v1/web/guest/default/webhttpecho.http
+swagger: "2.0"
+x-ibm-configuration:
+  assembly:
+    execute:
+    - operation-switch:
+        case:
+        - execute:
+          - invoke:
+              target-url: https://127.0.0.1/api/v1/web/guest/default/webhttpecho.http
+              verb: keep
+          operations:
+          - get_/rp
+  cors:
+    enabled: true
+

--- a/tests/dat/apigw/local.api.yaml
+++ b/tests/dat/apigw/local.api.yaml
@@ -1,0 +1,31 @@
+basePath: /bp
+info:
+  title: /bp
+  version: 1.0.0
+paths:
+  /rp:
+    get:
+      operationId: get_/rp
+      responses:
+        default:
+          description: Default response
+      x-openwhisk:
+        action: webhttpecho
+        namespace: guest
+        package: ""
+        url: https://127.0.0.1/api/v1/web/guest/default/webhttpecho.http
+swagger: "2.0"
+x-ibm-configuration:
+  assembly:
+    execute:
+    - operation-switch:
+        case:
+        - execute:
+          - invoke:
+              target-url: https://127.0.0.1/api/v1/web/guest/default/webhttpecho.http
+              verb: keep
+          operations:
+          - get_/rp
+  cors:
+    enabled: true
+

--- a/tests/src/test/scala/common/Wsk.scala
+++ b/tests/src/test/scala/common/Wsk.scala
@@ -909,11 +909,13 @@ class WskApi()
         basepathOrApiName: Option[String] = None,
         full: Option[Boolean] = None,
         expectedExitCode: Int = SUCCESS_EXIT,
-        cliCfgFile: Option[String] = None)(
+        cliCfgFile: Option[String] = None,
+        format: Option[String] = None)(
             implicit wp: WskProps): RunResult = {
         val params = Seq(noun, "get", "--auth", wp.authKey) ++
             { basepathOrApiName map { b => Seq(b) } getOrElse Seq() } ++
-            { full map { f => if (f) Seq("--full") else Seq() } getOrElse Seq() }
+            { full map { f => if (f) Seq("--full") else Seq() } getOrElse Seq() } ++
+            { format map { ft => Seq("--format", ft) } getOrElse Seq() }
         cli(wp.overrides ++ params, expectedExitCode, showCmd = true, env=Map("WSK_CONFIG_FILE" -> cliCfgFile.getOrElse("")))
     }
 

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -183,9 +183,10 @@ class ApiGwTests
       basepathOrApiName: Option[String] = None,
       full: Option[Boolean] = None,
       expectedExitCode: Int = SUCCESS_EXIT,
-      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath())): RunResult = {
+      cliCfgFile: Option[String] = Some(cliWskPropsFile.getCanonicalPath()),
+      format: Option[String] = None): RunResult = {
         checkThrottle()
-        wsk.api.get(basepathOrApiName, full, expectedExitCode, cliCfgFile)
+        wsk.api.get(basepathOrApiName, full, expectedExitCode, cliCfgFile, format)
     }
 
     def apiDelete(
@@ -198,7 +199,7 @@ class ApiGwTests
         wsk.api.delete(basepathOrApiName, relpath, operation, expectedExitCode, cliCfgFile)
     }
 
-  behavior of "Wsk api-experimental"
+    behavior of "Wsk api-experimental"
 
     it should "reject an api commands with an invalid path parameter" in {
         val badpath = "badpath"
@@ -214,33 +215,33 @@ class ApiGwTests
     }
 
     it should "verify full list output" in {
-      val testName = "CLI_APIGWTEST_RO1"
-      val testbasepath = "/" + testName + "_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName + " API Name"
-      val actionName = testName + "_action"
-      try {
-        println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
+        val testName = "CLI_APIGWTEST_RO1"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
 
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        println("api create: " + rr.stdout)
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
-        println("api list: " + rr.stdout)
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
-        rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
-        rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
-        rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
-        rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
-        rr.stdout should include regex (s"URL:\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
-      }
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            println("api create: " + rr.stdout)
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
+            println("api list: " + rr.stdout)
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
+            rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
+            rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
+            rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
+            rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
+            rr.stdout should include regex (s"URL:\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
+        }
     }
 
     it should "verify successful creation and deletion of a new API" in {
@@ -289,792 +290,903 @@ class ApiGwTests
     }
 
     it should "verify delete API name " in {
-      val testName = "CLI_APIGWTEST4"
-      val testbasepath = "/"+testName+"_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"_action"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiDeleteExperimental(basepathOrApiName = testapiname)
-        rr.stdout should include("ok: deleted API")
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST4"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiDeleteExperimental(basepathOrApiName = testapiname)
+            rr.stdout should include("ok: deleted API")
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify delete API basepath " in {
-      val testName = "CLI_APIGWTEST5"
-      val testbasepath = "/"+testName+"_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"_action"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
-        rr.stdout should include("ok: deleted API")
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST5"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
+            rr.stdout should include("ok: deleted API")
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify adding endpoints to existing api" in {
-      val testName = "CLI_APIGWTEST6"
-      val testbasepath = "/"+testName+"_bp"
-      val testrelpath = "/path2"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"_action"
-      val newEndpoint = "/newEndpoint"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr.stdout should include(testbasepath + newEndpoint)
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST6"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val newEndpoint = "/newEndpoint"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + newEndpoint)
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify successful creation with swagger doc as input" in {
-      // NOTE: These values must match the swagger file contents
-      val testName = "CLI_APIGWTEST7"
-      val testbasepath = "/"+testName+"_bp"
-      val testrelpath = "/path"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"_action"
-      val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1")
-      try {
-        var rr = apiCreateExperimental(swagger = Some(swaggerPath))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-        println("list stdout: "+rr.stdout)
-        println("list stderr: "+rr.stderr)
-        rr.stdout should include("ok: APIs")
-        // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-        rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        // NOTE: These values must match the swagger file contents
+        val testName = "CLI_APIGWTEST7"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1")
+        try {
+            var rr = apiCreateExperimental(swagger = Some(swaggerPath))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            println("list stdout: "+rr.stdout)
+            println("list stderr: "+rr.stderr)
+            rr.stdout should include("ok: APIs")
+            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify adding endpoints to two existing apis" in {
-      val testName = "CLI_APIGWTEST8"
-      val testbasepath = "/"+testName+"_bp"
-      val testbasepath2 = "/"+testName+"_bp2"
-      val testrelpath = "/path2"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"_action"
-      val newEndpoint = "/newEndpoint"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
+        val testName = "CLI_APIGWTEST8"
+        val testbasepath = "/"+testName+"_bp"
+        val testbasepath2 = "/"+testName+"_bp2"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val newEndpoint = "/newEndpoint"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
 
-        // Update both APIs - each with a new endpoint
-        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-        rr.stdout should include("ok: created API")
-        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-        rr.stdout should include("ok: created API")
+            // Update both APIs - each with a new endpoint
+            rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+            rr.stdout should include("ok: created API")
+            rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+            rr.stdout should include("ok: created API")
 
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr.stdout should include(testbasepath + newEndpoint)
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + newEndpoint)
 
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath2))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath2 + testrelpath)
-        rr.stdout should include(testbasepath2 + newEndpoint)
-      }
-      finally {
-        var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
-      }
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath2))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath2 + testrelpath)
+            rr.stdout should include(testbasepath2 + newEndpoint)
+        }
+        finally {
+            var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify successful creation of a new API using an action name using all allowed characters" in {
-      // Be aware: full action name is close to being truncated by the 'list' command
-      // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
-      val testName = "CLI_APIGWTEST9"
-      val testbasepath = "/" + testName + "_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName+" API Name"
-      val actionName = testName+"a-c@t ion"
-      try {
-        println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
+        // Be aware: full action name is close to being truncated by the 'list' command
+        // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
+        val testName = "CLI_APIGWTEST9"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"a-c@t ion"
+        try {
+            println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
 
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
-        deleteresult.stdout should include("ok: deleted API")
-      }
-      finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath)
+            deleteresult.stdout should include("ok: deleted API")
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify failed creation with invalid swagger doc as input" in {
-      val testName = "CLI_APIGWTEST10"
-      val testbasepath = "/" + testName + "_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName + " API Name"
-      val actionName = testName + "_action"
-      val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
-      try {
-        var rr = apiCreateExperimental(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
-        println("api create stdout: " + rr.stdout)
-        println("api create stderr: " + rr.stderr)
-        rr.stderr should include(s"Swagger file is invalid")
-      } finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST10"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
+        try {
+            var rr = apiCreateExperimental(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+            println("api create stdout: " + rr.stdout)
+            println("api create stderr: " + rr.stderr)
+            rr.stderr should include(s"Swagger file is invalid")
+        } finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify delete basepath/path " in {
-      val testName = "CLI_APIGWTEST11"
-      val testbasepath = "/" + testName + "_bp"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName + " API Name"
-      val actionName = testName + "_action"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        var rr2 = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr2.stdout should include("ok: created API")
-        rr = apiDeleteExperimental(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
-        rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
-        rr2 = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
-        rr2.stdout should include("ok: APIs")
-        rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr2.stdout should include(testbasepath + testnewrelpath)
-      } finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST11"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            var rr2 = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr2.stdout should include("ok: created API")
+            rr = apiDeleteExperimental(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
+            rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
+            rr2 = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
+            rr2.stdout should include("ok: APIs")
+            rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr2.stdout should include(testbasepath + testnewrelpath)
+        } finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify delete single operation from existing API basepath/path/operation(s) " in {
-      val testName = "CLI_APIGWTEST12"
-      val testbasepath = "/" + testName + "_bp"
-      val testrelpath = "/path2"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testurlop2 = "post"
-      val testapiname = testName + " API Name"
-      val actionName = testName + "_action"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr = apiDeleteExperimental(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
-        rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      } finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST12"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testurlop2 = "post"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiDeleteExperimental(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
+            rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+        } finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify successful creation with complex swagger doc as input" in {
-      val testName = "CLI_APIGWTEST13"
-      val testbasepath = "/test1/v1"
-      val testrelpath = "/whisk.system/utils/echo"
-      val testrelpath2 = "/whisk.system/utils/split"
-      val testurlop = "get"
-      val testapiname = "/test1/v1"
-      val actionName = "test1a"
-      val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2")
-      try {
-        var rr = apiCreateExperimental(swagger = Some(swaggerPath))
-        println("api create stdout: " + rr.stdout)
-        println("api create stderror: " + rr.stderr)
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
-        rr.stdout should include("ok: APIs")
-        // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-        rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr.stdout should include(testbasepath + testrelpath2)
-      } finally {
-        val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST13"
+        val testbasepath = "/test1/v1"
+        val testrelpath = "/whisk.system/utils/echo"
+        val testrelpath2 = "/whisk.system/utils/split"
+        val testurlop = "get"
+        val testapiname = "/test1/v1"
+        val actionName = "test1a"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2")
+        try {
+            var rr = apiCreateExperimental(swagger = Some(swaggerPath))
+            println("api create stdout: " + rr.stdout)
+            println("api create stderror: " + rr.stderr)
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + testrelpath2)
+        } finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
     it should "verify successful creation and deletion with multiple base paths" in {
-      val testName = "CLI_APIGWTEST14"
-      val testbasepath = "/" + testName + "_bp"
-      val testbasepath2 = "/" + testName + "_bp2"
-      val testrelpath = "/path"
-      val testnewrelpath = "/path_new"
-      val testurlop = "get"
-      val testapiname = testName + " API Name"
-      val actionName = testName + "_action"
-      try {
-        var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-        rr.stdout should include("ok: created API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath2 + testrelpath)
-        rr = apiDeleteExperimental(basepathOrApiName = testbasepath2)
-        rr.stdout should include("ok: deleted API")
-        rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-        rr.stdout should include("ok: APIs")
-        rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-        rr.stdout should include(testbasepath + testrelpath)
-        rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
-        rr.stdout should include("ok: deleted API")
-      } finally {
-        var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-        deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
-      }
+        val testName = "CLI_APIGWTEST14"
+        val testbasepath = "/" + testName + "_bp"
+        val testbasepath2 = "/" + testName + "_bp2"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            var rr = apiCreateExperimental(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiCreateExperimental(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath2 + testrelpath)
+            rr = apiDeleteExperimental(basepathOrApiName = testbasepath2)
+            rr.stdout should include("ok: deleted API")
+            rr = apiListExperimental(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiDeleteExperimental(basepathOrApiName = testbasepath)
+            rr.stdout should include("ok: deleted API")
+        } finally {
+            var deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        }
     }
 
-  behavior of "Wsk api"
+    behavior of "Wsk api"
 
-  it should "reject an api commands with an invalid path parameter" in {
-    val badpath = "badpath"
+    it should "reject an api commands with an invalid path parameter" in {
+        val badpath = "badpath"
 
-    var rr = apiCreate(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
-    rr.stderr should include (s"'${badpath}' must begin with '/'")
+        var rr = apiCreate(basepath = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), action = Some("action"), expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include (s"'${badpath}' must begin with '/'")
 
-    rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
-    rr.stderr should include (s"'${badpath}' must begin with '/'")
+        rr = apiDelete(basepathOrApiName = "/basepath", relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include (s"'${badpath}' must begin with '/'")
 
-    rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
-    rr.stderr should include (s"'${badpath}' must begin with '/'")
-  }
-
-  it should "verify full list output" in {
-    val testName = "CLI_APIGWTEST_RO1"
-    val testbasepath = "/" + testName + "_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    try {
-      println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
-
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      println("api create: " + rr.stdout)
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
-      println("api list: " + rr.stdout)
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
-      rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
-      rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
-      rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
-      rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
-      rr.stdout should include regex (s"URL:\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
+        rr = apiList(basepathOrApiName = Some("/basepath"), relpath = Some(badpath), operation = Some("GET"), expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include (s"'${badpath}' must begin with '/'")
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+
+    it should "verify full list output" in {
+        val testName = "CLI_APIGWTEST_RO1"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            println("api create: " + rr.stdout)
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), full = Some(true))
+            println("api list: " + rr.stdout)
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"Action:\\s+/${clinamespace}/${actionName}\n")
+            rr.stdout should include regex (s"Verb:\\s+${testurlop}\n")
+            rr.stdout should include regex (s"Base path:\\s+${testbasepath}\n")
+            rr.stdout should include regex (s"Path:\\s+${testrelpath}\n")
+            rr.stdout should include regex (s"API Name:\\s+${testapiname}\n")
+            rr.stdout should include regex (s"URL:\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+        }
     }
-  }
 
-  it should "verify successful creation and deletion of a new API" in {
-    val testName = "CLI_APIGWTEST1"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    try {
-      println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
+    it should "verify successful creation and deletion of a new API" in {
+        val testName = "CLI_APIGWTEST1"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
 
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
-      deleteresult.stdout should include("ok: deleted API")
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+            deleteresult.stdout should include("ok: deleted API")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify get API name " in {
+        val testName = "CLI_APIGWTEST3"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiGet(basepathOrApiName = Some(testapiname))
+            rr.stdout should include(testbasepath)
+            rr.stdout should include(s"${actionName}")
+            rr.stdout should include regex (""""cors":\s*\{\s*\n\s*"enabled":\s*true""")
+            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.json""")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify get API name " in {
-    val testName = "CLI_APIGWTEST3"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "verify delete API name " in {
+        val testName = "CLI_APIGWTEST4"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiGet(basepathOrApiName = Some(testapiname))
-      rr.stdout should include(testbasepath)
-      rr.stdout should include(s"${actionName}")
-      rr.stdout should include regex (""""cors":\s*\{\s*\n\s*"enabled":\s*true""")
-      rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.json""")
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiDelete(basepathOrApiName = testapiname)
+            rr.stdout should include("ok: deleted API")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify delete API basepath " in {
+        val testName = "CLI_APIGWTEST5"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiDelete(basepathOrApiName = testbasepath)
+            rr.stdout should include("ok: deleted API")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify delete API name " in {
-    val testName = "CLI_APIGWTEST4"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "verify adding endpoints to existing api" in {
+        val testName = "CLI_APIGWTEST6"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val newEndpoint = "/newEndpoint"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiDelete(basepathOrApiName = testapiname)
-      rr.stdout should include("ok: deleted API")
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + newEndpoint)
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify successful creation with swagger doc as input" in {
+        // NOTE: These values must match the swagger file contents
+        val testName = "CLI_APIGWTEST7"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1V2")
+        try {
+            var rr = apiCreate(swagger = Some(swaggerPath))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            println("list stdout: "+rr.stdout)
+            println("list stderr: "+rr.stderr)
+            rr.stdout should include("ok: APIs")
+            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+        }
+        finally {
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify delete API basepath " in {
-    val testName = "CLI_APIGWTEST5"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "verify adding endpoints to two existing apis" in {
+        val testName = "CLI_APIGWTEST8"
+        val testbasepath = "/"+testName+"_bp"
+        val testbasepath2 = "/"+testName+"_bp2"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val newEndpoint = "/newEndpoint"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiDelete(basepathOrApiName = testbasepath)
-      rr.stdout should include("ok: deleted API")
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+
+            // Update both APIs - each with a new endpoint
+            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+            rr.stdout should include("ok: created API")
+            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
+            rr.stdout should include("ok: created API")
+
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + newEndpoint)
+
+            rr = apiList(basepathOrApiName = Some(testbasepath2))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath2 + testrelpath)
+            rr.stdout should include(testbasepath2 + newEndpoint)
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify successful creation of a new API using an action name using all allowed characters" in {
+        // Be aware: full action name is close to being truncated by the 'list' command
+        // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
+        val testName = "CLI_APIGWTEST9"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"a-c@t ion"
+        try {
+            println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath)
+            deleteresult.stdout should include("ok: deleted API")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify adding endpoints to existing api" in {
-    val testName = "CLI_APIGWTEST6"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path2"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    val newEndpoint = "/newEndpoint"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
-
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr.stdout should include(testbasepath + newEndpoint)
+    it should "verify failed creation with invalid swagger doc as input" in {
+        val testName = "CLI_APIGWTEST10"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
+        try {
+            var rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+            println("api create stdout: " + rr.stdout)
+            println("api create stderr: " + rr.stderr)
+            rr.stderr should include(s"Swagger file is invalid")
+        } finally {
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify delete basepath/path " in {
+        val testName = "CLI_APIGWTEST11"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            var rr2 = apiCreate(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr2.stdout should include("ok: created API")
+            rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
+            rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
+            rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
+            rr2.stdout should include("ok: APIs")
+            rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr2.stdout should include(testbasepath + testnewrelpath)
+        } finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify successful creation with swagger doc as input" in {
-    // NOTE: These values must match the swagger file contents
-    val testName = "CLI_APIGWTEST7"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    val swaggerPath = TestUtils.getTestApiGwFilename("testswaggerdoc1V2")
-    try {
-      var rr = apiCreate(swagger = Some(swaggerPath))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-      println("list stdout: "+rr.stdout)
-      println("list stderr: "+rr.stderr)
-      rr.stdout should include("ok: APIs")
-      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
+    it should "verify delete single operation from existing API basepath/path/operation(s) " in {
+        val testName = "CLI_APIGWTEST12"
+        val testbasepath = "/" + testName + "_bp"
+        val testrelpath = "/path2"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testurlop2 = "post"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiDelete(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
+            rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+        } finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify successful creation with complex swagger doc as input" in {
+        val testName = "CLI_APIGWTEST13"
+        val testbasepath = "/test1/v1"
+        val testrelpath = "/whisk_system/utils/echo"
+        val testrelpath2 = "/whisk_system/utils/split"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = "test1a"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2V2")
+        try {
+            var rr = apiCreate(swagger = Some(swaggerPath))
+            println("api create stdout: " + rr.stdout)
+            println("api create stderror: " + rr.stderr)
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr.stdout should include(testbasepath + testrelpath2)
+        } finally {
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify adding endpoints to two existing apis" in {
-    val testName = "CLI_APIGWTEST8"
-    val testbasepath = "/"+testName+"_bp"
-    val testbasepath2 = "/"+testName+"_bp2"
-    val testrelpath = "/path2"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    val newEndpoint = "/newEndpoint"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "verify successful creation and deletion with multiple base paths" in {
+        val testName = "CLI_APIGWTEST14"
+        val testbasepath = "/" + testName + "_bp"
+        val testbasepath2 = "/" + testName + "_bp2"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-
-      // Update both APIs - each with a new endpoint
-      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-      rr.stdout should include("ok: created API")
-      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(newEndpoint), operation = Some(testurlop), action = Some(actionName))
-      rr.stdout should include("ok: created API")
-
-      rr = apiList(basepathOrApiName = Some(testbasepath))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr.stdout should include(testbasepath + newEndpoint)
-
-      rr = apiList(basepathOrApiName = Some(testbasepath2))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath2 + testrelpath)
-      rr.stdout should include(testbasepath2 + newEndpoint)
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath2 + testrelpath)
+            rr = apiDelete(basepathOrApiName = testbasepath2)
+            rr.stdout should include("ok: deleted API")
+            rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
+            rr.stdout should include("ok: APIs")
+            rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+            rr = apiDelete(basepathOrApiName = testbasepath)
+            rr.stdout should include("ok: deleted API")
+        } finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+
+    it should "reject an API created with a non-existent action" in {
+        val testName = "CLI_APIGWTEST15"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        try {
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
+            rr.stderr should include("does not exist")
+        }
+        finally {
+            val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify successful creation of a new API using an action name using all allowed characters" in {
-    // Be aware: full action name is close to being truncated by the 'list' command
-    // e.g. /lime@us.ibm.com/CLI_APIGWTEST9a-c@t ion  is currently at the 40 char 'list' display max
-    val testName = "CLI_APIGWTEST9"
-    val testbasepath = "/" + testName + "_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"a-c@t ion"
-    try {
-      println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "reject an API created with an action that is not a web action" in {
+        val testName = "CLI_APIGWTEST16"
+        val testbasepath = "/" + testName + "_bp"
+        val testbasepath2 = "/" + testName + "_bp2"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName + " API Name"
+        val actionName = testName + "_action"
+        try {
+            // Create the action for the API.  It must NOT be a "web-action" action for this test
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath)
-      deleteresult.stdout should include("ok: deleted API")
+            var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
+            rr.stderr should include("is not a web action")
+        } finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+
+    it should "verify API with http response type " in {
+        val testName = "CLI_APIGWTEST17"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val responseType = "http"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+
+            var rr = apiCreate(
+                basepath = Some(testbasepath),
+                relpath = Some(testrelpath),
+                operation = Some(testurlop),
+                action = Some(actionName),
+                apiname = Some(testapiname),
+                responsetype = Some(responseType)
+            )
+            rr.stdout should include("ok: created API")
+            rr = apiGet(basepathOrApiName = Some(testapiname))
+            rr.stdout should include(testbasepath)
+            rr.stdout should include(s"${actionName}")
+            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify failed creation with invalid swagger doc as input" in {
-    val testName = "CLI_APIGWTEST10"
-    val testbasepath = "/" + testName + "_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdocinvalid")
-    try {
-      var rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
-      println("api create stdout: " + rr.stdout)
-      println("api create stderr: " + rr.stderr)
-      rr.stderr should include(s"Swagger file is invalid")
-    } finally {
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    it should "reject API export when export type is invalid" in {
+        val testName = "CLI_APIGWTEST18"
+        val testbasepath = "/"+testName+"_bp"
+
+        var rr = apiGet(basepathOrApiName = Some(testbasepath), format = Some("BadType"), expectedExitCode = ANY_ERROR_EXIT)
+        rr.stderr should include("Invalid format type")
     }
-  }
 
-  it should "verify delete basepath/path " in {
-    val testName = "CLI_APIGWTEST11"
-    val testbasepath = "/" + testName + "_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "successfully export an API in YAML format" in {
+        val testName = "CLI_APIGWTEST19"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val responseType = "http"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      var rr2 = apiCreate(basepath = Some(testbasepath), relpath = Some(testnewrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr2.stdout should include("ok: created API")
-      rr = apiDelete(basepathOrApiName = testbasepath, relpath = Some(testrelpath))
-      rr.stdout should include("ok: deleted " + testrelpath +" from "+ testbasepath)
-      rr2 = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testnewrelpath))
-      rr2.stdout should include("ok: APIs")
-      rr2.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr2.stdout should include(testbasepath + testnewrelpath)
-    } finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            var rr = apiCreate(
+                basepath = Some(testbasepath),
+                relpath = Some(testrelpath),
+                operation = Some(testurlop),
+                action = Some(actionName),
+                apiname = Some(testapiname),
+                responsetype = Some(responseType)
+            )
+            rr.stdout should include("ok: created API")
+            rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("yaml"))
+            rr.stdout should include (s"basePath: ${testbasepath}")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify delete single operation from existing API basepath/path/operation(s) " in {
-    val testName = "CLI_APIGWTEST12"
-    val testbasepath = "/" + testName + "_bp"
-    val testrelpath = "/path2"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testurlop2 = "post"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+    it should "successfully export an API when JSON format is explcitly specified" in {
+        val testName = "CLI_APIGWTEST20"
+        val testbasepath = "/"+testName+"_bp"
+        val testrelpath = "/path"
+        val testnewrelpath = "/path_new"
+        val testurlop = "get"
+        val testapiname = testName+" API Name"
+        val actionName = testName+"_action"
+        val responseType = "http"
+        try {
+            // Create the action for the API.  It must be a "web-action" action.
+            val file = TestUtils.getTestActionFilename(s"echo.js")
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
 
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop2), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr = apiDelete(basepathOrApiName = testbasepath,relpath = Some(testrelpath), operation = Some(testurlop2))
-      rr.stdout should include("ok: deleted " + testrelpath + " " + "POST" +" from "+ testbasepath)
-      rr = apiList(basepathOrApiName = Some(testbasepath))
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-    } finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+            var rr = apiCreate(
+                basepath = Some(testbasepath),
+                relpath = Some(testrelpath),
+                operation = Some(testurlop),
+                action = Some(actionName),
+                apiname = Some(testapiname),
+                responsetype = Some(responseType)
+            )
+            rr.stdout should include("ok: created API")
+            rr = apiGet(basepathOrApiName = Some(testapiname), format = Some("json"))
+            rr.stdout should include(testbasepath)
+            rr.stdout should include(s"${actionName}")
+            rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
+        }
+        finally {
+            val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify successful creation with complex swagger doc as input" in {
-    val testName = "CLI_APIGWTEST13"
-    val testbasepath = "/test1/v1"
-    val testrelpath = "/whisk_system/utils/echo"
-    val testrelpath2 = "/whisk_system/utils/split"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = "test1a"
-    val swaggerPath = TestUtils.getTestApiGwFilename(s"testswaggerdoc2V2")
-    try {
-      var rr = apiCreate(swagger = Some(swaggerPath))
-      println("api create stdout: " + rr.stdout)
-      println("api create stderror: " + rr.stderr)
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath))
-      rr.stdout should include("ok: APIs")
-      // Actual CLI namespace will vary from local dev to automated test environments, so don't check
-      rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr.stdout should include(testbasepath + testrelpath2)
-    } finally {
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+    it should "successfully create an API from a YAML formatted API configuration file" in {
+        val testName = "CLI_APIGWTEST21"
+        val testbasepath = "/bp"
+        val testrelpath = "/rp"
+        val testurlop = "get"
+        val testapiname = testbasepath
+        val actionName = "webhttpecho"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.yaml")
+        try {
+            var rr = apiCreate(swagger = Some(swaggerPath))
+            println("api create stdout: " + rr.stdout)
+            println("api create stderror: " + rr.stderr)
+            rr.stdout should include("ok: created API")
+            rr = apiList(basepathOrApiName = Some(testbasepath))
+            rr.stdout should include("ok: APIs")
+            // Actual CLI namespace will vary from local dev to automated test environments, so don't check
+            rr.stdout should include regex (s"/[@\\w._\\-]+/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
+            rr.stdout should include(testbasepath + testrelpath)
+        } finally {
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
 
-  it should "verify successful creation and deletion with multiple base paths" in {
-    val testName = "CLI_APIGWTEST14"
-    val testbasepath = "/" + testName + "_bp"
-    val testbasepath2 = "/" + testName + "_bp2"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
-
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr = apiCreate(basepath = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
-      rr.stdout should include("ok: created API")
-      rr = apiList(basepathOrApiName = Some(testbasepath2), relpath = Some(testrelpath), operation = Some(testurlop))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath2 + testrelpath)
-      rr = apiDelete(basepathOrApiName = testbasepath2)
-      rr.stdout should include("ok: deleted API")
-      rr = apiList(basepathOrApiName = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop))
-      rr.stdout should include("ok: APIs")
-      rr.stdout should include regex (s"/${clinamespace}/${actionName}\\s+${testurlop}\\s+${testapiname}\\s+")
-      rr.stdout should include(testbasepath + testrelpath)
-      rr = apiDelete(basepathOrApiName = testbasepath)
-      rr.stdout should include("ok: deleted API")
-    } finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-      deleteresult = apiDelete(basepathOrApiName = testbasepath2, expectedExitCode = DONTCARE_EXIT)
+    it should "reject creation of an API from invalid YAML formatted API configuration file" in {
+        val testName = "CLI_APIGWTEST22"
+        val testbasepath = "/bp"
+        val swaggerPath = TestUtils.getTestApiGwFilename(s"local.api.bad.yaml")
+        try {
+            var rr = apiCreate(swagger = Some(swaggerPath), expectedExitCode = ANY_ERROR_EXIT)
+            println("api create stdout: " + rr.stdout)
+            println("api create stderror: " + rr.stderr)
+            rr.stderr should include("Unable to parse YAML configuration file")
+        } finally {
+            val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
+        }
     }
-  }
-
-  it should "reject an API created with a non-existent action" in {
-    val testName = "CLI_APIGWTEST15"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    try {
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-      rr.stderr should include("API action does not exist")
-    }
-    finally {
-      val deleteresult = apiDeleteExperimental(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-    }
-  }
-
-  it should "reject an API created with an action that is not a web action" in {
-    val testName = "CLI_APIGWTEST16"
-    val testbasepath = "/" + testName + "_bp"
-    val testbasepath2 = "/" + testName + "_bp2"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName + " API Name"
-    val actionName = testName + "_action"
-    try {
-      // Create the action for the API.  It must NOT be a "web-action" action for this test
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT)
-
-      var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname), expectedExitCode = ANY_ERROR_EXIT)
-      rr.stderr should include("is not a web action")
-    } finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      var deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-    }
-  }
-
-  it should "verify API with http response type " in {
-    val testName = "CLI_APIGWTEST17"
-    val testbasepath = "/"+testName+"_bp"
-    val testrelpath = "/path"
-    val testnewrelpath = "/path_new"
-    val testurlop = "get"
-    val testapiname = testName+" API Name"
-    val actionName = testName+"_action"
-    val responseType = "http"
-    try {
-      // Create the action for the API.  It must be a "web-action" action.
-      val file = TestUtils.getTestActionFilename(s"echo.js")
-      wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
-
-      var rr = apiCreate(
-          basepath = Some(testbasepath),
-          relpath = Some(testrelpath),
-          operation = Some(testurlop),
-          action = Some(actionName),
-          apiname = Some(testapiname),
-          responsetype = Some(responseType)
-      )
-      rr.stdout should include("ok: created API")
-      rr = apiGet(basepathOrApiName = Some(testapiname))
-      rr.stdout should include(testbasepath)
-      rr.stdout should include(s"${actionName}")
-      rr.stdout should include regex (s""""target-url":\\s+.*${actionName}.${responseType}""")
-    }
-    finally {
-      val finallydeleteActionResult = wsk.action.delete(name = actionName, expectedExitCode = DONTCARE_EXIT)
-      val deleteresult = apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
-    }
-  }
 }

--- a/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
+++ b/tests/src/test/scala/whisk/core/cli/test/ApiGwTests.scala
@@ -19,8 +19,6 @@ package whisk.core.cli.test
 import java.io.File
 import java.time.Instant
 import scala.concurrent.duration._
-import spray.json._
-import spray.json.DefaultJsonProtocol._
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
@@ -602,7 +600,7 @@ class ApiGwTests
             println("cli user: " + cliuser + "; cli namespace: " + clinamespace)
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             println("api create: " + rr.stdout)
@@ -637,7 +635,7 @@ class ApiGwTests
 
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -665,7 +663,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -692,7 +690,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -716,7 +714,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -741,7 +739,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -797,7 +795,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -843,7 +841,7 @@ class ApiGwTests
             println("cli user: "+cliuser+"; cli namespace: "+clinamespace)
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -890,7 +888,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -920,7 +918,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -977,7 +975,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(basepath = Some(testbasepath), relpath = Some(testrelpath), operation = Some(testurlop), action = Some(actionName), apiname = Some(testapiname))
             rr.stdout should include("ok: created API")
@@ -1057,7 +1055,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(
                 basepath = Some(testbasepath),
@@ -1099,7 +1097,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(
                 basepath = Some(testbasepath),
@@ -1131,7 +1129,7 @@ class ApiGwTests
         try {
             // Create the action for the API.  It must be a "web-action" action.
             val file = TestUtils.getTestActionFilename(s"echo.js")
-            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, annotations = Map("web-export" -> true.toJson))
+            wsk.action.create(name = actionName, artifact = Some(file), expectedExitCode = SUCCESS_EXIT, web = Some("true"))
 
             var rr = apiCreate(
                 basepath = Some(testbasepath),

--- a/tools/cli/go-whisk-cli/Godeps/Godeps.json
+++ b/tools/cli/go-whisk-cli/Godeps/Godeps.json
@@ -74,7 +74,12 @@
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "e4d366fc3c7938e2958e662b4258c7a89e1f0e3e"
+			"Rev": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Comment": "v1.0.0",
+			"Rev": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
 		}
 	]
 }

--- a/tools/cli/go-whisk-cli/commands/action.go
+++ b/tools/cli/go-whisk-cli/commands/action.go
@@ -848,7 +848,7 @@ func isWebAction(client *whisk.Client, qname QualifiedName) error {
     if err != nil {
         whisk.Debug(whisk.DbgError, "client.Actions.Get(%s) error: %s\n", fullActionName, err)
         whisk.Debug(whisk.DbgError, "Unable to obtain action '%s' for web action validation\n", fullActionName)
-        err = errors.New(wski18n.T("API action does not exist"))
+        err = errors.New(wski18n.T("API action '{{.name}}' does not exist", map[string]interface{}{"name": fullActionName}))
     } else {
         err = errors.New(wski18n.T("API action '{{.name}}' is not a web action. Issue 'wsk action update {{.name}} --web true' to convert the action to a web action.",
             map[string]interface{}{"name": fullActionName}))

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -17,6 +17,8 @@
 package commands
 
 import (
+    "bytes"
+    "bufio"
     "errors"
     "fmt"
     "reflect"
@@ -27,6 +29,7 @@ import (
     "../wski18n"
 
     "github.com/fatih/color"
+    "github.com/ghodss/yaml"
     "github.com/spf13/cobra"
     "encoding/json"
 )
@@ -897,6 +900,13 @@ var apiGetCmdV2 = &cobra.Command{
             return whiskErr
         }
 
+        if (cmd.LocalFlags().Changed("format") && strings.ToLower(flags.common.format) != "yaml" && strings.ToLower(flags.common.format) != "json") {
+            errMsg := wski18n.T("Invalid format type: {{.type}}", map[string]interface{}{"type": flags.common.format})
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return whiskErr
+        }
+
         apiGetReq := new(whisk.ApiGetRequest)
         apiGetReqOptions := new(whisk.ApiGetRequestOptions)
         apiGetReqOptions.ApiBasePath = args[0]
@@ -948,7 +958,24 @@ var apiGetCmdV2 = &cobra.Command{
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
             return whiskErr
         }
-        printJSON(displayResult)
+
+        if (cmd.LocalFlags().Changed("format") && strings.ToLower(flags.common.format) == "yaml") {
+            var jsonOutputBuffer bytes.Buffer
+            var jsonOutputWriter = bufio.NewWriter(&jsonOutputBuffer)
+            printJSON(displayResult, jsonOutputWriter)
+            jsonOutputWriter.Flush()
+            yamlbytes, err := yaml.JSONToYAML(jsonOutputBuffer.Bytes())
+            if err != nil {
+                whisk.Debug(whisk.DbgError, "yaml.JSONToYAML() error: %s\n", err)
+                errMsg := wski18n.T("Unable to convert API into YAML: {{.err}}", map[string]interface{}{"err": err})
+                whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                    whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+                return whiskErr
+            }
+            fmt.Println(string(yamlbytes))
+        } else {
+            printJSON(displayResult)
+        }
 
         return nil
     },
@@ -1421,6 +1448,21 @@ func parseSwaggerApiV2() (*whisk.Api, error) {
         return nil, whiskErr
     }
 
+    // Check if this swagger is in JSON or YAML format
+    isYaml := strings.HasSuffix(flags.api.configfile, "yaml") || strings.HasSuffix(flags.api.configfile, "yml")
+    if isYaml {
+        whisk.Debug(whisk.DbgInfo, "Converting YAML formated API configuration into JSON\n")
+        jsonbytes, err := yaml.YAMLToJSON([]byte(swagger))
+        if err != nil {
+            whisk.Debug(whisk.DbgError, "yaml.YAMLToJSON() error: %s\n", err)
+            errMsg := wski18n.T("Unable to parse YAML configuration file: {{.err}}", map[string]interface{}{"err": err})
+            whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
+                whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+            return nil, whiskErr
+        }
+        swagger = string(jsonbytes)
+    }
+
     // Parse the JSON into a swagger object
     swaggerObj := new(whisk.ApiSwaggerV2)
     err = json.Unmarshal([]byte(swagger), swaggerObj)
@@ -1520,6 +1562,7 @@ func init() {
     apiCreateCmdV2.Flags().StringVarP(&flags.api.configfile, "config-file", "c", "", wski18n.T("`CFG_FILE` containing API configuration in swagger JSON format"))
     apiCreateCmdV2.Flags().StringVar(&flags.api.resptype, "response-type", "json", wski18n.T("Set the web action response `TYPE`. Possible values are html, http, json, text, svg"))
     apiGetCmdV2.Flags().BoolVarP(&flags.common.detail, "full", "f", false, wski18n.T("display full API configuration details"))
+    apiGetCmdV2.Flags().StringVarP(&flags.common.format, "format", "", "json", wski18n.T("Specify the API output `TYPE`, either json or yaml"))
     apiListCmdV2.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))
     apiListCmdV2.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))
     apiListCmdV2.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("display full description of each API"))

--- a/tools/cli/go-whisk-cli/commands/api.go
+++ b/tools/cli/go-whisk-cli/commands/api.go
@@ -34,6 +34,14 @@ import (
     "encoding/json"
 )
 
+const (
+    yamlFileExtension = "yaml"
+    ymlFileExtension = "yml"
+
+    formatOptionYaml = "yaml"
+    formatOptionJson = "json"
+)
+
 //////////////
 // Commands //
 //////////////
@@ -900,7 +908,9 @@ var apiGetCmdV2 = &cobra.Command{
             return whiskErr
         }
 
-        if (cmd.LocalFlags().Changed("format") && strings.ToLower(flags.common.format) != "yaml" && strings.ToLower(flags.common.format) != "json") {
+        if ( cmd.LocalFlags().Changed("format") &&
+             strings.ToLower(flags.common.format) != formatOptionYaml &&
+             strings.ToLower(flags.common.format) != formatOptionJson) {
             errMsg := wski18n.T("Invalid format type: {{.type}}", map[string]interface{}{"type": flags.common.format})
             whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXITCODE_ERR_GENERAL,
                 whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
@@ -959,7 +969,7 @@ var apiGetCmdV2 = &cobra.Command{
             return whiskErr
         }
 
-        if (cmd.LocalFlags().Changed("format") && strings.ToLower(flags.common.format) == "yaml") {
+        if ( cmd.LocalFlags().Changed("format") && strings.ToLower(flags.common.format) == formatOptionYaml ) {
             var jsonOutputBuffer bytes.Buffer
             var jsonOutputWriter = bufio.NewWriter(&jsonOutputBuffer)
             printJSON(displayResult, jsonOutputWriter)
@@ -1449,7 +1459,7 @@ func parseSwaggerApiV2() (*whisk.Api, error) {
     }
 
     // Check if this swagger is in JSON or YAML format
-    isYaml := strings.HasSuffix(flags.api.configfile, "yaml") || strings.HasSuffix(flags.api.configfile, "yml")
+    isYaml := strings.HasSuffix(flags.api.configfile, yamlFileExtension) || strings.HasSuffix(flags.api.configfile, ymlFileExtension)
     if isYaml {
         whisk.Debug(whisk.DbgInfo, "Converting YAML formated API configuration into JSON\n")
         jsonbytes, err := yaml.YAMLToJSON([]byte(swagger))
@@ -1562,7 +1572,7 @@ func init() {
     apiCreateCmdV2.Flags().StringVarP(&flags.api.configfile, "config-file", "c", "", wski18n.T("`CFG_FILE` containing API configuration in swagger JSON format"))
     apiCreateCmdV2.Flags().StringVar(&flags.api.resptype, "response-type", "json", wski18n.T("Set the web action response `TYPE`. Possible values are html, http, json, text, svg"))
     apiGetCmdV2.Flags().BoolVarP(&flags.common.detail, "full", "f", false, wski18n.T("display full API configuration details"))
-    apiGetCmdV2.Flags().StringVarP(&flags.common.format, "format", "", "json", wski18n.T("Specify the API output `TYPE`, either json or yaml"))
+    apiGetCmdV2.Flags().StringVarP(&flags.common.format, "format", "", formatOptionJson, wski18n.T("Specify the API output `TYPE`, either json or yaml"))
     apiListCmdV2.Flags().IntVarP(&flags.common.skip, "skip", "s", 0, wski18n.T("exclude the first `SKIP` number of actions from the result"))
     apiListCmdV2.Flags().IntVarP(&flags.common.limit, "limit", "l", 30, wski18n.T("only return `LIMIT` number of actions from the collection"))
     apiListCmdV2.Flags().BoolVarP(&flags.common.full, "full", "f", false, wski18n.T("display full description of each API"))

--- a/tools/cli/go-whisk-cli/commands/flags.go
+++ b/tools/cli/go-whisk-cli/commands/flags.go
@@ -55,6 +55,7 @@ var flags struct {
         summary     bool
         feed        string  // name of feed
         detail      bool
+        format      string
     }
 
     property struct {

--- a/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
+++ b/tools/cli/go-whisk-cli/wski18n/resources/en_US.all.json
@@ -1380,8 +1380,8 @@
     "translation": "Invalid argument '{{.arg}}' for --web flag. Valid input consist of 'yes', 'true', 'raw', 'false', or 'no'."
   },
   {
-    "id": "API action does not exist",
-    "translation": "API action does not exist"
+    "id": "API action '{{.name}}' does not exist",
+    "translation": "API action '{{.name}}' does not exist"
   },
   {
     "id": "API action '{{.name}}' is not a web action. Issue 'wsk action update {{.name}} --web true' to convert the action to a web action.",
@@ -1446,5 +1446,21 @@
   {
     "id": "Authorization key is not configured (--auth is required)",
     "translation": "Authorization key is not configured (--auth is required)"
+  },
+  {
+    "id": "Specify the API output `TYPE`, either json or yaml",
+    "translation": "Specify the API output `TYPE`, either json or yaml"
+  },
+  {
+    "id": "Unable to parse YAML configuration file: {{.err}}",
+    "translation": "Unable to parse YAML configuration file: {{.err}}"
+  },
+  {
+    "id": "Unable to convert API into YAML: {{.err}}",
+    "translation": "Unable to convert API into YAML: {{.err}}"
+  },
+  {
+    "id": "Invalid format type: {{.type}}",
+    "translation": "Invalid format type: {{.type}}"
   }
 ]


### PR DESCRIPTION
Update the following command:
- `wsk api get --format yaml`  Add a new option `--format` that takes either `json` or `yaml`
- `wsk api create --config-file api.yaml`  The import logic looks at the file extenstion, if .yaml or .yml, the file is treated as YAML; otherwise the file is treated as JSON

Fixes #2170