### PR TITLE
Assure db_prefix begins and consists of lowercase chars for valid couchdb name

### DIFF
--- a/ansible/environments/distributed/group_vars/all
+++ b/ansible/environments/distributed/group_vars/all
@@ -5,7 +5,7 @@ db_protocol: http
 db_username: couch_user
 db_password: couch_password
 db_host: "{{ groups['db'] | first }}"
-db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
+db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
 
 # The following flag will put all activations into an seperated activations-db, instead of the whisks-db. (if true)
 # If it is false, all activations will be written into the whisks-db.

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -6,7 +6,7 @@ cli_nginx_dir: "{{ nginx_conf_dir }}/cli/go/download"
 docker_registry: ""
 docker_dns: ""
 
-db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
+db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
 
 # Auto lookup to find the db credentials
 db_provider: "{{ lookup('ini', 'db_provider section=db_creds file={{ playbook_dir }}/db_local.ini') }}"

--- a/ansible/environments/mac/group_vars/all
+++ b/ansible/environments/mac/group_vars/all
@@ -11,7 +11,7 @@ docker_dns: ""
 # a hostname that is resolved on the client, via /etc/hosts for example.
 whisk_api_localhost_name: "openwhisk"
 
-db_prefix: "{{ ansible_user_id }}_{{ ansible_hostname|lower }}_"
+db_prefix: "{{ ansible_user_id|lower }}_{{ ansible_hostname|lower }}_"
 
 # Auto lookup to find the db credentials
 db_provider: "{{ lookup('ini', 'db_provider section=db_creds file={{ playbook_dir }}/db_local.ini') }}"


### PR DESCRIPTION
Fixes https://github.com/openwhisk/openwhisk/issues/2216
"creating CouchDB database fails due to db_prefix grabbing uppercase account name"